### PR TITLE
release: 0.8.2 — macos-13 → cross-compile on macos-latest + MCP registry 422 fix

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -300,7 +300,7 @@ jobs:
           # Linux ships a fully static musl binary so the published
           # artefact runs on old glibc (Ubuntu 20.04 / RHEL 8 research &
           # HPC boxes), not just the ubuntu-latest glibc the runner has.
-          # macOS/Windows stay native (empty target → no cross-compile).
+          # macOS arm64 + Windows stay native; macOS x86_64 cross-compiles.
           - os: ubuntu-latest
             artifact: doiget-linux-x86_64
             ext: ""
@@ -309,11 +309,15 @@ jobs:
             artifact: doiget-macos-aarch64
             ext: ""
             target: ""
-          # Intel macOS runner (last GitHub-hosted x86_64 macOS runner, ADR-0025).
-          - os: macos-13
+          # Intel macOS: cross-compiled on the arm64 `macos-latest` runner
+          # (Apple's clang is universal). GitHub deprecated/removed the
+          # standalone x86_64 `macos-13` runner, so we no longer request one —
+          # the cross-compile-on-one-runner approach used across the author's
+          # other repos.
+          - os: macos-latest
             artifact: doiget-macos-x86_64
             ext: ""
-            target: ""
+            target: x86_64-apple-darwin
           - os: windows-latest
             artifact: doiget-windows-x86_64
             ext: ".exe"
@@ -340,6 +344,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
           rustup target add x86_64-unknown-linux-musl
+      - name: Add the macOS x86_64 cross target
+        if: matrix.target == 'x86_64-apple-darwin'
+        shell: bash
+        # The arm64 runner's clang cross-compiles to x86_64 with no extra C
+        # toolchain (Apple's clang is universal); only the Rust std target is
+        # needed, and `ring` builds cleanly for it.
+        run: rustup target add x86_64-apple-darwin
       - name: Build doiget (release, oa-only)
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.2-beta.1] - 2026-06-25
+
+### Fixed
+- **[release/ci]** The `release-plz.yml` binary-signing matrix requested the
+  deprecated `macos-13` (Intel) runner, which GitHub no longer allocates — it
+  hung the v0.8.1 release until cancelled. Build the x86_64 macOS binary by
+  cross-compiling `x86_64-apple-darwin` on the arm64 `macos-latest` runner
+  (Apple's clang is universal); `macos-13` is removed.
+- **[registry]** `server.json`'s `description` exceeded the MCP Registry's
+  100-char limit, so the new `mcp-registry` job failed with HTTP 422 on the
+  v0.8.1 release. Shortened it (≤100). doiget can now be published to the
+  registry (manually for 0.8.1, or automatically on the next stable tag).
+
 ## [0.8.1] - 2026-06-25
 
 Discoverability / MCP-registry release. Promotes the `0.8.1-beta.1`–`beta.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-## [0.8.2-beta.1] - 2026-06-25
+## [0.8.2] - 2026-06-25
+
+CI / release-infrastructure fixes from the v0.8.1 release (no library or CLI
+behavior change).
 
 ### Fixed
 - **[release/ci]** The `release-plz.yml` binary-signing matrix requested the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.1"
+version = "0.8.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.1"
+version = "0.8.2-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.1"
+version = "0.8.2-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.2-beta.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.2-beta.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.2-beta.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.1"
+version       = "0.8.2-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.2-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.2-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.2-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.2-beta.1"
+version       = "0.8.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.2-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.2-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.2-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sotashimozono/doiget",
   "title": "doiget",
-  "description": "OA-first academic paper fetcher: DOIs & arXiv IDs to local PDFs + metadata via official Open Access APIs.",
+  "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
   "repository": {
     "url": "https://github.com/sotashimozono/doiget",
     "source": "github"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/sotashimozono/doiget",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "packages": [
     {
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "doiget-cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
**The 0.8.2 release cut** — beta stripped, direct to stable per request. Fixes
the two v0.8.1 failures. `0.8.2-beta.1 → 0.8.2`.

### ⚠️ `version-bump` is RED — expected
A clean `X.Y.Z` on a PR→`next` is the release-cut exception (ADR-0033), same as
the 0.8.1 cut (#357). Verified: `release-version-gate.sh v0.8.2` passes G0–G6;
all other checks pass.

## 1. macos-13 is deprecated (hung the v0.8.1 release)
The sign matrix requested the `macos-13` Intel runner, which GitHub no longer
allocates (the v0.8.1 sign job hung in "Waiting for a runner…"; run cancelled).
Ported to the cross-compile-on-one-runner model your other repos use
(e.g. `obsidian-remote-ssh`): **cross-compile `x86_64-apple-darwin` on the
arm64 `macos-latest` runner** (Apple's clang is universal). Both macOS arches
now build with **no `macos-13`**.

## 2. MCP registry HTTP 422 (the real `mcp-registry` failure)
Not indexing lag — `server.json`'s `description` was **105 chars**; the registry
rejects `> 100`. Shortened to **85**. server.json `version` bumped to `0.8.2`.

## Sequence
1. Merge this → `next` (`next` = `0.8.2`).
2. I open the `next → main` promotion PR (its `version-bump` is green).
3. Merge promotion → `main` = `0.8.2`.
4. Signed **`v0.8.2`** tag → `publish` ships 0.8.2 (incl. the Intel-macOS
   binary via cross-compile) → the `mcp-registry` job auto-registers doiget
   (valid description now).