### PR TITLE
fix(mcp): accept stringified numbers in numeric tool params (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+- **[mcp]** Numeric tool parameters now accept a **stringified number**
+  (`"10"`) as well as a JSON number (`10`). Several MCP clients / LLMs emit
+  numeric arguments as strings, which previously failed deserialization for
+  `limit` (`search_local` / `paper_search` / `list_recent` /
+  `resolve_citation` / `batch_resolve_citations`), `max_chars` (`paper_text`
+  / `paper_tex_source`), `depth` / `total` / `per_paper`
+  (`expand_citation_graph`), and `from_year` / `to_year` / `min_citations` /
+  `min_percentile` / `min_fwci` (`paper_search`). The published input schema
+  is unchanged (still `integer` / `number`); only the runtime is lenient.
+  (#370)
+
 ## [0.8.4] - 2026-06-25
 
 doiget joins the Claude Desktop Extensions distribution channel.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.4"
+version = "0.8.5-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.4"
+version = "0.8.5-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.4"
+version = "0.8.5-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.4"
+version       = "0.8.5-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2716,7 +2716,10 @@ where
             if trimmed.is_empty() {
                 Ok(None)
             } else {
-                trimmed.parse::<T>().map(Some).map_err(serde::de::Error::custom)
+                trimmed
+                    .parse::<T>()
+                    .map(Some)
+                    .map_err(serde::de::Error::custom)
             }
         }
     }
