### PR TITLE
release: 0.8.1 — MCP registry (server.json + OIDC auto-publish) + crates.io README fixes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ name: release
 # Job order — each gates the next; the entire reversible gate precedes the
 # first irreversible action (`cargo publish`), per ADR-0025 D5:
 #
-#   version-gate  -> publish -> (sign, sbom, github-release)
+#   version-gate  -> publish -> (sign, sbom, github-release, mcp-registry)
 #
 #   * version-gate : scripts/release-version-gate.sh (ADR-0025 D2, G0–G7).
 #                    If it fails NOTHING else runs (nothing external happens).
@@ -486,3 +486,69 @@ jobs:
             "${SBOM}.sha256" \
             "${SBOM}.cosign.bundle" \
             --clobber
+
+  # -------------------------------------------------------------------------
+  # e. mcp-registry — publish / refresh the official MCP Registry entry
+  #    (io.github.sotashimozono/doiget) via GitHub OIDC. STABLE tags only (the
+  #    registry should point at a stable crate version; betas are pre-release).
+  #    BEST-EFFORT (continue-on-error): a registry hiccup must never fail the
+  #    crates.io / GitHub release. NO secret — the `id-token: write` OIDC token
+  #    authorizes the `io.github.sotashimozono/*` namespace because this Action
+  #    runs in that org's repo. The registry verifies the `mcp-name:` marker on
+  #    the doiget-cli crate README the `publish` job just uploaded, so a short
+  #    retry loop absorbs crates.io indexing lag. mcp-publisher is version-pinned
+  #    (the repo pins third-party deps; ADR-0013 supply-chain posture).
+  # -------------------------------------------------------------------------
+  mcp-registry:
+    name: publish to MCP registry (OIDC)
+    runs-on: ubuntu-latest
+    needs: publish
+    if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write   # OIDC: mint the MCP registry token (no secret)
+    env:
+      MCP_PUBLISHER_VERSION: v1.7.9
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ env.TAG }}
+      - name: Install mcp-publisher (pinned)
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          test -x ./mcp-publisher && echo "mcp-publisher ${MCP_PUBLISHER_VERSION} installed"
+      - name: Pin server.json version to the released tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          ver="${TAG#v}"
+          # Keep server.json's top-level + cargo-package versions in lockstep
+          # with the crate version this release just published to crates.io.
+          jq --arg v "$ver" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+          mv server.tmp server.json
+          echo "---- server.json ----"; cat server.json
+      - name: Authenticate to the MCP registry (GitHub OIDC)
+        shell: bash
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server.json (retry for crates.io indexing)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The registry verifies the `mcp-name:` marker on the doiget-cli
+          # crates.io README; retry while crates.io indexes the version the
+          # `publish` job just uploaded.
+          for i in $(seq 1 6); do
+            if ./mcp-publisher publish; then
+              echo "::notice::published io.github.sotashimozono/doiget@${TAG#v} to the MCP registry"
+              exit 0
+            fi
+            echo "publish attempt $i/6 failed (crate may not be indexed yet); waiting 30s"
+            sleep 30
+          done
+          echo "::error::mcp-publisher publish did not succeed after retries" >&2
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.1-beta.2] - 2026-06-25
+
+### Added
+- **[release/ci]** `release-plz.yml` gains an `mcp-registry` job: on a **stable**
+  tag it publishes / refreshes the official MCP Registry entry
+  (`io.github.sotashimozono/doiget`) via GitHub OIDC (no secret; the
+  `id-token` authorizes the `io.github.sotashimozono/*` namespace), pinning
+  `server.json`'s version to the tag and retrying for crates.io indexing. It is
+  best-effort (`continue-on-error`) so a registry hiccup never fails the
+  crates.io / GitHub release, and runs on stable tags only. `mcp-publisher`
+  pinned to `v1.7.9`.
+
 ## [0.8.1-beta.1] - 2026-06-24
 
 Post-0.8.0 cycle. Discoverability + MCP-registry registration prep.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,30 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-## [0.8.1-beta.2] - 2026-06-25
