### PR TITLE
Promote next → main: 0.8.1 (MCP registry registration + OIDC auto-publish)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ name: release
 # Job order — each gates the next; the entire reversible gate precedes the
 # first irreversible action (`cargo publish`), per ADR-0025 D5:
 #
-#   version-gate  -> publish -> (sign, sbom, github-release)
+#   version-gate  -> publish -> (sign, sbom, github-release, mcp-registry)
 #
 #   * version-gate : scripts/release-version-gate.sh (ADR-0025 D2, G0–G7).
 #                    If it fails NOTHING else runs (nothing external happens).
@@ -486,3 +486,69 @@ jobs:
             "${SBOM}.sha256" \
             "${SBOM}.cosign.bundle" \
             --clobber
+
+  # -------------------------------------------------------------------------
+  # e. mcp-registry — publish / refresh the official MCP Registry entry
+  #    (io.github.sotashimozono/doiget) via GitHub OIDC. STABLE tags only (the
+  #    registry should point at a stable crate version; betas are pre-release).
+  #    BEST-EFFORT (continue-on-error): a registry hiccup must never fail the
+  #    crates.io / GitHub release. NO secret — the `id-token: write` OIDC token
+  #    authorizes the `io.github.sotashimozono/*` namespace because this Action
+  #    runs in that org's repo. The registry verifies the `mcp-name:` marker on
+  #    the doiget-cli crate README the `publish` job just uploaded, so a short
+  #    retry loop absorbs crates.io indexing lag. mcp-publisher is version-pinned
+  #    (the repo pins third-party deps; ADR-0013 supply-chain posture).
+  # -------------------------------------------------------------------------
+  mcp-registry:
+    name: publish to MCP registry (OIDC)
+    runs-on: ubuntu-latest
+    needs: publish
+    if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write   # OIDC: mint the MCP registry token (no secret)
+    env:
+      MCP_PUBLISHER_VERSION: v1.7.9
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ env.TAG }}
+      - name: Install mcp-publisher (pinned)
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          test -x ./mcp-publisher && echo "mcp-publisher ${MCP_PUBLISHER_VERSION} installed"
+      - name: Pin server.json version to the released tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          ver="${TAG#v}"
+          # Keep server.json's top-level + cargo-package versions in lockstep
+          # with the crate version this release just published to crates.io.
+          jq --arg v "$ver" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+          mv server.tmp server.json
+          echo "---- server.json ----"; cat server.json
+      - name: Authenticate to the MCP registry (GitHub OIDC)
+        shell: bash
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server.json (retry for crates.io indexing)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The registry verifies the `mcp-name:` marker on the doiget-cli
+          # crates.io README; retry while crates.io indexes the version the
+          # `publish` job just uploaded.
+          for i in $(seq 1 6); do
+            if ./mcp-publisher publish; then
+              echo "::notice::published io.github.sotashimozono/doiget@${TAG#v} to the MCP registry"
+              exit 0
+            fi
+            echo "publish attempt $i/6 failed (crate may not be indexed yet); waiting 30s"
+            sleep 30
+          done
+          echo "::error::mcp-publisher publish did not succeed after retries" >&2
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.1-beta.2] - 2026-06-25
+
+### Added
+- **[release/ci]** `release-plz.yml` gains an `mcp-registry` job: on a **stable**
+  tag it publishes / refreshes the official MCP Registry entry
+  (`io.github.sotashimozono/doiget`) via GitHub OIDC (no secret; the
+  `id-token` authorizes the `io.github.sotashimozono/*` namespace), pinning
+  `server.json`'s version to the tag and retrying for crates.io indexing. It is
+  best-effort (`continue-on-error`) so a registry hiccup never fails the
+  crates.io / GitHub release, and runs on stable tags only. `mcp-publisher`
+  pinned to `v1.7.9`.
+
 ## [0.8.1-beta.1] - 2026-06-24
 
 Post-0.8.0 cycle. Discoverability + MCP-registry registration prep.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,30 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-## [0.8.1-beta.2] - 2026-06-25
+## [0.8.1] - 2026-06-25
+
+Discoverability / MCP-registry release. Promotes the `0.8.1-beta.1`–`beta.2`
+cycle to stable.
 
 ### Added
