### PR TITLE
fix(core): keep old-style arXiv ids in OpenAlex extraction (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   Fixes a `.mcpb` install leaving the store unwritable (`os error 5`) when the
   config was left blank (the literal `${user_config.store_root}` leaked
   through). (#369)
+- **[discovery]** `doiget_link` / discovery now return **old-style arXiv ids**
+  intact (e.g. `cond-mat/0701105`). The OpenAlex `arxiv.org/abs/<id>`
+  extractor stopped at the `/` separator, truncating pre-2007 ids to just the
+  archive (`cond-mat`); it now keeps the full id and validates it via
+  `ArxivId::parse` (a malformed URL yields no id rather than a garbage one).
+  (#371)
 
 ## [0.8.4] - 2026-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.2"
+version = "0.8.5-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.2"
+version = "0.8.5-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.2"
+version = "0.8.5-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.2"
+version       = "0.8.5-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -832,20 +832,25 @@ fn reconstruct_abstract(inv: &serde_json::Value) -> Option<String> {
 }
 
 /// Best-effort arXiv id extraction from a single OpenAlex location's
-/// `landing_page_url` / `pdf_url`. Looks for `arxiv.org/abs/<id>` and
-/// returns `<id>` (a trailing `vN` version is kept — the downstream
-/// parser accepts it).
+/// `landing_page_url` / `pdf_url`. Looks for `arxiv.org/abs/<id>` and returns
+/// the validated `<id>`. Old-style (pre-2007) ids embed a `/`
+/// (`archive/number`, e.g. `cond-mat/0701105`), so the capture must NOT stop
+/// at `/`; a trailing `vN` version is kept. The capture is validated via
+/// [`ArxivId::parse`], so a malformed URL yields `None` rather than a
+/// truncated / garbage id. (#371)
 fn extract_arxiv_from_location(loc: &serde_json::Value) -> Option<String> {
     for key in ["landing_page_url", "pdf_url"] {
         if let Some(u) = loc.get(key).and_then(serde_json::Value::as_str) {
             if let Some(idx) = u.find("arxiv.org/abs/") {
                 let after = &u[idx + "arxiv.org/abs/".len()..];
-                let id: String = after
+                // Stop at a query / fragment / whitespace — but NOT at '/',
+                // which separates `archive` from `number` in old-style ids.
+                let raw: String = after
                     .chars()
-                    .take_while(|c| !matches!(c, '?' | '#' | '/' | ' '))
+                    .take_while(|c| !matches!(c, '?' | '#' | ' ' | '\t' | '\n' | '\r'))
                     .collect();
-                if !id.is_empty() {
-                    return Some(id);
+                if let Ok(id) = crate::ArxivId::parse(raw.trim_end_matches('/')) {
+                    return Some(id.as_str().to_string());
                 }
             }
         }
@@ -1908,6 +1913,33 @@ mod tests {
             extract_arxiv_from_location(&loc).as_deref(),
             Some("2101.12345")
         );
+    }
+
+    #[test]
+    fn arxiv_extracted_old_style_id_not_truncated() {
+        // Pre-2007 ids embed a '/'; the capture must keep it (#371).
+        let loc =
+            serde_json::json!({ "landing_page_url": "https://arxiv.org/abs/cond-mat/0701105" });
+        assert_eq!(
+            extract_arxiv_from_location(&loc).as_deref(),
+            Some("cond-mat/0701105")
+        );
+        // Old-style with subclass + version + a trailing query string.
+        let loc2 = serde_json::json!({
+            "pdf_url": "http://arxiv.org/abs/astro-ph.CO/0703123v2?foo=bar"
+        });
+        assert_eq!(
+            extract_arxiv_from_location(&loc2).as_deref(),
+            Some("astro-ph.CO/0703123v2")
+        );
+    }
+
+    #[test]
+    fn arxiv_extraction_rejects_garbage() {
+        // A non-arXiv capture under abs/ fails ArxivId::parse -> None, rather
+        // than a truncated / garbage id (#371).
+        let loc = serde_json::json!({ "landing_page_url": "https://arxiv.org/abs/not an id!" });
+        assert_eq!(extract_arxiv_from_location(&loc), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes the **arXiv-id** finding from the Claude Desktop (`.mcpb`) dogfooding.

> ⛓️ **Stacked on #375** (→ #374). Merge after #375; GitHub retargets this to `next` as the stack lands.

## Problem (#371)
`doiget_link 10.1103/RevModPhys.80.395` returned `arxiv: "cond-mat"` — only the archive/category. `extract_arxiv_from_location` (`discovery.rs`) captured the id after `arxiv.org/abs/` but **stopped at `/`**, truncating old-style (pre-2007) ids of the form `archive/number` (e.g. `cond-mat/0701105`) to just the archive.

## Fix
- Stop the capture at `?` / `#` / whitespace only — **not** `/`.
- Validate the capture via `ArxivId::parse` (which already accepts old-style ids): returns the canonical id, or `None` for a malformed URL — so a bad URL no longer yields a garbage / truncated id.
- Modern ids (`NNNN.NNNNN[vN]`) are unaffected; the two existing extraction tests still hold.

Adds tests: old-style `cond-mat/0701105`, old-style-with-subclass+version+query `astro-ph.CO/0703123v2?...`, and garbage rejection.

Version `0.8.5-beta.3`. Closes #371.