+## [0.8.1] - 2026-06-25
+
+Discoverability / MCP-registry release. Promotes the `0.8.1-beta.1`–`beta.2`
+cycle to stable.
 
 ### Added
-- **[release/ci]** `release-plz.yml` gains an `mcp-registry` job: on a **stable**
-  tag it publishes / refreshes the official MCP Registry entry
-  (`io.github.sotashimozono/doiget`) via GitHub OIDC (no secret; the
-  `id-token` authorizes the `io.github.sotashimozono/*` namespace), pinning
-  `server.json`'s version to the tag and retrying for crates.io indexing. It is
-  best-effort (`continue-on-error`) so a registry hiccup never fails the
-  crates.io / GitHub release, and runs on stable tags only. `mcp-publisher`
-  pinned to `v1.7.9`.
+- **[registry]** `server.json` (MCP `server.schema.json` 2025-12-11) describing
+  doiget as a `cargo` package (`doiget-cli`, run via `doiget serve`) for the
+  official MCP Registry (`io.github.sotashimozono/doiget`), plus a
+  `release-plz.yml` `mcp-registry` job that auto-publishes / refreshes the
+  registry entry on each **stable** tag via GitHub OIDC (no secret; the
+  `id-token` authorizes the `io.github.sotashimozono/*` namespace; best-effort
+  `continue-on-error`). `mcp-publisher` pinned to `v1.7.9`.
+
+### Fixed
+- **[docs]** The `doiget-cli` crates.io README was stale — it announced a
+  "Phase 0 skeleton" where "every subcommand exits with a Phase-0-pending
+  error". Replaced with the real shipping status + an MCP-host setup snippet
+  and the `mcp-name:` registry ownership marker. Corrected `cargo install
+  doiget` → `cargo install doiget-cli` (no `doiget` crate exists; the binary is
+  `doiget`) in both READMEs, and dropped the stale `v0.2.0` status line in the
+  root README.
+
+See `0.8.1-beta.*` below for per-change detail.
 
 ## [0.8.1-beta.1] - 2026-06-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.1-beta.2"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.1-beta.2"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.1-beta.2"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.1-beta.1"
+version = "0.8.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.1-beta.1"
+version = "0.8.1-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.1-beta.1"
+version = "0.8.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.1-beta.2"
+version       = "0.8.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.1-beta.1"
+version       = "0.8.1-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
**This is the 0.8.1 release cut** — per request, the beta is dropped here
instead of in a separate PR. It bundles the MCP-registry registration + the
OIDC auto-publish CI. `0.8.1-beta.2 → 0.8.1`.

## ⚠️ `version-bump` is RED here — expected
ADR-0033 rejects a clean `X.Y.Z` on a PR→`next` (clean versions only land via
the `next → main` promotion). This is the **release-cut exception**, identical
to the 0.8.0 cut (#354) — merge it as the release cut. Verified locally:
`release-version-gate.sh v0.8.1` passes **G0–G6**. All other checks pass.

## Contents
- **`server.json`** + **`doiget-cli` crates.io README** rewrite (stale "Phase 0
  skeleton / every subcommand exits with a pending error" → real shipping
  status + MCP-host setup snippet + the `mcp-name:` registry marker) + install
  fix (`cargo install doiget` → `doiget-cli`; no `doiget` crate exists).
- **`release-plz.yml` `mcp-registry` job**: stable-tag-only, GitHub OIDC (no
  secret), best-effort (`continue-on-error`) auto-publish/refresh of the
  registry entry on each release; `mcp-publisher` pinned `v1.7.9`.
- `0.8.1-beta.2 → 0.8.1` + curated `## [0.8.1]` CHANGELOG.

## Sequence from here
1. **Merge this → `next`** (`next` becomes `0.8.1`).
2. I open the **`next → main` promotion PR** (its `version-bump` is green —
   clean `0.8.1`, +1 patch over `main` 0.8.0).
3. Merge promotion → `main` = `0.8.1`.
4. Signed **`v0.8.1`** tag → `publish` ships `doiget-cli` 0.8.1 (with the
   marker) → the `mcp-registry` job auto-registers doiget.