### PR TITLE
Promote next → main: 0.8.3 (MCP registry source-only + cargo-audit node24)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+      - uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432 # node24 (master, "Update to use Node 24" #48; v2.0.0 was the GitHub-deprecated node20)
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -538,9 +538,12 @@ jobs:
         run: |
           set -euo pipefail
           ver="${TAG#v}"
-          # Keep server.json's top-level + cargo-package versions in lockstep
-          # with the crate version this release just published to crates.io.
-          jq --arg v "$ver" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+          # Pin server.json's version to the released tag. Source-only entry
+          # (no `packages` array): the live MCP Registry does not yet accept the
+          # `cargo` registry type (400 "unsupported registry type: cargo"),
+          # though the 2025-12-11 schema lists it. Re-add a cargo package once
+          # the registry deploys cargo support.
+          jq --arg v "$ver" '.version = $v' server.json > server.tmp
           mv server.tmp server.json
           echo "---- server.json ----"; cat server.json
       - name: Authenticate to the MCP registry (GitHub OIDC)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.3-beta.1] - 2026-06-25
+
+### Fixed
+- **[registry]** The live MCP Registry rejects `registryType: cargo` (HTTP 400
+  "unsupported registry type", even though the 2025-12-11 schema lists it), so
+  the `mcp-registry` job failed on the v0.8.2 release. Make `server.json` a
+  **source-only** entry (drop the `packages` array) so doiget is listed /
+  discoverable in the registry; the CI version-pin no longer touches
+  `packages`. A `cargo` package can be re-added once the registry deploys cargo
+  support. (Install is unchanged: `cargo install doiget-cli`, per the README.)
+- **[ci]** Re-pin `rustsec/audit-check` from `v2.0.0` (node20, GitHub-deprecated)
+  to its node24 `master` commit, silencing the "Node 20 is deprecated" warning
+  in the `cargo audit` job.
+
 ## [0.8.2] - 2026-06-25
 
 CI / release-infrastructure fixes from the v0.8.1 release (no library or CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-## [0.8.3-beta.1] - 2026-06-25
+## [0.8.3] - 2026-06-25
+
+CI / release-infrastructure fixes (no library or CLI behavior change).
 
 ### Fixed
 - **[registry]** The live MCP Registry rejects `registryType: cargo` (HTTP 400

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.3-beta.1"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.3-beta.1"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.3-beta.1"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.2"
+version = "0.8.3-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.2"
+version = "0.8.3-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.2"
+version = "0.8.3-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.2"
+version       = "0.8.3-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.3-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.3-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.3-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.3-beta.1"
+version       = "0.8.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.3-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.3-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.3-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/server.json
+++ b/server.json
@@ -7,5 +7,5 @@
     "url": "https://github.com/sotashimozono/doiget",
     "source": "github"
   },
-  "version": "0.8.2"
+  "version": "0.8.3"
 }

--- a/server.json
+++ b/server.json
@@ -7,22 +7,5 @@
     "url": "https://github.com/sotashimozono/doiget",
     "source": "github"
   },
-  "version": "0.8.2",
-  "packages": [
-    {
-      "registryType": "cargo",
-      "registryBaseUrl": "https://crates.io",
-      "identifier": "doiget-cli",
-      "version": "0.8.2",
-      "transport": {
-        "type": "stdio"
-      },
-      "packageArguments": [
-        {
-          "type": "positional",
-          "value": "serve"
-        }
-      ]
-    }
-  ]
+  "version": "0.8.2"
 }


### PR DESCRIPTION
Promotion of **0.8.3** from `next` to `main`. CI / release-infra fixes (no
library or CLI behavior change):

- **MCP registry → source-only.** The live registry rejects `registryType:
  cargo` (HTTP 400), so `server.json` drops the `packages` array → a source-only
  entry (doiget stays listed/discoverable; install `cargo install doiget-cli`).
  The `mcp-registry` CI `jq` no longer touches `.packages`.
- **cargo-audit Node 20.** Re-pinned `rustsec/audit-check` v2.0.0 (node20) → its
  node24 `master` commit, silencing the deprecation warning.

`version-bump` is **green** (clean `0.8.3`, +1 patch over `main` 0.8.2).
Verified: `release-version-gate.sh v0.8.3` passes G0–G6.

## After merge
Push the signed **`v0.8.3`** tag → `publish` ships 0.8.3 to crates.io (+ both
macOS arches via cross-compile) → the `mcp-registry` job attempts the
source-only registry entry. I'll handle the tag once this is on `main`.

No auto-merge.