-- **[release/ci]** `release-plz.yml` gains an `mcp-registry` job: on a **stable**
-  tag it publishes / refreshes the official MCP Registry entry
-  (`io.github.sotashimozono/doiget`) via GitHub OIDC (no secret; the
-  `id-token` authorizes the `io.github.sotashimozono/*` namespace), pinning
-  `server.json`'s version to the tag and retrying for crates.io indexing. It is
-  best-effort (`continue-on-error`) so a registry hiccup never fails the
-  crates.io / GitHub release, and runs on stable tags only. `mcp-publisher`
-  pinned to `v1.7.9`.
+- **[registry]** `server.json` (MCP `server.schema.json` 2025-12-11) describing
+  doiget as a `cargo` package (`doiget-cli`, run via `doiget serve`) for the
+  official MCP Registry (`io.github.sotashimozono/doiget`), plus a
+  `release-plz.yml` `mcp-registry` job that auto-publishes / refreshes the
+  registry entry on each **stable** tag via GitHub OIDC (no secret; the
+  `id-token` authorizes the `io.github.sotashimozono/*` namespace; best-effort
+  `continue-on-error`). `mcp-publisher` pinned to `v1.7.9`.
+
+### Fixed
+- **[docs]** The `doiget-cli` crates.io README was stale — it announced a
+  "Phase 0 skeleton" where "every subcommand exits with a Phase-0-pending
+  error". Replaced with the real shipping status + an MCP-host setup snippet
+  and the `mcp-name:` registry ownership marker. Corrected `cargo install
+  doiget` → `cargo install doiget-cli` (no `doiget` crate exists; the binary is
+  `doiget`) in both READMEs, and dropped the stale `v0.2.0` status line in the
+  root README.
+
+See `0.8.1-beta.*` below for per-change detail.
 
 ## [0.8.1-beta.1] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.1-beta.1] - 2026-06-24
+
+Post-0.8.0 cycle. Discoverability + MCP-registry registration prep.
+
+### Added
+- **[registry]** `server.json` (MCP `server.schema.json` 2025-12-11) describing
+  doiget as a `cargo` package (`doiget-cli`, run via `doiget serve`) for the
+  official MCP registry under `io.github.sotashimozono/doiget`.
+
+### Fixed
+- **[docs]** The `doiget-cli` crate README on crates.io was badly stale — it
+  still announced a "Phase 0 skeleton" where "every subcommand exits with a
+  Phase-0-pending error". Replaced with the real shipping status + an MCP-host
+  setup snippet and the `mcp-name:` ownership marker (registry verification).
+- **[docs]** Corrected the install command `cargo install doiget` →
+  `cargo install doiget-cli` (no `doiget` crate exists; the binary is `doiget`)
+  in both READMEs, and dropped the stale `v0.2.0` status line in the root README.
+
 ## [0.8.0] - 2026-06-24
 
 Promotes the cumulative `0.8.0-beta.1`–`0.8.0-beta.8` line to a stable release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.0"
+version = "0.8.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.0"
+version = "0.8.1-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.0"
+version = "0.8.1-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.1-beta.2"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.1-beta.2"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.1-beta.2"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.1-beta.1"
+version = "0.8.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.1-beta.1"
+version = "0.8.1-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.1-beta.1"
+version = "0.8.1-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.0"
+version       = "0.8.1-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.0" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.0" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.0" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.1-beta.2"
+version       = "0.8.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.1-beta.1"
+version       = "0.8.1-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.1-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **Docs:** stable = the Zola site (built from `main`); dev = rustdoc built from `next`; API = `docs.rs` (latest published release).
 
