### PR TITLE
release: 0.8.5 (strip beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-06-29
+
+Reliability pass from Claude Desktop (`.mcpb`) dogfooding — the local store, numeric tool parameters, arXiv-id linking, and citation matching, plus a now-working citation-graph tool in the Desktop Extension.
+
 ### Fixed
 - **[mcp]** Numeric tool parameters now accept a **stringified number**
   (`"10"`) as well as a JSON number (`10`). Several MCP clients / LLMs emit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.5"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.5"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.5"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.5"
+version       = "0.8.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "doiget",
   "display_name": "doiget",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
   "long_description": "doiget is a single-binary, stdio MCP server that turns DOIs and arXiv IDs into local PDFs and structured metadata through official Open-Access APIs (Crossref, Unpaywall, arXiv, OpenAlex). It never bypasses paywalls and makes no network call that is not the direct result of a fetch you ask for. PDFs and metadata are saved to a local store; nothing is redistributed or phoned home. It is the agent-facing companion to BiblioFetch.jl and shares the same on-disk paper store.",
   "author": {


### PR DESCRIPTION
Cuts the **0.8.5 stable release** from `next`: `0.8.5-beta.5` → `0.8.5` (Cargo.toml + Cargo.lock + `mcpb/manifest.json`) and finalizes the `## [0.8.5]` CHANGELOG.

0.8.5 is the reliability pass from Claude Desktop (`.mcpb`) dogfooding:
- #369 store `os error 5` (manifest default + `${...}` guard)
- #370 numeric tool params accept stringified numbers
- #371 old-style arXiv ids no longer truncated
- #372 citation matching scores all authors
- #373a the citation-graph tool ships **working** in the `.mcpb` (+ CI now covers the `citation` feature)

`version-bump` is **RED** — a clean `X.Y.Z` on a PR→next is the release-cut exception (ADR-0033). `release-version-gate.sh v0.8.5` passes G0–G6.