### PR TITLE
fix(core): score citations against all authors, not just the first (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   archive (`cond-mat`); it now keeps the full id and validates it via
   `ArxivId::parse` (a malformed URL yields no id rather than a garbage one).
   (#371)
+- **[discovery]** `doiget_resolve_citation` / `doiget_batch_resolve_citations`
+  now score candidates against **all** authors of a work, not just the first,
+  so a citation string naming several authors (e.g. "Bulla Costi Pruschke
+  2008") is no longer dropped below the confidence threshold. (#372)
 
 ## [0.8.4] - 2026-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.3"
+version = "0.8.5-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.3"
+version = "0.8.5-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.3"
+version = "0.8.5-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.3"
+version       = "0.8.5-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/sources/crossref.rs
+++ b/crates/doiget-core/src/sources/crossref.rs
@@ -156,7 +156,10 @@ impl CrossrefSource {
                 candidate_text.push_str(&t.to_lowercase());
                 candidate_text.push(' ');
             }
-            if let Some(author) = fields.authors.first() {
+            // Score against ALL authors, not just the first, so a citation
+            // naming several authors (e.g. "Bulla Costi Pruschke 2008") still
+            // matches instead of being dropped below the threshold — #372.
+            for author in &fields.authors {
                 candidate_text.push_str(&author.to_lowercase());
                 candidate_text.push(' ');
             }
@@ -578,5 +581,51 @@ mod tests {
         assert_eq!(cand.author, "Onsager, Lars");
         assert_eq!(cand.year, Some(1944));
         assert_eq!(cand.score, 1.0);
+    }
+
+    #[tokio::test]
+    async fn resolve_citation_matches_non_first_authors() {
+        // #372: candidate scoring text must include ALL authors, not just the
+        // first. With the old first-author-only text, "Costi Pruschke 2008"
+        // (2nd / 3rd authors + year) matched only the year (1/3 = 0.33) and was
+        // filtered out; now all authors match (3/3 = 1.0).
+        let server = MockServer::start().await;
+        let mock_body = serde_json::json!({
+            "status": "ok",
+            "message": {
+                "items": [
+                    {
+                        "DOI": "10.1103/RevModPhys.80.395",
+                        "title": ["Numerical renormalization group method for quantum impurity systems"],
+                        "author": [
+                            {"family": "Bulla", "given": "Ralf"},
+                            {"family": "Costi", "given": "Theo A."},
+                            {"family": "Pruschke", "given": "Thomas"}
+                        ],
+                        "issued": { "date-parts": [[2008, 4, 2]] },
+                        "container-title": ["Reviews of Modern Physics"]
+                    }
+                ]
+            }
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(mock_body))
+            .mount(&server)
+            .await;
+
+        let host = server_host(&server);
+        let s = crossref_for(&server);
+        let (_td, ctx) = build_test_context(&host);
+
+        let candidates = s
+            .resolve_citation("Costi Pruschke 2008", 5, &ctx)
+            .await
+            .expect("resolve ok");
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].doi, "10.1103/RevModPhys.80.395");
+        assert_eq!(candidates[0].score, 1.0);
     }
 }


### PR DESCRIPTION
Fixes the citation-resolver finding from the Claude Desktop (`.mcpb`) dogfooding.

> ⛓️ **Stacked on #376** (→ #375 → #374). Merge **last**.

## Problem (#372)
`doiget_batch_resolve_citations(["…", "Bulla Costi Pruschke 2008"])` dropped the 2nd query — a well-known paper (Rev. Mod. Phys. 80, 395). The score is `matched_query_tokens / query_tokens`, but the candidate text was built from only the **first** author (`fields.authors.first()`), so later-author tokens (`costi`, `pruschke`) never matched and the score fell below `MIN_CITATION_SCORE` (0.5).

## Fix
Include **all** authors in the candidate scoring text. Since the score is query-token coverage, adding tokens can only raise a score — existing matches are unaffected (the `Onsager 1944` test still yields 1.0). Adds a regression test: `Costi Pruschke 2008` against a Bulla/Costi/Pruschke work now scores 1.0 (was 1/3 → filtered).

Version `0.8.5-beta.4`. Closes #372.