### PR TITLE
feat(registry): MCP registry server.json + crates.io README fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.1-beta.1] - 2026-06-24
+
+Post-0.8.0 cycle. Discoverability + MCP-registry registration prep.
+
+### Added
+- **[registry]** `server.json` (MCP `server.schema.json` 2025-12-11) describing
+  doiget as a `cargo` package (`doiget-cli`, run via `doiget serve`) for the
+  official MCP registry under `io.github.sotashimozono/doiget`.
+
+### Fixed
+- **[docs]** The `doiget-cli` crate README on crates.io was badly stale — it
+  still announced a "Phase 0 skeleton" where "every subcommand exits with a
+  Phase-0-pending error". Replaced with the real shipping status + an MCP-host
+  setup snippet and the `mcp-name:` ownership marker (registry verification).
+- **[docs]** Corrected the install command `cargo install doiget` →
+  `cargo install doiget-cli` (no `doiget` crate exists; the binary is `doiget`)
+  in both READMEs, and dropped the stale `v0.2.0` status line in the root README.
+
 ## [0.8.0] - 2026-06-24
 
 Promotes the cumulative `0.8.0-beta.1`–`0.8.0-beta.8` line to a stable release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0"
+version = "0.8.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0"
+version = "0.8.1-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0"
+version = "0.8.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0"
+version       = "0.8.1-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **Docs:** stable = the Zola site (built from `main`); dev = rustdoc built from `next`; API = `docs.rs` (latest published release).
 
-**Status:** Shipping — **v0.2.0** on crates.io (`doiget-core`, `doiget-cli`,
+**Status:** Shipping on crates.io (`doiget-core`, `doiget-cli`,
 `doiget-mcp`), with sigstore-signed binaries + an SBOM attached to the GitHub
 Release. Tier 1 + Tier 2 sources, the stdio MCP server, citation-graph
 expansion, and gated TDM sources are all implemented. Releases are cut by a
@@ -85,7 +85,7 @@ irm https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.
 ### From crates.io (Rust toolchain)
 
 ```sh
-cargo install doiget
+cargo install doiget-cli   # installs the `doiget` binary
 ```
 
 Further prebuilt-binary channels (Homebrew tap, `cargo binstall`, npm/npx, Nix flake,

--- a/crates/doiget-cli/README.md
+++ b/crates/doiget-cli/README.md
@@ -9,9 +9,9 @@ same library without coordination.
 ## Install
 
 ```sh
-cargo install doiget                                    # Tier 1 only (default)
-cargo install doiget --features metadata                # +OpenAlex / Semantic Scholar / DOAJ
-cargo install doiget --features metadata,tdm-springer   # add Springer Nature OA TDM
+cargo install doiget-cli                                    # Tier 1 only (default)
+cargo install doiget-cli --features metadata               # +OpenAlex / Semantic Scholar / DOAJ
+cargo install doiget-cli --features metadata,tdm-springer  # add Springer Nature OA TDM
 ```
 
 The default build compiles **Tier 1 (Open Access)** sources only. Tier 2 metadata
@@ -21,16 +21,25 @@ must be opted in at build time. There is no `tdm-all` umbrella feature by design
 See [`docs/SOURCES.md`](https://github.com/sotashimozono/doiget/blob/main/docs/SOURCES.md)
 for the full source matrix, feature names, required env vars, and Terms-of-Service links.
 
-## Status: Phase 0
+## Status
 
-The published crate currently ships the **Phase 0 skeleton**:
+Shipping and fully functional. OA fetch (Crossref / Unpaywall / arXiv), the
+on-disk store, BibTeX / CSL export, the citation graph, and the **stdio MCP
+server** (`doiget serve`) are all implemented. The installed binary is named
+`doiget`. See the
+[CHANGELOG](https://github.com/sotashimozono/doiget/blob/main/CHANGELOG.md) for
+the current version and history.
 
-- `doiget --help` works and lists the full subcommand surface.
-- Every subcommand currently exits with a Phase-0-pending error.
-- Real fetch / store / MCP behavior lands in Phase 1+.
+## Use as an MCP server
 
-See [`docs/PHASES.md`](https://github.com/sotashimozono/doiget/blob/main/docs/PHASES.md)
-for the phase plan and Phase 1 readiness criteria.
+`doiget serve` runs the stdio MCP server. Register it with any MCP host
+(Claude Desktop, Cursor, …):
+
+```json
+{ "mcpServers": { "doiget": { "command": "doiget", "args": ["serve"] } } }
+```
+
+MCP Registry name: `mcp-name: io.github.sotashimozono/doiget`
 
 ## Subcommand surface
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sotashimozono/doiget",
+  "title": "doiget",
+  "description": "OA-first academic paper fetcher: DOIs & arXiv IDs to local PDFs + metadata via official Open Access APIs.",
+  "repository": {
+    "url": "https://github.com/sotashimozono/doiget",
+    "source": "github"
+  },
+  "version": "0.8.1",
+  "packages": [
+    {
+      "registryType": "cargo",
+      "registryBaseUrl": "https://crates.io",
+      "identifier": "doiget-cli",
+      "version": "0.8.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Gets doiget **into the official MCP registry** and fixes its crates.io
presentation. `next` 0.8.0 → 0.8.1-beta.1 (post-0.8.0 retarget). No auto-merge.

## What
- **`server.json`** (schema `2025-12-11`): a `cargo` package entry —
  `identifier: doiget-cli`, `registryBaseUrl: https://crates.io`, run as
  `doiget serve` (`packageArguments: ["serve"]`), `transport: stdio`, name
  `io.github.sotashimozono/doiget`.
- **`doiget-cli` crate README** (the crates.io page): was badly stale —
  *"Phase 0 skeleton … every subcommand exits with a Phase-0-pending error"*.
  Replaced with the shipping status + an MCP-host setup snippet + the
  **`mcp-name: io.github.sotashimozono/doiget`** ownership marker (what the
  registry checks for cargo packages).
- **Install fix**: `cargo install doiget` → `cargo install doiget-cli` (no
  `doiget` crate exists; the binary is `doiget`) in both READMEs; dropped the
  stale `v0.2.0` line in the root README.

## How registry registration works (mechanics I verified)
- `cargo` IS a supported `registryType` (npm/pypi/nuget/**cargo**/oci/mcpb).
- Cargo ownership is verified by a **visible** `mcp-name: <server-name>` marker
  in the **published crate README** → so the marker must ship in a crate
  version on crates.io. crates.io is immutable, so it can't be 0.8.0.

## Remaining steps (yours — gated)
1. Merge this → `next`.
2. Cut **0.8.1** (next → main promotion + signed `v0.8.1` tag) so `doiget-cli`
   `0.8.1` publishes **with** the `mcp-name:` marker. (Bump `server.json`'s
   `version` to the exact published version if it differs from `0.8.1`.)
3. Publish to the registry:
   ```sh
   brew install mcp-publisher        # or download the release binary
   mcp-publisher login github        # auth as sotashimozono
   mcp-publisher publish             # reads ./server.json
   ```
   (Or I can add a GitHub Actions OIDC step to release-plz so each tag
   auto-publishes to the registry — say the word.)

## Caveat to watch
The cargo binary is `doiget` (≠ crate `doiget-cli`) and the server is the
`serve` subcommand. `packageArguments: ["serve"]` covers the subcommand; if a
client mis-resolves the binary name, we'll add a fix — worth a quick check
against one MCP host after publishing.