### PR TITLE
fix(mcp,cli): writable store default + ignore ${...} placeholder env (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   `min_percentile` / `min_fwci` (`paper_search`). The published input schema
   is unchanged (still `integer` / `number`); only the runtime is lenient.
   (#370)
+- **[mcp/distribution]** The Claude Desktop Extension now ships a writable
+  **default store location** (`${HOME}/Documents/doiget-papers`), and
+  `resolve_store_root` (MCP + CLI) ignores an empty or unexpanded `${...}`
+  placeholder value of `DOIGET_STORE_ROOT` rather than using it as a path.
+  Fixes a `.mcpb` install leaving the store unwritable (`os error 5`) when the
+  config was left blank (the literal `${user_config.store_root}` leaked
+  through). (#369)
 
 ## [0.8.4] - 2026-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.1"
+version = "0.8.5-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.1"
+version = "0.8.5-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.1"
+version = "0.8.5-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.1"
+version       = "0.8.5-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -71,7 +71,11 @@ use camino::Utf8PathBuf;
 /// real working directory untouched.
 pub(crate) fn resolve_store_root() -> Result<Utf8PathBuf> {
     if let Ok(s) = std::env::var("DOIGET_STORE_ROOT") {
-        if !s.is_empty() {
+        // Ignore an empty value or an unexpanded "${...}" placeholder — a
+        // Desktop-Extension config left blank can pass the literal
+        // "${user_config.store_root}", which must not become a path (#369).
+        let s = s.trim();
+        if !s.is_empty() && !s.contains("${") {
             return Ok(Utf8PathBuf::from(s));
         }
     }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3793,10 +3793,19 @@ impl ServerHandler for Server {
 /// `doiget-cli -> doiget-mcp` wiring established by this PR and pull
 /// `clap` etc. into the MCP crate. Lifting this helper into `doiget-core`
 /// is a viable Phase-3 follow-up but is out of scope for this foundation.
+/// Whether a `DOIGET_STORE_ROOT` value is usable as a path: non-empty and not
+/// an unexpanded `${...}` placeholder. A Desktop-Extension config left blank
+/// passes the literal `${user_config.store_root}`, which must never become a
+/// filesystem path (it produced `os error 5` access-denied). See #369.
+fn store_root_env_is_usable(value: &str) -> bool {
+    let v = value.trim();
+    !v.is_empty() && !v.contains("${")
+}
+
 fn resolve_store_root() -> Option<Utf8PathBuf> {
     if let Ok(s) = std::env::var("DOIGET_STORE_ROOT") {
-        if !s.is_empty() {
-            return Some(Utf8PathBuf::from(s));
+        if store_root_env_is_usable(&s) {
+            return Some(Utf8PathBuf::from(s.trim()));
         }
     }
     // Default: `papers/` under the current working directory (#344 / ADR-0036),
@@ -4049,6 +4058,18 @@ mod tests {
             err.contains("rdf") && err.contains("auto"),
             "error must name the offending token AND the accepted set: {err}"
         );
+    }
+
+    #[test]
+    fn store_root_env_usable_rejects_placeholder_and_empty() {
+        // Real paths are usable.
+        assert!(store_root_env_is_usable("/home/u/papers"));
+        assert!(store_root_env_is_usable(r"C:\Users\u\papers"));
+        // Empty / whitespace and an unexpanded placeholder are not (#369).
+        assert!(!store_root_env_is_usable(""));
+        assert!(!store_root_env_is_usable("   "));
+        assert!(!store_root_env_is_usable("${user_config.store_root}"));
+        assert!(!store_root_env_is_usable("${HOME}/papers"));
     }
 
     #[test]

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -38,7 +38,8 @@
     "store_root": {
       "type": "directory",
       "title": "Paper store location",
-      "description": "Directory where fetched PDFs and metadata are saved. Leave empty to use ./papers under the server's working directory.",
+      "description": "Directory where fetched PDFs and metadata are saved. Defaults to a doiget-papers folder under your home directory.",
+      "default": "${HOME}/Documents/doiget-papers",
       "required": false
     }
   },


### PR DESCRIPTION
Fixes the **store** half of the Claude Desktop (`.mcpb`) dogfooding findings.

> ⛓️ **Stacked on #374** (base = `fix/mcp-numeric-string-params`). Review the top commit; merge **after** #374 — GitHub will retarget this to `next` once #374 lands.

## Problem (#369)
In Claude Desktop every store-backed tool failed with `os error 5` and `doiget_health` reported `store_writable: false`. Root cause:
1. `mcpb/manifest.json` mapped `DOIGET_STORE_ROOT = "${user_config.store_root}"` but `store_root` had **no default**, so a blank config passed the **literal** `${user_config.store_root}`.
2. `resolve_store_root` used any non-empty value verbatim — including the literal placeholder — so the store landed under a non-writable path.

## Fix
- **manifest**: `store_root` now has a writable `default` (`${HOME}/Documents/doiget-papers`), so the value is never empty in Claude Desktop.
- **`resolve_store_root`** (MCP `lib.rs` + CLI `commands/mod.rs`): ignore an empty or `${`-containing (unexpanded placeholder) `DOIGET_STORE_ROOT` and fall back, instead of using it as a path. Extracted `store_root_env_is_usable` with a unit test. Double-protected: even if mcpb fails to expand the default, the `${` guard catches the leak.

The CLI default (`<cwd>/papers`, ADR-0036) is unchanged.

> **Deferred (separate decision):** defaulting the **MCP server** to `dirs::data_dir()/doiget/papers` instead of `<cwd>/papers` would also help raw `doiget serve` users, but adds a `dirs` dep + an ADR-0036 amendment + a behavior change — intentionally out of scope here.

Version `0.8.5-beta.2`. Closes #369.