### PR TITLE
release: promote 0.8.5 to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         features:
           - "oa-only"
+          - "oa-only,citation"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -73,6 +74,23 @@ jobs:
       # Aligned with clippy job: --no-default-features --features oa-only,
       # so test and clippy exercise an identical feature surface.
       - run: cargo test --workspace --all-targets --no-default-features --features oa-only
+
+  test-citation:
+    name: test (citation feature)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-bin: false
+      # #373: the released binaries (and the .mcpb) ship with
+      # --features citation, so exercise that surface here — the default
+      # `test` job above runs oa-only only, leaving the citation tool +
+      # citation_graph e2e test unvalidated.
+      - run: cargo test --workspace --all-targets --no-default-features --features oa-only,citation
 
   msrv:
     # MSRV is pinned in rust-toolchain.toml / Cargo.toml; the job name

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -357,16 +357,16 @@ jobs:
           set -euo pipefail
           # Linux builds a fully static musl binary (runs on old glibc);
           # macOS/Windows build native (dynamic libc is fine there — no
-          # cross-compile). `oa-only` matches the feature surface CI
-          # tests/clippy already gate on.
+          # cross-compile). `oa-only,citation` matches the feature surface CI
+          # gates on; the citation graph tool ships in release binaries (#373).
           if [ -n "${{ matrix.target }}" ]; then
             cargo build --release -p doiget-cli \
-              --no-default-features --features oa-only \
+              --no-default-features --features oa-only,citation \
               --target "${{ matrix.target }}"
             echo "BIN_DIR=target/${{ matrix.target }}/release" >> "$GITHUB_ENV"
           else
             cargo build --release -p doiget-cli \
-              --no-default-features --features oa-only
+              --no-default-features --features oa-only,citation
             echo "BIN_DIR=target/release" >> "$GITHUB_ENV"
           fi
       - name: Stage binary + checksum

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -88,7 +88,7 @@ jobs:
           # Native target per runner — no cross-compilation, so the
           # produced binary's arch matches the runner. `oa-only` matches
           # the feature surface CI tests/clippy already gate on.