@@ -3924,7 +3927,10 @@ mod tests {
         let g: ExpandCitationGraphInput =
             from_value(json!({"ref": "10.1/x", "depth": "2", "total": "50", "per_paper": "5"}))
                 .unwrap();
-        assert_eq!((g.depth, g.total, g.per_paper), (Some(2), Some(50), Some(5)));
+        assert_eq!(
+            (g.depth, g.total, g.per_paper),
+            (Some(2), Some(50), Some(5))
+        );
 
         let t: PaperTextInput =
             from_value(json!({"ref": "arxiv:2401.00001", "max_chars": "2000"})).unwrap();

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2444,7 +2444,7 @@ pub struct SearchLocalInput {
     pub query: String,
     /// Maximum number of results to return. `None` means default (50);
     /// values >200 are clamped to 200.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub limit: Option<u32>,
 }
 
@@ -2481,28 +2481,28 @@ pub struct PaperSearchInput {
     /// Free-text topic query (e.g. "tropical tensor networks for spin glasses").
     pub query: String,
     /// Maximum results (1..=200; default 25). Out-of-range is rejected.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub limit: Option<u32>,
     /// Inclusive lower publication-year bound.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub from_year: Option<i32>,
     /// Inclusive upper publication-year bound.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub to_year: Option<i32>,
     /// Restrict to open-access works.
     #[serde(default)]
     pub oa_only: Option<bool>,
     /// Only works cited strictly more than this many times.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub min_citations: Option<u64>,
     /// Minimum field-and-year-normalized impact (FWCI) — a quality filter
     /// (#290).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub min_fwci: Option<f64>,
     /// Minimum within-cohort citation percentile (0–100): top-X% among
     /// same-year works; combine with `from_year` for "recent and standing
     /// out" (#290).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub min_percentile: Option<u8>,
     /// Author name (resolved to an OpenAlex author id).
     #[serde(default)]
@@ -2533,7 +2533,7 @@ pub struct PaperTextInput {
     pub ref_: String,
     /// Cap the returned text to this many characters (truncation is
     /// flagged on `truncated`). Omit for the full text.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub max_chars: Option<u32>,
 }
 
@@ -2549,7 +2549,7 @@ pub struct PaperTexSourceInput {
     pub ref_: String,
     /// Cap the returned LaTeX source to this many characters (truncation is
     /// flagged on `truncated`). Omit for the full source.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub max_chars: Option<u32>,
 }
 
@@ -2574,7 +2574,7 @@ pub struct LinkInput {
 pub struct ListRecentInput {
     /// Maximum number of results to return. `None` means default (50);
     /// values >200 are clamped to 200.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub limit: Option<u32>,
 }
 
@@ -2609,16 +2609,16 @@ pub struct ExpandCitationGraphInput {
     #[schemars(rename = "ref")]
     pub ref_: String,
     /// Max BFS depth (1..=3). Default is the ADR-0010 maximum (3).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub depth: Option<u32>,
     /// Max total nodes (1..=100). Default is the ADR-0010 maximum
     /// (100). `truncated: true` is set on the response when this
     /// cap is hit.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub total: Option<u32>,
     /// Max children expanded per parent (1..=20). Default is the
     /// ADR-0010 maximum (20).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub per_paper: Option<u32>,
 }
 
@@ -2652,7 +2652,7 @@ pub struct ResolveCitationInput {
     /// Bibliographic citation query string (e.g. "Onsager 1944").
     pub query: String,
     /// Maximum number of candidates to return (default: 5).
-    #[serde(default = "default_resolve_limit")]
+    #[serde(default = "default_resolve_limit", deserialize_with = "de_lenient_num")]
     pub limit: u8,
 }
 
@@ -2664,12 +2664,62 @@ pub struct BatchResolveCitationsInput {
     /// Bibliographic citation query strings.
     pub queries: Vec<String>,
     /// Maximum number of candidates to return per query (default: 5).
-    #[serde(default = "default_resolve_limit")]
+    #[serde(default = "default_resolve_limit", deserialize_with = "de_lenient_num")]
     pub limit: u8,
 }
 
 fn default_resolve_limit() -> u8 {
     5
+}
+
+/// A numeric value that may arrive as a JSON number (`10`) or a JSON string
+/// (`"10"`). Some MCP clients / LLMs stringify numeric arguments; doiget
+/// accepts either form. Private helper for the lenient numeric deserializers.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum NumOrStr<T> {
+    Num(T),
+    Str(String),
+}
+
+/// Deserialize a required number leniently: accepts a JSON number or a
+/// stringified number (`"10"`); a non-numeric string is rejected. The
+/// published input schema is unchanged — schemars derives it from the field's
+/// concrete type, so the tool still advertises `integer` / `number`; only the
+/// runtime is lenient (Postel's law, #370).
+fn de_lenient_num<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr + serde::Deserialize<'de>,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    match NumOrStr::<T>::deserialize(deserializer)? {
+        NumOrStr::Num(n) => Ok(n),
+        NumOrStr::Str(s) => s.trim().parse::<T>().map_err(serde::de::Error::custom),
+    }
+}
+
+/// `Option` variant of [`de_lenient_num`]: accepts a number, a stringified
+/// number, JSON `null`, or (with `#[serde(default)]`) an absent field. An
+/// empty / whitespace-only string is treated as absent (`None`).
+fn de_lenient_opt_num<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr + serde::Deserialize<'de>,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    match Option::<NumOrStr<T>>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(NumOrStr::Num(n)) => Ok(Some(n)),
+        Some(NumOrStr::Str(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                trimmed.parse::<T>().map(Some).map_err(serde::de::Error::custom)
+            }
+        }
+    }
 }
 
 /// JSON-schema-derived input for the `doiget_tag` MCP tool.
