### PR TITLE
release: promote 0.8.4 to stable — Claude Desktop Extension (.mcpb) + privacy disclosure

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ name: release
 # Job order — each gates the next; the entire reversible gate precedes the
 # first irreversible action (`cargo publish`), per ADR-0025 D5:
 #
-#   version-gate  -> publish -> (sign, sbom, github-release, mcp-registry)
+#   version-gate  -> publish -> (sign, sbom, github-release, mcp-registry, desktop-extension)
 #
 #   * version-gate : scripts/release-version-gate.sh (ADR-0025 D2, G0–G7).
 #                    If it fails NOTHING else runs (nothing external happens).
@@ -566,3 +566,49 @@ jobs:
           done
           echo "::error::mcp-publisher publish did not succeed after retries" >&2
           exit 1
+
+  # -------------------------------------------------------------------------
+  # f. desktop-extension — build the Claude Desktop Extension (.mcpb) and
+  #    attach it to the Release, so doiget is one-click-installable from Claude
+  #    Desktop (Settings > Extensions) — a separate channel from the MCP
+  #    Registry. STABLE tags only, BEST-EFFORT (continue-on-error). Runs on
+  #    macOS for `lipo` (universal macOS binary). Reuses the signed release
+  #    binaries the `sign` job uploaded.
+  # -------------------------------------------------------------------------
+  desktop-extension:
+    name: build Claude Desktop Extension (.mcpb)
+    runs-on: macos-latest
+    needs: [github-release, sign]
+    if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
+    continue-on-error: true
+    permissions:
+      contents: write   # download release binaries + upload the .mcpb
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ env.TAG }}
+      - name: Install the mcpb CLI
+        shell: bash
+        # node/npm are preinstalled on the GitHub-hosted macOS runner.
+        run: npm install -g @anthropic-ai/mcpb
+      - name: Download the signed release binaries
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p bin
+          gh release download "$TAG" -D bin \
+            -p 'doiget-linux-x86_64' \
+            -p 'doiget-macos-aarch64' \
+            -p 'doiget-macos-x86_64' \
+            -p 'doiget-windows-x86_64.exe'
+      - name: Build the .mcpb bundle
+        shell: bash
+        run: bash scripts/build-mcpb.sh "${TAG#v}" bin "doiget-${TAG#v}.mcpb"
+      - name: Upload the .mcpb to the Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$TAG" "doiget-${TAG#v}.mcpb" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.4-beta.1] - 2026-06-25
+
+### Added
+- **[distribution]** Claude **Desktop Extension** (`.mcpb`): doiget can be
+  one-click-installed from Claude Desktop (Settings > Extensions) — a separate,
+  more discoverable channel than the MCP Registry. Adds `mcpb/manifest.json`
+  (binary server, all 22 tools, a `store_root` user-config, per-platform
+  binaries via `platform_overrides`), `scripts/build-mcpb.sh` (assembles the
+  bundle; fuses the two macOS arches with `lipo` into a universal binary), a
+  release-pipeline `desktop-extension` job that builds + attaches
+  `doiget-<ver>.mcpb` to each stable Release, and `docs/PRIVACY.md` (required
+  for the Extensions directory).
+
 ## [0.8.3] - 2026-06-25
 
 CI / release-infrastructure fixes (no library or CLI behavior change).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-## [0.8.4-beta.1] - 2026-06-25
+## [0.8.4] - 2026-06-25
+
+doiget joins the Claude Desktop Extensions distribution channel.
 
 ### Added
 - **[distribution]** Claude **Desktop Extension** (`.mcpb`): doiget can be
@@ -18,10 +20,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   more discoverable channel than the MCP Registry. Adds `mcpb/manifest.json`
   (binary server, all 22 tools, a `store_root` user-config, per-platform
   binaries via `platform_overrides`), `scripts/build-mcpb.sh` (assembles the
-  bundle; fuses the two macOS arches with `lipo` into a universal binary), a
+  bundle; fuses the two macOS arches with `lipo` into a universal binary), and a
   release-pipeline `desktop-extension` job that builds + attaches
-  `doiget-<ver>.mcpb` to each stable Release, and `docs/PRIVACY.md` (required
-  for the Extensions directory).
+  `doiget-<ver>.mcpb` to each stable Release.
+- **[docs]** `docs/PRIVACY.md` — privacy policy (required for the Extensions
+  directory) that also enumerates every upstream API doiget contacts (Crossref /
+  Unpaywall / arXiv+ar5iv / OpenAlex, plus opt-in Semantic Scholar / DOAJ /
+  publisher TDM) and states each request is governed by that provider's ToS,
+  with the user as the contracting party.
 
 ## [0.8.3] - 2026-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.3"