-          cargo build --release -p doiget-cli --no-default-features --features oa-only
+          cargo build --release -p doiget-cli --no-default-features --features oa-only,citation
 
       - name: Stage binary + checksum
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   Fixes a `.mcpb` install leaving the store unwritable (`os error 5`) when the
   config was left blank (the literal `${user_config.store_root}` leaked
   through). (#369)
+- **[discovery]** `doiget_link` / discovery now return **old-style arXiv ids**
+  intact (e.g. `cond-mat/0701105`). The OpenAlex `arxiv.org/abs/<id>`
+  extractor stopped at the `/` separator, truncating pre-2007 ids to just the
+  archive (`cond-mat`); it now keeps the full id and validates it via
+  `ArxivId::parse` (a malformed URL yields no id rather than a garbage one).
+  (#371)
 
 ## [0.8.4] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   `min_percentile` / `min_fwci` (`paper_search`). The published input schema
   is unchanged (still `integer` / `number`); only the runtime is lenient.
   (#370)
+- **[mcp/distribution]** The Claude Desktop Extension now ships a writable
+  **default store location** (`${HOME}/Documents/doiget-papers`), and
+  `resolve_store_root` (MCP + CLI) ignores an empty or unexpanded `${...}`
+  placeholder value of `DOIGET_STORE_ROOT` rather than using it as a path.
+  Fixes a `.mcpb` install leaving the store unwritable (`os error 5`) when the
+  config was left blank (the literal `${user_config.store_root}` leaked
+  through). (#369)
 
 ## [0.8.4] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-06-29
+
+Reliability pass from Claude Desktop (`.mcpb`) dogfooding — the local store, numeric tool parameters, arXiv-id linking, and citation matching, plus a now-working citation-graph tool in the Desktop Extension.
+
 ### Fixed
 - **[mcp]** Numeric tool parameters now accept a **stringified number**
   (`"10"`) as well as a JSON number (`10`). Several MCP clients / LLMs emit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+- **[mcp]** Numeric tool parameters now accept a **stringified number**
+  (`"10"`) as well as a JSON number (`10`). Several MCP clients / LLMs emit
+  numeric arguments as strings, which previously failed deserialization for
+  `limit` (`search_local` / `paper_search` / `list_recent` /
+  `resolve_citation` / `batch_resolve_citations`), `max_chars` (`paper_text`
+  / `paper_tex_source`), `depth` / `total` / `per_paper`
+  (`expand_citation_graph`), and `from_year` / `to_year` / `min_citations` /
+  `min_percentile` / `min_fwci` (`paper_search`). The published input schema
+  is unchanged (still `integer` / `number`); only the runtime is lenient.
+  (#370)
+
 ## [0.8.4] - 2026-06-25
 
 doiget joins the Claude Desktop Extensions distribution channel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   now score candidates against **all** authors of a work, not just the first,
   so a citation string naming several authors (e.g. "Bulla Costi Pruschke
   2008") is no longer dropped below the confidence threshold. (#372)
+- **[mcp/distribution]** The **released binaries and the `.mcpb` are now built
+  with `--features citation`**, and the `.mcpb` presets
+  `DOIGET_ENABLE_OPENALEX=1`, so `doiget_expand_citation_graph` actually works
+  in Claude Desktop (ADR-0010 hard caps depth≤3 / ≤100 nodes apply). CI now
+  builds and tests the `citation` feature (previously `oa-only` only). A
+  feature-off `cargo install` build still advertises the tool and returns
+  `NOT_IMPLEMENTED`; cleanly hiding it is blocked by rmcp's `#[tool_router]`
+  (it references tool methods unconditionally, so cfg-gating the method fails
+  to compile) and is tracked as a follow-up. (#373)
 
 ## [0.8.4] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   archive (`cond-mat`); it now keeps the full id and validates it via
   `ArxivId::parse` (a malformed URL yields no id rather than a garbage one).
   (#371)
+- **[discovery]** `doiget_resolve_citation` / `doiget_batch_resolve_citations`
+  now score candidates against **all** authors of a work, not just the first,
+  so a citation string naming several authors (e.g. "Bulla Costi Pruschke
+  2008") is no longer dropped below the confidence threshold. (#372)
 
 ## [0.8.4] - 2026-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.1"
+version = "0.8.5-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.1"
+version = "0.8.5-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.1"
+version = "0.8.5-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.3"
+version = "0.8.5-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.3"
+version = "0.8.5-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.3"
+version = "0.8.5-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.4"
+version = "0.8.5-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.4"
+version = "0.8.5-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.4"
+version = "0.8.5-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.5"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.5"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.5"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.2"
+version = "0.8.5-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.2"
+version = "0.8.5-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.2"
+version = "0.8.5-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.5-beta.4"
+version = "0.8.5-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.5-beta.4"
+version = "0.8.5-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.5-beta.4"
+version = "0.8.5-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.4"
+version       = "0.8.5-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.3"
+version       = "0.8.5-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.5"
+version       = "0.8.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.2"
+version       = "0.8.5-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.4"
+version       = "0.8.5-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.5-beta.1"
+version       = "0.8.5-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.5-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.5-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.5-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -71,7 +71,11 @@ use camino::Utf8PathBuf;
 /// real working directory untouched.
 pub(crate) fn resolve_store_root() -> Result<Utf8PathBuf> {
     if let Ok(s) = std::env::var("DOIGET_STORE_ROOT") {
-        if !s.is_empty() {
+        // Ignore an empty value or an unexpanded "${...}" placeholder — a
+        // Desktop-Extension config left blank can pass the literal
+        // "${user_config.store_root}", which must not become a path (#369).
+        let s = s.trim();
+        if !s.is_empty() && !s.contains("${") {
             return Ok(Utf8PathBuf::from(s));
         }
     }

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -127,17 +127,25 @@ pub struct GraphNode {
 /// One edge: `from` cites `to`.
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphEdge {
+    /// The citing Work (OpenAlex Work ID).
     pub from: String,
+    /// The cited Work (OpenAlex Work ID).
     pub to: String,
 }
 
 /// Result of [`expand`].
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphResult {
+    /// OpenAlex Work ID the expansion started from.
     pub seed_work_id: String,
+    /// Every Work visited, including the seed (`depth == 0`).
     pub nodes: Vec<GraphNode>,
+    /// Directed `from` cites `to` relationships discovered during the walk.
     pub edges: Vec<GraphEdge>,
+    /// `true` if an ADR-0010 hard cap (depth / total / per-paper) stopped the
+    /// walk before the graph was exhausted.
     pub truncated: bool,
+    /// Number of Works visited (equals `nodes.len()`).
     pub total_visited: usize,
 }
 
@@ -145,6 +153,7 @@ pub struct GraphResult {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum GraphError {
+    /// An OpenAlex fetch failed during the walk.
     #[error("openalex source error: {0}")]
     Source(#[from] FetchError),
     /// Provenance log write failed — fail-closed (the expansion is
@@ -152,8 +161,11 @@ pub enum GraphError {
     /// posture per `docs/PROVENANCE_LOG.md` §5.
     #[error("provenance log error during graph expansion: {0}")]
     Log(#[from] LogError),
+    /// The seed DOI is not indexed by OpenAlex (no `id` field in the response).
     #[error("seed DOI not indexed by OpenAlex (no `id` field in response)")]
     SeedNotIndexed,
+    /// Citation expansion is not enabled (requires `DOIGET_ENABLE_OPENALEX`
+    /// and `--features metadata`).
     #[error("citation graph requires DOIGET_ENABLE_OPENALEX + --features metadata")]
     CapabilityDenied,
 }

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -832,20 +832,25 @@ fn reconstruct_abstract(inv: &serde_json::Value) -> Option<String> {
 }
 
 /// Best-effort arXiv id extraction from a single OpenAlex location's
-/// `landing_page_url` / `pdf_url`. Looks for `arxiv.org/abs/<id>` and
-/// returns `<id>` (a trailing `vN` version is kept — the downstream
-/// parser accepts it).
+/// `landing_page_url` / `pdf_url`. Looks for `arxiv.org/abs/<id>` and returns
+/// the validated `<id>`. Old-style (pre-2007) ids embed a `/`
+/// (`archive/number`, e.g. `cond-mat/0701105`), so the capture must NOT stop
+/// at `/`; a trailing `vN` version is kept. The capture is validated via
+/// [`ArxivId::parse`], so a malformed URL yields `None` rather than a
+/// truncated / garbage id. (#371)
 fn extract_arxiv_from_location(loc: &serde_json::Value) -> Option<String> {
     for key in ["landing_page_url", "pdf_url"] {
         if let Some(u) = loc.get(key).and_then(serde_json::Value::as_str) {
             if let Some(idx) = u.find("arxiv.org/abs/") {
                 let after = &u[idx + "arxiv.org/abs/".len()..];
-                let id: String = after
+                // Stop at a query / fragment / whitespace — but NOT at '/',
+                // which separates `archive` from `number` in old-style ids.
+                let raw: String = after
                     .chars()
-                    .take_while(|c| !matches!(c, '?' | '#' | '/' | ' '))
+                    .take_while(|c| !matches!(c, '?' | '#' | ' ' | '\t' | '\n' | '\r'))
                     .collect();
-                if !id.is_empty() {
-                    return Some(id);
+                if let Ok(id) = crate::ArxivId::parse(raw.trim_end_matches('/')) {
+                    return Some(id.as_str().to_string());
                 }
             }
         }
@@ -1908,6 +1913,33 @@ mod tests {
             extract_arxiv_from_location(&loc).as_deref(),
             Some("2101.12345")
         );
+    }
+
+    #[test]
+    fn arxiv_extracted_old_style_id_not_truncated() {
+        // Pre-2007 ids embed a '/'; the capture must keep it (#371).
+        let loc =
+            serde_json::json!({ "landing_page_url": "https://arxiv.org/abs/cond-mat/0701105" });
+        assert_eq!(
+            extract_arxiv_from_location(&loc).as_deref(),
+            Some("cond-mat/0701105")
+        );
+        // Old-style with subclass + version + a trailing query string.
+        let loc2 = serde_json::json!({
+            "pdf_url": "http://arxiv.org/abs/astro-ph.CO/0703123v2?foo=bar"
+        });
+        assert_eq!(
+            extract_arxiv_from_location(&loc2).as_deref(),
+            Some("astro-ph.CO/0703123v2")
+        );
+    }
+
+    #[test]
+    fn arxiv_extraction_rejects_garbage() {
+        // A non-arXiv capture under abs/ fails ArxivId::parse -> None, rather
+        // than a truncated / garbage id (#371).
+        let loc = serde_json::json!({ "landing_page_url": "https://arxiv.org/abs/not an id!" });
+        assert_eq!(extract_arxiv_from_location(&loc), None);
     }
 
     #[test]

--- a/crates/doiget-core/src/sources/crossref.rs
+++ b/crates/doiget-core/src/sources/crossref.rs
@@ -156,7 +156,10 @@ impl CrossrefSource {
                 candidate_text.push_str(&t.to_lowercase());
                 candidate_text.push(' ');
             }
-            if let Some(author) = fields.authors.first() {
+            // Score against ALL authors, not just the first, so a citation
+            // naming several authors (e.g. "Bulla Costi Pruschke 2008") still
+            // matches instead of being dropped below the threshold — #372.
+            for author in &fields.authors {
                 candidate_text.push_str(&author.to_lowercase());
                 candidate_text.push(' ');
             }
@@ -578,5 +581,51 @@ mod tests {
         assert_eq!(cand.author, "Onsager, Lars");
         assert_eq!(cand.year, Some(1944));
         assert_eq!(cand.score, 1.0);
+    }
+
+    #[tokio::test]
+    async fn resolve_citation_matches_non_first_authors() {
+        // #372: candidate scoring text must include ALL authors, not just the
+        // first. With the old first-author-only text, "Costi Pruschke 2008"
+        // (2nd / 3rd authors + year) matched only the year (1/3 = 0.33) and was
+        // filtered out; now all authors match (3/3 = 1.0).
+        let server = MockServer::start().await;
+        let mock_body = serde_json::json!({
+            "status": "ok",
+            "message": {
+                "items": [
+                    {
+                        "DOI": "10.1103/RevModPhys.80.395",
+                        "title": ["Numerical renormalization group method for quantum impurity systems"],
+                        "author": [
+                            {"family": "Bulla", "given": "Ralf"},
+                            {"family": "Costi", "given": "Theo A."},
+                            {"family": "Pruschke", "given": "Thomas"}
+                        ],
+                        "issued": { "date-parts": [[2008, 4, 2]] },
+                        "container-title": ["Reviews of Modern Physics"]
+                    }
+                ]
+            }
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(mock_body))
+            .mount(&server)
+            .await;
+
+        let host = server_host(&server);
+        let s = crossref_for(&server);
+        let (_td, ctx) = build_test_context(&host);
+
+        let candidates = s
+            .resolve_citation("Costi Pruschke 2008", 5, &ctx)
+            .await
+            .expect("resolve ok");
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].doi, "10.1103/RevModPhys.80.395");
+        assert_eq!(candidates[0].score, 1.0);
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3793,10 +3793,19 @@ impl ServerHandler for Server {
 /// `doiget-cli -> doiget-mcp` wiring established by this PR and pull
 /// `clap` etc. into the MCP crate. Lifting this helper into `doiget-core`
 /// is a viable Phase-3 follow-up but is out of scope for this foundation.
+/// Whether a `DOIGET_STORE_ROOT` value is usable as a path: non-empty and not
+/// an unexpanded `${...}` placeholder. A Desktop-Extension config left blank
+/// passes the literal `${user_config.store_root}`, which must never become a
+/// filesystem path (it produced `os error 5` access-denied). See #369.
+fn store_root_env_is_usable(value: &str) -> bool {
+    let v = value.trim();
+    !v.is_empty() && !v.contains("${")
+}
+
 fn resolve_store_root() -> Option<Utf8PathBuf> {
     if let Ok(s) = std::env::var("DOIGET_STORE_ROOT") {
-        if !s.is_empty() {
-            return Some(Utf8PathBuf::from(s));
+        if store_root_env_is_usable(&s) {
+            return Some(Utf8PathBuf::from(s.trim()));
         }
     }
     // Default: `papers/` under the current working directory (#344 / ADR-0036),
@@ -4049,6 +4058,18 @@ mod tests {
             err.contains("rdf") && err.contains("auto"),
             "error must name the offending token AND the accepted set: {err}"
         );
+    }
+
+    #[test]
+    fn store_root_env_usable_rejects_placeholder_and_empty() {
+        // Real paths are usable.
+        assert!(store_root_env_is_usable("/home/u/papers"));
+        assert!(store_root_env_is_usable(r"C:\Users\u\papers"));
+        // Empty / whitespace and an unexpanded placeholder are not (#369).
+        assert!(!store_root_env_is_usable(""));
+        assert!(!store_root_env_is_usable("   "));
+        assert!(!store_root_env_is_usable("${user_config.store_root}"));
+        assert!(!store_root_env_is_usable("${HOME}/papers"));
     }
 
     #[test]

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2716,7 +2716,10 @@ where
             if trimmed.is_empty() {
                 Ok(None)
             } else {
-                trimmed.parse::<T>().map(Some).map_err(serde::de::Error::custom)
+                trimmed
+                    .parse::<T>()
+                    .map(Some)
+                    .map_err(serde::de::Error::custom)
             }
         }
     }
@@ -3924,7 +3927,10 @@ mod tests {
         let g: ExpandCitationGraphInput =
             from_value(json!({"ref": "10.1/x", "depth": "2", "total": "50", "per_paper": "5"}))
                 .unwrap();
-        assert_eq!((g.depth, g.total, g.per_paper), (Some(2), Some(50), Some(5)));
+        assert_eq!(
+            (g.depth, g.total, g.per_paper),
+            (Some(2), Some(50), Some(5))
+        );
 
         let t: PaperTextInput =
             from_value(json!({"ref": "arxiv:2401.00001", "max_chars": "2000"})).unwrap();

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2444,7 +2444,7 @@ pub struct SearchLocalInput {
     pub query: String,
     /// Maximum number of results to return. `None` means default (50);
     /// values >200 are clamped to 200.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub limit: Option<u32>,
 }
 
@@ -2481,28 +2481,28 @@ pub struct PaperSearchInput {
     /// Free-text topic query (e.g. "tropical tensor networks for spin glasses").
     pub query: String,
     /// Maximum results (1..=200; default 25). Out-of-range is rejected.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub limit: Option<u32>,
     /// Inclusive lower publication-year bound.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub from_year: Option<i32>,
     /// Inclusive upper publication-year bound.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub to_year: Option<i32>,
     /// Restrict to open-access works.
     #[serde(default)]
     pub oa_only: Option<bool>,
     /// Only works cited strictly more than this many times.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub min_citations: Option<u64>,
     /// Minimum field-and-year-normalized impact (FWCI) — a quality filter
     /// (#290).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub min_fwci: Option<f64>,
     /// Minimum within-cohort citation percentile (0–100): top-X% among
     /// same-year works; combine with `from_year` for "recent and standing
     /// out" (#290).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub min_percentile: Option<u8>,
     /// Author name (resolved to an OpenAlex author id).
     #[serde(default)]
@@ -2533,7 +2533,7 @@ pub struct PaperTextInput {
     pub ref_: String,
     /// Cap the returned text to this many characters (truncation is
     /// flagged on `truncated`). Omit for the full text.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub max_chars: Option<u32>,
 }
 
@@ -2549,7 +2549,7 @@ pub struct PaperTexSourceInput {
     pub ref_: String,
     /// Cap the returned LaTeX source to this many characters (truncation is
     /// flagged on `truncated`). Omit for the full source.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub max_chars: Option<u32>,
 }
 
@@ -2574,7 +2574,7 @@ pub struct LinkInput {
 pub struct ListRecentInput {
     /// Maximum number of results to return. `None` means default (50);
     /// values >200 are clamped to 200.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub limit: Option<u32>,
 }
 
@@ -2609,16 +2609,16 @@ pub struct ExpandCitationGraphInput {
     #[schemars(rename = "ref")]
     pub ref_: String,
     /// Max BFS depth (1..=3). Default is the ADR-0010 maximum (3).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub depth: Option<u32>,
     /// Max total nodes (1..=100). Default is the ADR-0010 maximum
     /// (100). `truncated: true` is set on the response when this
     /// cap is hit.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub total: Option<u32>,
     /// Max children expanded per parent (1..=20). Default is the
     /// ADR-0010 maximum (20).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_num")]
     pub per_paper: Option<u32>,
 }
 
@@ -2652,7 +2652,7 @@ pub struct ResolveCitationInput {
     /// Bibliographic citation query string (e.g. "Onsager 1944").
     pub query: String,
     /// Maximum number of candidates to return (default: 5).
-    #[serde(default = "default_resolve_limit")]
+    #[serde(default = "default_resolve_limit", deserialize_with = "de_lenient_num")]
     pub limit: u8,
 }
 
@@ -2664,12 +2664,62 @@ pub struct BatchResolveCitationsInput {
     /// Bibliographic citation query strings.
     pub queries: Vec<String>,
     /// Maximum number of candidates to return per query (default: 5).
-    #[serde(default = "default_resolve_limit")]
+    #[serde(default = "default_resolve_limit", deserialize_with = "de_lenient_num")]
     pub limit: u8,
 }
 
 fn default_resolve_limit() -> u8 {
     5
+}
+
+/// A numeric value that may arrive as a JSON number (`10`) or a JSON string
+/// (`"10"`). Some MCP clients / LLMs stringify numeric arguments; doiget
+/// accepts either form. Private helper for the lenient numeric deserializers.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum NumOrStr<T> {
+    Num(T),
+    Str(String),
+}
+
+/// Deserialize a required number leniently: accepts a JSON number or a
+/// stringified number (`"10"`); a non-numeric string is rejected. The
+/// published input schema is unchanged — schemars derives it from the field's
+/// concrete type, so the tool still advertises `integer` / `number`; only the
+/// runtime is lenient (Postel's law, #370).
+fn de_lenient_num<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr + serde::Deserialize<'de>,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    match NumOrStr::<T>::deserialize(deserializer)? {
+        NumOrStr::Num(n) => Ok(n),
+        NumOrStr::Str(s) => s.trim().parse::<T>().map_err(serde::de::Error::custom),
+    }
+}
+
+/// `Option` variant of [`de_lenient_num`]: accepts a number, a stringified
+/// number, JSON `null`, or (with `#[serde(default)]`) an absent field. An
+/// empty / whitespace-only string is treated as absent (`None`).
+fn de_lenient_opt_num<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr + serde::Deserialize<'de>,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    match Option::<NumOrStr<T>>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(NumOrStr::Num(n)) => Ok(Some(n)),
+        Some(NumOrStr::Str(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                trimmed.parse::<T>().map(Some).map_err(serde::de::Error::custom)
+            }
+        }
+    }
 }
 
 /// JSON-schema-derived input for the `doiget_tag` MCP tool.
@@ -3834,6 +3884,78 @@ fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// #370: numeric tool params accept a JSON number OR a stringified
+    /// number (`"10"`); absent / `null` / empty-string stay `None`.
+    #[test]
+    fn lenient_numbers_accept_string_or_number() {
+        use serde_json::{from_value, json};
+
+        let s: SearchLocalInput = from_value(json!({"query": "x", "limit": "10"})).unwrap();
+        assert_eq!(s.limit, Some(10));
+        let n: SearchLocalInput = from_value(json!({"query": "x", "limit": 10})).unwrap();
+        assert_eq!(n.limit, Some(10));
+        let a: SearchLocalInput = from_value(json!({"query": "x"})).unwrap();
+        assert_eq!(a.limit, None);
+        let z: SearchLocalInput = from_value(json!({"query": "x", "limit": null})).unwrap();
+        assert_eq!(z.limit, None);
+        let e: SearchLocalInput = from_value(json!({"query": "x", "limit": ""})).unwrap();
+        assert_eq!(e.limit, None);
+    }
+
+    /// #370: a non-numeric or out-of-range string is still rejected — the
+    /// deserializer is lenient about *form*, not *validity*.
+    #[test]
+    fn lenient_numbers_reject_non_numeric_string() {
+        use serde_json::{from_value, json};
+        assert!(from_value::<SearchLocalInput>(json!({"query": "x", "limit": "abc"})).is_err());
+        // 300 overflows u8 (min_percentile) -> parse error.
+        assert!(
+            from_value::<PaperSearchInput>(json!({"query": "x", "min_percentile": "300"})).is_err()
+        );
+    }
+
+    /// #370: every numeric input field across the tool surface (u32 / i32 /
+    /// u64 / u8 / f64, `Option` + required) tolerates stringified numbers.
+    #[test]
+    fn lenient_numbers_cover_every_numeric_input() {
+        use serde_json::{from_value, json};
+
+        let g: ExpandCitationGraphInput =
+            from_value(json!({"ref": "10.1/x", "depth": "2", "total": "50", "per_paper": "5"}))
+                .unwrap();
+        assert_eq!((g.depth, g.total, g.per_paper), (Some(2), Some(50), Some(5)));
+
+        let t: PaperTextInput =
+            from_value(json!({"ref": "arxiv:2401.00001", "max_chars": "2000"})).unwrap();
+        assert_eq!(t.max_chars, Some(2000));
+        let x: PaperTexSourceInput =
+            from_value(json!({"ref": "arxiv:2401.00001", "max_chars": "2000"})).unwrap();
+        assert_eq!(x.max_chars, Some(2000));
+
+        let p: PaperSearchInput = from_value(json!({
+            "query": "x", "limit": "7", "from_year": "2010", "to_year": "2020",
+            "min_citations": "100", "min_percentile": "90", "min_fwci": "1.5"
+        }))
+        .unwrap();
+        assert_eq!(p.limit, Some(7));
+        assert_eq!(p.from_year, Some(2010));
+        assert_eq!(p.to_year, Some(2020));
+        assert_eq!(p.min_citations, Some(100));
+        assert_eq!(p.min_percentile, Some(90));
+        assert_eq!(p.min_fwci, Some(1.5));
+
+        let l: ListRecentInput = from_value(json!({"limit": "25"})).unwrap();
+        assert_eq!(l.limit, Some(25));
+
+        let r: ResolveCitationInput = from_value(json!({"query": "x", "limit": "3"})).unwrap();
+        assert_eq!(r.limit, 3);
+        let d: ResolveCitationInput = from_value(json!({"query": "x"})).unwrap();
+        assert_eq!(d.limit, 5);
+        let b: BatchResolveCitationsInput =
+            from_value(json!({"queries": ["x"], "limit": "8"})).unwrap();
+        assert_eq!(b.limit, 8);
+    }
 
     #[test]
     fn capability_profile_to_json_clean_env_shape() {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -22,7 +22,8 @@
       "command": "${__dirname}/server/doiget-linux",
       "args": ["serve"],
       "env": {
-        "DOIGET_STORE_ROOT": "${user_config.store_root}"
+        "DOIGET_STORE_ROOT": "${user_config.store_root}",
+        "DOIGET_ENABLE_OPENALEX": "1"
       },
       "platform_overrides": {
         "darwin": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -38,7 +38,8 @@
     "store_root": {
       "type": "directory",
       "title": "Paper store location",
-      "description": "Directory where fetched PDFs and metadata are saved. Leave empty to use ./papers under the server's working directory.",
+      "description": "Directory where fetched PDFs and metadata are saved. Defaults to a doiget-papers folder under your home directory.",
+      "default": "${HOME}/Documents/doiget-papers",
       "required": false
     }
   },

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "doiget",
   "display_name": "doiget",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
   "long_description": "doiget is a single-binary, stdio MCP server that turns DOIs and arXiv IDs into local PDFs and structured metadata through official Open-Access APIs (Crossref, Unpaywall, arXiv, OpenAlex). It never bypasses paywalls and makes no network call that is not the direct result of a fetch you ask for. PDFs and metadata are saved to a local store; nothing is redistributed or phoned home. It is the agent-facing companion to BiblioFetch.jl and shares the same on-disk paper store.",
   "author": {


### PR DESCRIPTION
Promote `next` (0.8.5) to `main` — the **0.8.5 stable release**.

Reliability pass from Claude Desktop (`.mcpb`) dogfooding:
- **#369** store `os error 5` — `.mcpb` store now works (manifest default + `${...}` placeholder guard)
- **#370** numeric tool params accept stringified numbers (`"10"`)
- **#371** old-style arXiv ids (`cond-mat/0701105`) no longer truncated
- **#372** citation matching scores against all authors
- **#373a** citation-graph tool ships **working** in the `.mcpb` (`--features citation` + `DOIGET_ENABLE_OPENALEX`); CI now covers the `citation` feature

Follow-ups: #379 (hide the tool in feature-off `cargo install` builds), #369 data_dir default (deferred).

version-bump (promotion): GREEN (0.8.4 → 0.8.5). The signed `v0.8.5` tag follows once this lands on `main`.