-**Status:** Shipping — **v0.2.0** on crates.io (`doiget-core`, `doiget-cli`,
+**Status:** Shipping on crates.io (`doiget-core`, `doiget-cli`,
 `doiget-mcp`), with sigstore-signed binaries + an SBOM attached to the GitHub
 Release. Tier 1 + Tier 2 sources, the stdio MCP server, citation-graph
 expansion, and gated TDM sources are all implemented. Releases are cut by a
@@ -85,7 +85,7 @@ irm https://raw.githubusercontent.com/sotashimozono/doiget/main/scripts/install.
 ### From crates.io (Rust toolchain)
 
 ```sh
-cargo install doiget
+cargo install doiget-cli   # installs the `doiget` binary
 ```
 
 Further prebuilt-binary channels (Homebrew tap, `cargo binstall`, npm/npx, Nix flake,

--- a/crates/doiget-cli/README.md
+++ b/crates/doiget-cli/README.md
@@ -9,9 +9,9 @@ same library without coordination.
 ## Install
 
 ```sh
-cargo install doiget                                    # Tier 1 only (default)
-cargo install doiget --features metadata                # +OpenAlex / Semantic Scholar / DOAJ
-cargo install doiget --features metadata,tdm-springer   # add Springer Nature OA TDM
+cargo install doiget-cli                                    # Tier 1 only (default)
+cargo install doiget-cli --features metadata               # +OpenAlex / Semantic Scholar / DOAJ
+cargo install doiget-cli --features metadata,tdm-springer  # add Springer Nature OA TDM
 ```
 
 The default build compiles **Tier 1 (Open Access)** sources only. Tier 2 metadata
@@ -21,16 +21,25 @@ must be opted in at build time. There is no `tdm-all` umbrella feature by design
 See [`docs/SOURCES.md`](https://github.com/sotashimozono/doiget/blob/main/docs/SOURCES.md)
 for the full source matrix, feature names, required env vars, and Terms-of-Service links.
 
-## Status: Phase 0
+## Status
 
-The published crate currently ships the **Phase 0 skeleton**:
+Shipping and fully functional. OA fetch (Crossref / Unpaywall / arXiv), the
+on-disk store, BibTeX / CSL export, the citation graph, and the **stdio MCP
+server** (`doiget serve`) are all implemented. The installed binary is named
+`doiget`. See the
+[CHANGELOG](https://github.com/sotashimozono/doiget/blob/main/CHANGELOG.md) for
+the current version and history.
 
-- `doiget --help` works and lists the full subcommand surface.
-- Every subcommand currently exits with a Phase-0-pending error.
-- Real fetch / store / MCP behavior lands in Phase 1+.
+## Use as an MCP server
 
-See [`docs/PHASES.md`](https://github.com/sotashimozono/doiget/blob/main/docs/PHASES.md)
-for the phase plan and Phase 1 readiness criteria.
+`doiget serve` runs the stdio MCP server. Register it with any MCP host
+(Claude Desktop, Cursor, …):
+
+```json
+{ "mcpServers": { "doiget": { "command": "doiget", "args": ["serve"] } } }
+```
+
+MCP Registry name: `mcp-name: io.github.sotashimozono/doiget`
 
 ## Subcommand surface
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sotashimozono/doiget",
+  "title": "doiget",
+  "description": "OA-first academic paper fetcher: DOIs & arXiv IDs to local PDFs + metadata via official Open Access APIs.",
+  "repository": {
+    "url": "https://github.com/sotashimozono/doiget",
+    "source": "github"
+  },
+  "version": "0.8.1",
+  "packages": [
+    {
+      "registryType": "cargo",
+      "registryBaseUrl": "https://crates.io",
+      "identifier": "doiget-cli",
+      "version": "0.8.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Promotion of the **0.8.1** cycle from `next` to `main`. Delta since 0.8.0:
the MCP-registry registration (`server.json` + the `doiget-cli` crates.io
README rewrite + install fix, #356) and the `release-plz.yml` OIDC
auto-publish job (#357).

## ⏳ Opened ahead of the release cut — RED until #357 merges
Right now `next` is `0.8.1-beta.1`, so the `version-bump` check is **red**
("a promotion to main must carry a clean X.Y.Z"). The release cut is **#357**
(`0.8.1-beta.2 → 0.8.1`). The moment **#357 merges into `next`**, this PR's
head advances to `next` = `0.8.1` and `version-bump` flips **green**
(`0.7.0`… `0.8.0` → `0.8.1`, +1 patch — valid single-step promotion).

## Sequence
1. Merge **#357 → next** (the release cut; `next` becomes `0.8.1`).
2. This PR's `version-bump` goes green → **merge this → main** (`main` = `0.8.1`).
3. Signed **`v0.8.1`** tag on `main` → `publish` ships `doiget-cli` 0.8.1 (with
   the `mcp-name:` marker) → the new `mcp-registry` job auto-registers doiget
   to the official MCP Registry.

No auto-merge — human-gated release.