### PR TITLE
fix(mcp): build release binaries + .mcpb with --features citation (#373 part a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         features:
           - "oa-only"
+          - "oa-only,citation"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -73,6 +74,23 @@ jobs:
       # Aligned with clippy job: --no-default-features --features oa-only,
       # so test and clippy exercise an identical feature surface.
       - run: cargo test --workspace --all-targets --no-default-features --features oa-only
+
+  test-citation:
+    name: test (citation feature)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-bin: false
+      # #373: the released binaries (and the .mcpb) ship with
+      # --features citation, so exercise that surface here — the default
+      # `test` job above runs oa-only only, leaving the citation tool +
+      # citation_graph e2e test unvalidated.
+      - run: cargo test --workspace --all-targets --no-default-features --features oa-only,citation
 
   msrv:
     # MSRV is pinned in rust-toolchain.toml / Cargo.toml; the job name

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -357,16 +357,16 @@ jobs:
           set -euo pipefail
           # Linux builds a fully static musl binary (runs on old glibc);
           # macOS/Windows build native (dynamic libc is fine there — no
-          # cross-compile). `oa-only` matches the feature surface CI
-          # tests/clippy already gate on.
+          # cross-compile). `oa-only,citation` matches the feature surface CI
+          # gates on; the citation graph tool ships in release binaries (#373).
           if [ -n "${{ matrix.target }}" ]; then
             cargo build --release -p doiget-cli \
-              --no-default-features --features oa-only \
+              --no-default-features --features oa-only,citation \
               --target "${{ matrix.target }}"
             echo "BIN_DIR=target/${{ matrix.target }}/release" >> "$GITHUB_ENV"
           else
             cargo build --release -p doiget-cli \
-              --no-default-features --features oa-only
+              --no-default-features --features oa-only,citation
             echo "BIN_DIR=target/release" >> "$GITHUB_ENV"
           fi
       - name: Stage binary + checksum

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -88,7 +88,7 @@ jobs:
           # Native target per runner — no cross-compilation, so the
           # produced binary's arch matches the runner. `oa-only` matches
           # the feature surface CI tests/clippy already gate on.
-          cargo build --release -p doiget-cli --no-default-features --features oa-only
+          cargo build --release -p doiget-cli --no-default-features --features oa-only,citation
 
       - name: Stage binary + checksum
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   now score candidates against **all** authors of a work, not just the first,
   so a citation string naming several authors (e.g. "Bulla Costi Pruschke
   2008") is no longer dropped below the confidence threshold. (#372)
+- **[mcp/distribution]** The **released binaries and the `.mcpb` are now built
+  with `--features citation`**, and the `.mcpb` presets
+  `DOIGET_ENABLE_OPENALEX=1`, so `doiget_expand_citation_graph` actually works
+  in Claude Desktop (ADR-0010 hard caps depth≤3 / ≤100 nodes apply). CI now
+  builds and tests the `citation` feature (previously `oa-only` only). A
+  feature-off `cargo install` build still advertises the tool and returns
+  `NOT_IMPLEMENTED`; cleanly hiding it is blocked by rmcp's `#[tool_router]`
+  (it references tool methods unconditionally, so cfg-gating the method fails
+  to compile) and is tracked as a follow-up. (#373)
 
 ## [0.8.4] - 2026-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.4"
+version = "0.8.5-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.4"
+version = "0.8.5-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.4"
+version = "0.8.5-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.4"
+version       = "0.8.5-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -127,17 +127,25 @@ pub struct GraphNode {
 /// One edge: `from` cites `to`.
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphEdge {
+    /// The citing Work (OpenAlex Work ID).
     pub from: String,
+    /// The cited Work (OpenAlex Work ID).
     pub to: String,
 }
 
 /// Result of [`expand`].
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphResult {
+    /// OpenAlex Work ID the expansion started from.
     pub seed_work_id: String,
+    /// Every Work visited, including the seed (`depth == 0`).
     pub nodes: Vec<GraphNode>,
+    /// Directed `from` cites `to` relationships discovered during the walk.
     pub edges: Vec<GraphEdge>,
+    /// `true` if an ADR-0010 hard cap (depth / total / per-paper) stopped the
+    /// walk before the graph was exhausted.
     pub truncated: bool,
+    /// Number of Works visited (equals `nodes.len()`).
     pub total_visited: usize,
 }
 
@@ -145,6 +153,7 @@ pub struct GraphResult {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum GraphError {
+    /// An OpenAlex fetch failed during the walk.
     #[error("openalex source error: {0}")]
     Source(#[from] FetchError),
     /// Provenance log write failed — fail-closed (the expansion is
@@ -152,8 +161,11 @@ pub enum GraphError {
     /// posture per `docs/PROVENANCE_LOG.md` §5.
     #[error("provenance log error during graph expansion: {0}")]
     Log(#[from] LogError),
+    /// The seed DOI is not indexed by OpenAlex (no `id` field in the response).
     #[error("seed DOI not indexed by OpenAlex (no `id` field in response)")]
     SeedNotIndexed,
+    /// Citation expansion is not enabled (requires `DOIGET_ENABLE_OPENALEX`
+    /// and `--features metadata`).
     #[error("citation graph requires DOIGET_ENABLE_OPENALEX + --features metadata")]
     CapabilityDenied,
 }

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -22,7 +22,8 @@
       "command": "${__dirname}/server/doiget-linux",
       "args": ["serve"],
       "env": {
-        "DOIGET_STORE_ROOT": "${user_config.store_root}"
+        "DOIGET_STORE_ROOT": "${user_config.store_root}",
+        "DOIGET_ENABLE_OPENALEX": "1"
       },
       "platform_overrides": {
         "darwin": {


### PR DESCRIPTION
Addresses the `.mcpb` dogfooding finding (#373) — `doiget_expand_citation_graph` was advertised but returned `NOT_IMPLEMENTED` because the default build omits the `citation` feature.

Ships **part (a)** — make the tool actually work in Claude Desktop:
- `release-plz.yml` + `release-sign.yml` build with `--features oa-only,citation`, so the GitHub-release binaries (bundled into the `.mcpb`) include the citation graph.
- `mcpb/manifest.json` presets `DOIGET_ENABLE_OPENALEX=1` so the tool runs out-of-the-box in Claude Desktop. **ADR-0010 hard caps (depth≤3, ≤100 nodes) still bound the cost.**
- CI now builds + tests the `citation` feature (clippy matrix gains `oa-only,citation`; new `test-citation` job) — previously `oa-only`-only, so the feature was unvalidated.

**Part (b) (hide the tool from `tools/list` in feature-off `cargo install` builds) is NOT here.** A first attempt proved it's blocked by rmcp 1.7: `#[tool_router]` references each tool method unconditionally (`Self::doiget_expand_citation_graph{,_tool_attr}`), so `#[cfg(feature = "citation")]` on the method fails to compile with `E0599` in the feature-off build (CI-confirmed). The clean fix needs a runtime `list_tools` filter (uncertain rmcp `ToolRouter` API) — tracked as a follow-up. cargo-install default keeps the current behavior (tool advertised → `NOT_IMPLEMENTED`); the `.mcpb` (the directory target) is fully fixed.

Version `0.8.5-beta.5`. Refs #373.