+version = "0.8.4-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.3"
+version = "0.8.4-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.3"
+version = "0.8.4-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.4-beta.1"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.4-beta.1"
+version = "0.8.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.4-beta.1"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.4-beta.1"
+version       = "0.8.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.4-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.4-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.4-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.3"
+version       = "0.8.4-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.4-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.4-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.4-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,40 @@
+# Privacy Policy
+
+doiget is a local, single-binary CLI + stdio MCP server. It runs entirely on
+your machine.
+
+## What doiget collects
+
+**Nothing.** doiget has no telemetry, no analytics, no crash reporting, and no
+"phone home" of any kind ([ADR-0015](DECISIONS/0015-no-telemetry.md) /
+[`SCOPE.md`](SCOPE.md) non-goal #10). It makes **no network connection that is
+not the direct result of a paper you (or your agent) ask it to fetch**.
+
+## What leaves your machine
+
+Only the API requests required to fulfil a fetch you initiate:
+
+- DOI / arXiv id lookups to **Crossref, Unpaywall, arXiv, and OpenAlex**
+  (Open-Access metadata and PDF sources).
+- An optional contact email in the `User-Agent` header **only if you set**
+  `DOIGET_UNPAYWALL_EMAIL` / `DOIGET_CONTACT_EMAIL` (used for the providers'
+  polite API pool; never sent otherwise).
+
+doiget transmits no document content anywhere. It downloads PDFs and metadata
+**to your local store** and never redistributes them.
+
+## What is stored locally
+
+Fetched PDFs and metadata under your store root (default `./papers`, or
+`DOIGET_STORE_ROOT`), plus an append-only local provenance log. All of it stays
+on your machine.
+
+## Credentials
+
+Any publisher API keys you configure are read from your local environment or
+`credentials.toml` and are used only to authenticate **your own** access to the
+sources you explicitly enabled. doiget bundles no keys and shares none.
+
+## Contact
+
+Questions or concerns: <https://github.com/sotashimozono/doiget/issues>

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -12,16 +12,39 @@ not the direct result of a paper you (or your agent) ask it to fetch**.
 
 ## What leaves your machine
 
-Only the API requests required to fulfil a fetch you initiate:
+doiget stores nothing about you, but **fulfilling a fetch sends the identifier
+you request** — a DOI or arXiv id, and (only if you set it) your contact email —
+to the upstream provider for that source. Nothing else leaves your machine:
+doiget transmits no document content, saves PDFs and metadata **to your local
+store**, and never redistributes them.
 
-- DOI / arXiv id lookups to **Crossref, Unpaywall, arXiv, and OpenAlex**
-  (Open-Access metadata and PDF sources).
-- An optional contact email in the `User-Agent` header **only if you set**
-  `DOIGET_UNPAYWALL_EMAIL` / `DOIGET_CONTACT_EMAIL` (used for the providers'
-  polite API pool; never sent otherwise).
+### Third-party services doiget contacts
 
-doiget transmits no document content anywhere. It downloads PDFs and metadata
-**to your local store** and never redistributes them.
+Each request is governed by **that provider's own Terms of Service and privacy
+policy**. doiget operates within those terms, and — because doiget holds no
+credentials and runs locally — **you are the contracting party** for every
+source you use (see [`LEGAL.md`](LEGAL.md) and [`SOURCES.md`](SOURCES.md) for the
+full matrix and ToS links). doiget enforces a hard 5 requests/second cap to keep
+its use of these APIs polite.
+
+**Default build — Open Access, always on:**
+
+- **Crossref** — DOI → metadata.
+  <https://www.crossref.org/services/metadata-retrieval/rest-api/>
+- **Unpaywall** — Open-Access PDF locations (the polite pool uses your email if
+  you set it). <https://unpaywall.org/products/api>
+- **arXiv** (export API + **ar5iv** for full text) — preprint metadata, PDF,
+  text. <https://info.arxiv.org/help/api/index.html>
+- **OpenAlex** — literature discovery, identity resolution, and citation graph
+  (the search / frontier / link / citation tools).
+  <https://docs.openalex.org/how-to-use-the-api/api-overview>
+
+**Opt-in only — compile-time feature flag + your own configuration:**
+
+- `--features metadata`: **Semantic Scholar**, **DOAJ** (extra metadata).
+- `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
+  text-and-data-mining APIs, used **only with your own API key and explicit
+  agreement**. doiget bundles no keys and shares none.
 
 ## What is stored locally
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "doiget",
   "display_name": "doiget",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
   "long_description": "doiget is a single-binary, stdio MCP server that turns DOIs and arXiv IDs into local PDFs and structured metadata through official Open-Access APIs (Crossref, Unpaywall, arXiv, OpenAlex). It never bypasses paywalls and makes no network call that is not the direct result of a fetch you ask for. PDFs and metadata are saved to a local store; nothing is redistributed or phoned home. It is the agent-facing companion to BiblioFetch.jl and shares the same on-disk paper store.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,73 @@
+{
+  "manifest_version": "0.3",
+  "name": "doiget",
+  "display_name": "doiget",
+  "version": "0.8.3",
+  "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
+  "long_description": "doiget is a single-binary, stdio MCP server that turns DOIs and arXiv IDs into local PDFs and structured metadata through official Open-Access APIs (Crossref, Unpaywall, arXiv, OpenAlex). It never bypasses paywalls and makes no network call that is not the direct result of a fetch you ask for. PDFs and metadata are saved to a local store; nothing is redistributed or phoned home. It is the agent-facing companion to BiblioFetch.jl and shares the same on-disk paper store.",
+  "author": {
+    "name": "Sota Shimozono",
+    "url": "https://github.com/sotashimozono"
+  },
+  "homepage": "https://github.com/sotashimozono/doiget",
+  "documentation": "https://github.com/sotashimozono/doiget/blob/main/docs/MCP_TOOLS.md",
+  "support": "https://github.com/sotashimozono/doiget/issues",
+  "license": "MIT",
+  "keywords": ["doi", "arxiv", "open-access", "academic", "bibliography", "crossref", "unpaywall", "research", "papers", "mcp"],
+  "privacy_policies": ["https://github.com/sotashimozono/doiget/blob/main/docs/PRIVACY.md"],
+  "server": {
+    "type": "binary",
+    "entry_point": "server/doiget-linux",
+    "mcp_config": {
+      "command": "${__dirname}/server/doiget-linux",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "${user_config.store_root}"
+      },
+      "platform_overrides": {
+        "darwin": {
+          "command": "${__dirname}/server/doiget-darwin"
+        },
+        "win32": {
+          "command": "${__dirname}/server/doiget-windows.exe"
+        }
+      }
+    }
+  },
+  "user_config": {
+    "store_root": {
+      "type": "directory",
+      "title": "Paper store location",
+      "description": "Directory where fetched PDFs and metadata are saved. Leave empty to use ./papers under the server's working directory.",
+      "required": false
+    }
+  },
+  "tools": [
+    { "name": "doiget_fetch_paper", "description": "Resolve a DOI or arXiv id and download its Open-Access PDF to the local store." },
+    { "name": "doiget_resolve_paper", "description": "Resolve a DOI or arXiv id to authoritative metadata (no download)." },
+    { "name": "doiget_metadata_only", "description": "Resolve a ref to metadata only — guarantees no PDF or publisher fetch." },
+    { "name": "doiget_batch_fetch", "description": "Fetch up to 100 DOIs / arXiv ids in one rate-limited call." },
+    { "name": "doiget_batch_from_bibliography", "description": "Fetch every resolvable reference from a .bib / CSL-JSON bibliography file." },
+    { "name": "doiget_info", "description": "Return a stored entry's metadata." },
+    { "name": "doiget_search_local", "description": "Search the local store by title / authors / venue." },
+    { "name": "doiget_paper_search", "description": "Discover literature via OpenAlex full-text search (abstract-bearing candidates; never fetches a PDF)." },
+    { "name": "doiget_paper_text", "description": "Extract an arXiv paper's full text from ar5iv as sectioned plain text (never opens the PDF blob)." },
+    { "name": "doiget_paper_tex_source", "description": "Fetch an arXiv paper's LaTeX source as structured text." },
+    { "name": "doiget_link", "description": "Resolve a DOI to its arXiv preprint + cross-id identity cluster (DOI / arXiv / OpenAlex / title) over OpenAlex." },
+    { "name": "doiget_list_recent", "description": "List the most recently fetched entries." },
+    { "name": "doiget_paper_pdf_path", "description": "Return the local path of a cached PDF (does not read, parse, or transmit content)." },
+    { "name": "doiget_capability_profile", "description": "Report which sources this instance is allowed to use." },
+    { "name": "doiget_health", "description": "Operational health: store writable, version, schema." },
+    { "name": "doiget_expand_citation_graph", "description": "Breadth-first expansion of a paper's citation graph (hard-capped)." },
+    { "name": "doiget_bibtex_export", "description": "Export one or many stored entries as BibTeX." },
+    { "name": "doiget_csl_export", "description": "Export one or many stored entries as CSL-JSON." },
+    { "name": "doiget_resolve_citation", "description": "Resolve a free-form bibliographic citation string to ranked DOI candidates." },
+    { "name": "doiget_batch_resolve_citations", "description": "Batch-resolve bibliographic citation strings to ranked DOI candidates." },
+    { "name": "doiget_tag", "description": "Add or remove tags on a stored entry." },
+    { "name": "doiget_annotate", "description": "Add or clear a note on a stored entry." }
+  ],
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"]
+  }
+}

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# build-mcpb.sh — assemble the doiget Claude Desktop Extension (.mcpb).
+#
+# A `.mcpb` is a zip of `manifest.json` + `server/<per-platform binaries>` that
+# Claude Desktop one-click-installs and launches over stdio (`doiget serve`).
+# This is a SEPARATE distribution channel from the MCP Registry (`server.json`):
+# the Desktop Extensions directory (Settings > Extensions in Claude Desktop).
+#
+# Usage:
+#   scripts/build-mcpb.sh <version> <bindir> [out.mcpb]
+#
+# <bindir> must contain the release binaries under their GitHub Release asset
+# names:
+#   doiget-linux-x86_64  doiget-macos-aarch64  doiget-macos-x86_64  doiget-windows-x86_64.exe
+#
+# Requirements: the `mcpb` CLI (`npm install -g @anthropic-ai/mcpb`), `jq`, and
+# `lipo` for the universal macOS binary — run on macOS (the release CI
+# `desktop-extension` job does). Without `lipo` the bundle ships arm64-only macOS.
+set -euo pipefail
+
+VERSION="${1:?usage: build-mcpb.sh <version> <bindir> [out.mcpb]}"
+BINDIR="${2:?usage: build-mcpb.sh <version> <bindir> [out.mcpb]}"
+OUT="${3:-doiget-${VERSION}.mcpb}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STAGE="$(mktemp -d)/doiget"
+mkdir -p "$STAGE/server"
+
+# manifest.json with the version pinned to this release.
+jq --arg v "$VERSION" '.version = $v' "$REPO_ROOT/mcpb/manifest.json" > "$STAGE/manifest.json"
+
+# macOS: fuse the two arch binaries into ONE universal binary, because the
+# .mcpb platform override is OS-level (darwin), not arch-level — a single
+# `darwin` entry must serve both Apple Silicon and Intel. `lipo` is macOS-only.
+if command -v lipo >/dev/null 2>&1; then
+  lipo -create -output "$STAGE/server/doiget-darwin" \
+    "$BINDIR/doiget-macos-aarch64" "$BINDIR/doiget-macos-x86_64"
+else
+  echo "::warning::lipo not found — bundling the arm64 macOS binary only (Intel Macs unsupported in this build)" >&2
+  cp "$BINDIR/doiget-macos-aarch64" "$STAGE/server/doiget-darwin"
+fi
+chmod +x "$STAGE/server/doiget-darwin"
+
+cp "$BINDIR/doiget-linux-x86_64"       "$STAGE/server/doiget-linux"
+chmod +x "$STAGE/server/doiget-linux"
+cp "$BINDIR/doiget-windows-x86_64.exe" "$STAGE/server/doiget-windows.exe"
+
+# Optional icon (mcpb/icon.png), if present.
+[ -f "$REPO_ROOT/mcpb/icon.png" ] && cp "$REPO_ROOT/mcpb/icon.png" "$STAGE/icon.png"
+
+# Pack: `mcpb pack <dir> <out>` zips the staging dir into the .mcpb.
+mcpb pack "$STAGE" "$OUT"
+echo "built $OUT"


### PR DESCRIPTION
Promote `next` (0.8.4) to `main` — the **0.8.4 stable release**.

## 0.8.4 — Claude Desktop Extensions distribution channel

- **Desktop Extension (`.mcpb`)** — one-click install into Claude Desktop.
  - `mcpb/manifest.json`: all 22 tools, a `store_root` user-config wired to `DOIGET_STORE_ROOT`, per-OS binary overrides (darwin/win32/linux), and a privacy-policy link.
  - `scripts/build-mcpb.sh`: assembles the bundle from the release binaries, `lipo`s the macOS arches into one universal binary, pins the version, then `mcpb pack`.
  - The `desktop-extension` release-plz job builds and attaches the `.mcpb` to the GitHub Release.
- **Privacy disclosure (`docs/PRIVACY.md`)** — "doiget collects nothing", plus an explicit enumeration of every third-party API doiget contacts (Crossref / Unpaywall / arXiv + ar5iv / OpenAlex by default; Semantic Scholar / DOAJ / publisher TDM opt-in), each governed by that provider's own ToS with **you as the contracting party**.

### Gates
- version-bump (promotion): **GREEN** — 0.8.3 → 0.8.4, a valid +1 single-component step (ADR-0033).
- release-version-gate v0.8.4: **PASS** (G0–G6).

Promotion of #366. The signed `v0.8.4` tag follows once this lands on `main` → triggers crates.io publish + `.mcpb` attach.