@@ -3834,6 +3884,78 @@ fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// #370: numeric tool params accept a JSON number OR a stringified
+    /// number (`"10"`); absent / `null` / empty-string stay `None`.
+    #[test]
+    fn lenient_numbers_accept_string_or_number() {
+        use serde_json::{from_value, json};
+
+        let s: SearchLocalInput = from_value(json!({"query": "x", "limit": "10"})).unwrap();
+        assert_eq!(s.limit, Some(10));
+        let n: SearchLocalInput = from_value(json!({"query": "x", "limit": 10})).unwrap();
+        assert_eq!(n.limit, Some(10));
+        let a: SearchLocalInput = from_value(json!({"query": "x"})).unwrap();
+        assert_eq!(a.limit, None);
+        let z: SearchLocalInput = from_value(json!({"query": "x", "limit": null})).unwrap();
+        assert_eq!(z.limit, None);
+        let e: SearchLocalInput = from_value(json!({"query": "x", "limit": ""})).unwrap();
+        assert_eq!(e.limit, None);
+    }
+
+    /// #370: a non-numeric or out-of-range string is still rejected — the
+    /// deserializer is lenient about *form*, not *validity*.
+    #[test]
+    fn lenient_numbers_reject_non_numeric_string() {
+        use serde_json::{from_value, json};
+        assert!(from_value::<SearchLocalInput>(json!({"query": "x", "limit": "abc"})).is_err());
+        // 300 overflows u8 (min_percentile) -> parse error.
+        assert!(
+            from_value::<PaperSearchInput>(json!({"query": "x", "min_percentile": "300"})).is_err()
+        );
+    }
+
+    /// #370: every numeric input field across the tool surface (u32 / i32 /
+    /// u64 / u8 / f64, `Option` + required) tolerates stringified numbers.
+    #[test]
+    fn lenient_numbers_cover_every_numeric_input() {
+        use serde_json::{from_value, json};
+
+        let g: ExpandCitationGraphInput =
+            from_value(json!({"ref": "10.1/x", "depth": "2", "total": "50", "per_paper": "5"}))
+                .unwrap();
+        assert_eq!((g.depth, g.total, g.per_paper), (Some(2), Some(50), Some(5)));
+
+        let t: PaperTextInput =
+            from_value(json!({"ref": "arxiv:2401.00001", "max_chars": "2000"})).unwrap();
+        assert_eq!(t.max_chars, Some(2000));
+        let x: PaperTexSourceInput =
+            from_value(json!({"ref": "arxiv:2401.00001", "max_chars": "2000"})).unwrap();
+        assert_eq!(x.max_chars, Some(2000));
+
+        let p: PaperSearchInput = from_value(json!({
+            "query": "x", "limit": "7", "from_year": "2010", "to_year": "2020",
+            "min_citations": "100", "min_percentile": "90", "min_fwci": "1.5"
+        }))
+        .unwrap();
+        assert_eq!(p.limit, Some(7));
+        assert_eq!(p.from_year, Some(2010));
+        assert_eq!(p.to_year, Some(2020));
+        assert_eq!(p.min_citations, Some(100));
+        assert_eq!(p.min_percentile, Some(90));
+        assert_eq!(p.min_fwci, Some(1.5));
+
+        let l: ListRecentInput = from_value(json!({"limit": "25"})).unwrap();
+        assert_eq!(l.limit, Some(25));
+
+        let r: ResolveCitationInput = from_value(json!({"query": "x", "limit": "3"})).unwrap();
+        assert_eq!(r.limit, 3);
+        let d: ResolveCitationInput = from_value(json!({"query": "x"})).unwrap();
+        assert_eq!(d.limit, 5);
+        let b: BatchResolveCitationsInput =
+            from_value(json!({"queries": ["x"], "limit": "8"})).unwrap();
+        assert_eq!(b.limit, 8);
+    }
 
     #[test]
     fn capability_profile_to_json_clean_env_shape() {


### PR DESCRIPTION
Fixes the numeric-parameter half of the Claude Desktop (`.mcpb`) dogfooding findings.

## Problem (#370)
MCP clients / LLMs frequently emit numeric tool arguments as JSON **strings** (`"10"` instead of `10`). doiget's numeric tool inputs were plain `Option<u32>` / `u8`, so a stringified number failed deserialization — observed in Claude Desktop on `paper_search.limit`, `paper_text.max_chars`, and `expand_citation_graph.depth`/`total`/`per_paper`.

## Fix
- Two private lenient deserializers in `doiget-mcp`: `de_lenient_num` (required) / `de_lenient_opt_num` (`Option`), backed by an untagged `NumOrStr<T>` helper that accepts a JSON number **or** a stringified number.
- Applied to **all 15 numeric tool-input fields**: `limit` (search_local / paper_search / list_recent / resolve_citation / batch_resolve_citations), `max_chars` (paper_text / paper_tex_source), `depth` / `total` / `per_paper` (expand_citation_graph), `from_year` / `to_year` / `min_citations` / `min_percentile` / `min_fwci` (paper_search).
- A non-numeric / out-of-range string is still rejected; absent / `null` / empty-string stay `None`.

The published input schema is **unchanged** — schemars derives it from the field's concrete type, so tools still advertise `integer` / `number`. Only the runtime is lenient (Postel's law).

## Tests
Three unit tests: number ↔ stringified-number equivalence, rejection of non-numeric / overflowing strings, and coverage of every numeric field across the tool surface (u32 / i32 / u64 / u8 / f64; `Option` + required + default).

Version `0.8.5-beta.1` (first beta of the 0.8.5 cycle); version-bump gate green.

Closes #370