### PR TITLE
release: 0.8.6 (strip beta — MCP tool safety annotations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-06-29
+
+MCP tool safety annotations — the `.mcpb` is now ready for the Claude Desktop Extensions directory.
+
 ### Added
 - **[mcp]** All 22 MCP tools now carry **safety annotations**
   (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`), so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.6-beta.1"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.6-beta.1"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.6-beta.1"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.6-beta.1"
+version       = "0.8.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.6-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.6-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.6-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "doiget",
   "display_name": "doiget",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
   "long_description": "doiget is a single-binary, stdio MCP server that turns DOIs and arXiv IDs into local PDFs and structured metadata through official Open-Access APIs (Crossref, Unpaywall, arXiv, OpenAlex). It never bypasses paywalls and makes no network call that is not the direct result of a fetch you ask for. PDFs and metadata are saved to a local store; nothing is redistributed or phoned home. It is the agent-facing companion to BiblioFetch.jl and shares the same on-disk paper store.",
   "author": {


### PR DESCRIPTION
Cuts **0.8.6** from `next`: `0.8.6-beta.1` → `0.8.6` + finalize the `## [0.8.6]` CHANGELOG + bump `mcpb/manifest.json`.

0.8.6 = **MCP tool safety annotations** on all 22 tools (#383) — the `.mcpb` is now ready for the Claude Desktop Extensions directory.

`version-bump` RED = release-cut exception (ADR-0033). `release-version-gate.sh v0.8.6` passes G0–G6.