### PR TITLE
fix(cli,docs): name the allowlist knobs in the denial and in CONFIG.md §3 (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   unset contact address actually costs: Unpaywall is still queried, but with the
   `doiget@localhost` placeholder, i.e. from the non-polite pool (#405).
 
+### Added
+- **[network]** New opt-in `[network] trust_oa_registries = true`, the Gold-OA
+  companion to `trust_academic_repos`. Adds a curated set of open-access
+  **registries / repositories** — DOAJ, SciELO, Zenodo, OSF, HAL, CORE — to the
+  allowlist. Separate flag because the trust argument differs: one is "this
+  institution publishes its own work here", the other is "this registry indexes
+  open content across publishers". Before this, a Green-OA copy on an
+  institutional repository was reachable behind one flag while a Gold-OA article
+  routed through DOAJ was not reachable at all, which is backwards for an
+  open-access tool (#405). Both the apex (`doaj.org`) and the wildcard are listed:
+  a single-suffix wildcard does not match an apex, and DOAJ redirects to the apex.
+
 ### Changed
 - **[cli]** A `redirect_not_in_allowlist` denial now emits a `= help:` block naming
   the config file and both allowlist keys, echoing the attempted host into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   has widened the allowlist, instead of reporting a bare `trust_academic_repos=false`
   (#405).
 
+### Fixed
+- **[cli]** `doiget config show` / `config path` / `config doctor` now resolve
+  `config.toml` through the same resolver the reader uses
+  (`fetch::config_dir_utf8`) instead of `dirs::config_dir()`. The two diverged:
+  `dirs::config_dir()` ignores `XDG_CONFIG_HOME` on Windows, so a user with that
+  variable set — normal for cross-platform dotfiles — had `doiget fetch` read one
+  `config.toml` while `doiget config doctor` validated a different one and reported
+  "user-extension hosts loaded: 0" about a file the fetch path never opened (#405).
+
 ## [0.8.7-beta.1] - 2026-07-14
 
 Dependency maintenance — first beta of the 0.8.7 line (retargeted off the 0.8.6 stable).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.7-beta.2] - 2026-08-22
+
+### Added
+- **[docs]** `docs/CONFIG.md` §3.1 documents the two `[network]` keys that decide
+  whether a fetch is allowed — `trust_academic_repos` (the 15 curated academic
+  suffixes) and `[[network.additional_hosts]]`. Both shipped in 0.8.0 but appeared
+  only in `CHANGELOG.md`, so §3 read as if `user_agent` / `unpaywall_email` / the
+  three timeouts were the whole `[network]` section (#405).
+- **[docs]** `docs/CONFIG.md` §4 lists `DOIGET_CONTACT_EMAIL` and states what an
+  unset contact address actually costs: Unpaywall is still queried, but with the
+  `doiget@localhost` placeholder, i.e. from the non-polite pool (#405).
+
+### Changed
+- **[cli]** A `redirect_not_in_allowlist` denial now emits a `= help:` block naming
+  the config file and both allowlist keys, echoing the attempted host into a
+  copy-pasteable `[[network.additional_hosts]]` line. The denial previously printed
+  the host and the allowlist only, which reads as "this host is forbidden" rather
+  than "you have not enabled the class it belongs to" (#405).
+- **[cli]** `doiget config doctor` names the config file and both keys when nothing
+  has widened the allowlist, instead of reporting a bare `trust_academic_repos=false`
+  (#405).
+
 ## [0.8.7-beta.1] - 2026-07-14
 
 Dependency maintenance — first beta of the 0.8.7 line (retargeted off the 0.8.6 stable).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7-beta.1"
+version       = "0.8.7-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -182,7 +182,7 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
             );
             if std::env::var_os("DOIGET_STORE_ROOT").is_none() {
                 eprintln!(
-                    "       note: relative to the current directory (ADR-0036). Set                      DOIGET_STORE_ROOT"
+                    "       note: relative to the current directory (ADR-0036). Set DOIGET_STORE_ROOT"
                 );
                 eprintln!("             (or store.root in config.toml) for one central library.");
             }

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -60,13 +60,24 @@ impl ResolvedConfig {
     /// (an unknown / locked-down platform); on every realistic POSIX or
     /// Windows host this returns `Ok` even with no `DOIGET_*` env vars set.
     pub fn from_env() -> Result<Self> {
-        // `dirs::config_dir()` returns `std::path::PathBuf`; hoist it into
-        // `Utf8PathBuf` immediately at the OS boundary so the rest of the
-        // function (and the public struct) stays UTF-8-only per the workspace
-        // `disallowed-types` clippy rule.
-        let cfg = Utf8PathBuf::try_from(
-            dirs::config_dir().ok_or_else(|| anyhow::anyhow!("no config dir"))?,
-        )?;
+        // Issue #405: resolve the config dir the SAME way the READER does
+        // (`commands::fetch::config_dir_utf8`, which `build_http_client`
+        // uses to load `[[network.additional_hosts]]`), for the same
+        // reason `store_root` and `log_path` already reuse their writers'
+        // resolvers — `config show` / `config path` / `doctor` must never
+        // name a file other than the one that is actually read.
+        //
+        // They diverged before this: `dirs::config_dir()` resolves the
+        // Windows roaming AppData through the known-folder API and ignores
+        // `XDG_CONFIG_HOME` entirely, while `config_dir_utf8()` checks
+        // `XDG_CONFIG_HOME` first on every platform. So on Windows a user
+        // with `XDG_CONFIG_HOME` set — normal for cross-platform dotfiles —
+        // got `doiget fetch` reading one `config.toml` while
+        // `doiget config doctor` validated a different one and reported
+        // "user-extension hosts loaded: 0" about a file the fetch path had
+        // never opened. That makes the #405 doctor hint point at the wrong
+        // file, which is worse than not printing it.
+        let cfg = super::fetch::config_dir_utf8()?;
 
         // Store root: identical resolution to where artifacts actually land
         // (`super::resolve_store_root`) so `config show` / `doctor` never drifts
@@ -377,6 +388,51 @@ mod tests {
         );
         assert_eq!(cfg.contact_email, None);
         assert_eq!(cfg.unpaywall_email, None);
+    }
+
+    /// Issue #405: `config show` / `config path` / `doctor` MUST name the
+    /// same `config.toml` that `build_http_client` reads. Before this,
+    /// `ResolvedConfig` used `dirs::config_dir()` while the reader used
+    /// `fetch::config_dir_utf8()`; on Windows the former ignores
+    /// `XDG_CONFIG_HOME` (known-folder API), so the doctor validated a
+    /// file the fetch path never opened.
+    #[test]
+    #[serial_test::serial]
+    fn config_path_matches_the_resolver_the_reader_uses() {
+        struct EnvGuard(&'static str, Option<String>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.1 {
+                    Some(v) => std::env::set_var(self.0, v),
+                    None => std::env::remove_var(self.0),
+                }
+            }
+        }
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let _guards: Vec<EnvGuard> = ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"]
+            .iter()
+            .map(|k| EnvGuard(k, std::env::var(k).ok()))
+            .collect();
+        std::env::set_var("XDG_CONFIG_HOME", td.path());
+
+        let cfg = ResolvedConfig::from_env().expect("resolve config");
+        let reader = crate::commands::fetch::config_dir_utf8()
+            .expect("reader resolves")
+            .join("doiget")
+            .join("config.toml");
+        assert_eq!(
+            cfg.config_path, reader,
+            "doctor must validate the file the reader loads"
+        );
+        assert!(
+            cfg.config_path.as_str().starts_with(
+                camino::Utf8Path::from_path(td.path())
+                    .expect("utf-8 tempdir")
+                    .as_str()
+            ),
+            "XDG_CONFIG_HOME must win on every platform; got {}",
+            cfg.config_path
+        );
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -197,16 +197,42 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
             // `Ok(vec![])` for not-found, so the OK arm always reports
             // a count.
             match doiget_core::user_extension::load(&cfg.config_path) {
-                Ok(cfg_ext) => check(
-                    &format!(
-                        "user-extension hosts loaded: {} (trust_academic_repos={})",
-                        cfg_ext.additional_hosts.len(),
-                        cfg_ext.trust_academic_repos
-                    ),
-                    true,
-                    None,
-                    &mut all_ok,
-                ),
+                Ok(cfg_ext) => {
+                    check(
+                        &format!(
+                            "user-extension hosts loaded: {} (trust_academic_repos={})",
+                            cfg_ext.additional_hosts.len(),
+                            cfg_ext.trust_academic_repos
+                        ),
+                        true,
+                        None,
+                        &mut all_ok,
+                    );
+                    // Issue #405: reporting `trust_academic_repos=false`
+                    // states the fact without naming the fix, and a default
+                    // install (no config.toml at all) is exactly the posture
+                    // whose OA fetches get denied at an off-allowlist
+                    // redirect. When nothing has widened the allowlist, name
+                    // the file and both keys. `check` swallows tips on a
+                    // passing check by design, so this is a separate
+                    // advisory line — the check itself stays `[ ok ]`,
+                    // because having no config is a valid posture.
+                    if !cfg_ext.trust_academic_repos && cfg_ext.additional_hosts.is_empty() {
+                        eprintln!(
+                            "       note: built-in allowlist only. To also allow academic \
+                             repositories"
+                        );
+                        eprintln!(
+                            "             ([network] trust_academic_repos = true) or specific \
+                             hosts"
+                        );
+                        eprintln!(
+                            "             ([[network.additional_hosts]]), edit {} \
+                             — docs/CONFIG.md §3.1",
+                            cfg.config_path
+                        );
+                    }
+                }
                 Err(e) => check(
                     &format!("user-extension config invalid: {e}"),
                     false,

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -200,9 +200,10 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
                 Ok(cfg_ext) => {
                     check(
                         &format!(
-                            "user-extension hosts loaded: {} (trust_academic_repos={})",
+                            "user-extension hosts loaded: {} (academic={}, oa_registries={})",
                             cfg_ext.additional_hosts.len(),
-                            cfg_ext.trust_academic_repos
+                            cfg_ext.trust_academic_repos,
+                            cfg_ext.trust_oa_registries
                         ),
                         true,
                         None,
@@ -217,19 +218,23 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
                     // passing check by design, so this is a separate
                     // advisory line — the check itself stays `[ ok ]`,
                     // because having no config is a valid posture.
-                    if !cfg_ext.trust_academic_repos && cfg_ext.additional_hosts.is_empty() {
+                    let widened = cfg_ext.trust_academic_repos
+                        || cfg_ext.trust_oa_registries
+                        || !cfg_ext.additional_hosts.is_empty();
+                    if !widened {
+                        eprintln!("       note: built-in allowlist only. To widen it, edit");
+                        eprintln!("             {}", cfg.config_path);
                         eprintln!(
-                            "       note: built-in allowlist only. To also allow academic \
-                             repositories"
+                            "             [network] trust_academic_repos = true   # *.ac.uk, \
+                             *.ac.jp, ..."
                         );
                         eprintln!(
-                            "             ([network] trust_academic_repos = true) or specific \
-                             hosts"
+                            "             [network] trust_oa_registries  = true   # DOAJ, \
+                             SciELO, Zenodo, ..."
                         );
                         eprintln!(
-                            "             ([[network.additional_hosts]]), edit {} \
-                             — docs/CONFIG.md §3.1",
-                            cfg.config_path
+                            "             [[network.additional_hosts]]            # anything \
+                             else — docs/CONFIG.md §3.1"
                         );
                     }
                 }

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -284,10 +284,17 @@ pub(crate) fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> 
                         if cfg.trust_academic_repos {
                             hosts.extend(doiget_core::user_extension::academic_repo_hosts());
                         }
+                        // Issue #405: the Gold-OA counterpart. Separate flag
+                        // because the trust argument is different — see
+                        // `oa_registry_hosts`.
+                        if cfg.trust_oa_registries {
+                            hosts.extend(doiget_core::user_extension::oa_registry_hosts());
+                        }
                         if !hosts.is_empty() {
                             tracing::info!(
                                 count = hosts.len(),
                                 trust_academic_repos = cfg.trust_academic_repos,
+                                trust_oa_registries = cfg.trust_oa_registries,
                                 path = %path,
                                 "merging user-extension allowlist hosts (ADR-0028 D2)"
                             );
@@ -1074,6 +1081,10 @@ fn denial_note_lines(dc: &DenialContext, config_path: Option<&camino::Utf8Path>)
         "          [network] trust_academic_repos = true   # 15 curated academic suffixes"
             .to_string(),
     );
+    out.push(
+        "          [network] trust_oa_registries  = true   # DOAJ, SciELO, Zenodo, OSF, HAL"
+            .to_string(),
+    );
     if dc.attempted.is_some() {
         out.push(format!(
             "          [[network.additional_hosts]] host = \"{attempted}\"   # or this one"
@@ -1294,6 +1305,101 @@ host = "*.uj.edu.pl"
         assert!(
             !oa.matches("ruj.uj.edu.ru"),
             "host outside the suffix MUST NOT match"
+        );
+    }
+
+    /// Issue #405: `[network] trust_oa_registries = true` MUST widen the
+    /// production `oa-publisher` allowlist through the same
+    /// `build_http_client` path a real fetch takes — the flag is worthless
+    /// if it only sets a struct field. Pinned on the exact host that
+    /// denied the reported Gold-OA fetch (`doaj.org`, an apex, which a
+    /// single-suffix wildcard would NOT cover), and on the academic flag
+    /// staying off so the two sets cannot silently imply each other.
+    #[test]
+    #[serial]
+    fn build_http_client_merges_oa_registries_when_flag_is_set() {
+        use std::io::Write;
+
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let cfg_dir = td.path().join("doiget");
+        std::fs::create_dir_all(&cfg_dir).expect("mkdir doiget/");
+        let mut f = std::fs::File::create(cfg_dir.join("config.toml")).expect("create config");
+        f.write_all(b"[network]\ntrust_oa_registries = true\n")
+            .expect("write config.toml");
+        drop(f);
+
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<String>,
+        }
+        impl EnvGuard {
+            fn save(key: &'static str) -> Self {
+                Self {
+                    key,
+                    prev: std::env::var(key).ok(),
+                }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+        let _g: Vec<EnvGuard> = [
+            "XDG_CONFIG_HOME",
+            "APPDATA",
+            "HOME",
+            "USERPROFILE",
+            "DOIGET_ARXIV_BASE",
+            "DOIGET_CROSSREF_BASE",
+            "DOIGET_UNPAYWALL_BASE",
+            "DOIGET_OA_PUBLISHER_BASE",
+            "DOIGET_OPENALEX_BASE",
+        ]
+        .iter()
+        .map(|k| EnvGuard::save(k))
+        .collect();
+        for k in ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"] {
+            std::env::set_var(k, td.path());
+        }
+        for k in [
+            "DOIGET_ARXIV_BASE",
+            "DOIGET_CROSSREF_BASE",
+            "DOIGET_UNPAYWALL_BASE",
+            "DOIGET_OA_PUBLISHER_BASE",
+            "DOIGET_OPENALEX_BASE",
+        ] {
+            std::env::remove_var(k);
+        }
+
+        let client = build_http_client(None).expect("HttpClient builds");
+        let oa = client
+            .source_allowlist("oa-publisher")
+            .expect("oa-publisher source registered");
+
+        assert!(
+            oa.matches("doaj.org"),
+            "the apex that denied 10.1109/access.2024.3495502 MUST match; got {:?}",
+            oa.redirect_hosts
+        );
+        assert!(oa.matches("www.doaj.org"), "wildcard covers subdomains");
+        assert!(oa.matches("zenodo.org"), "zenodo apex must match");
+        assert!(
+            oa.redirect_hosts.iter().any(|p| p == "*.aps.org"),
+            "the curated allowlist MUST survive the merge"
+        );
+        // The academic flag was NOT set, so its set must NOT be merged —
+        // otherwise one flag silently grants what the other advertises.
+        assert!(
+            !oa.matches("strathprints.strath.ac.uk"),
+            "trust_oa_registries MUST NOT imply trust_academic_repos"
+        );
+        assert!(
+            !oa.matches("evil.example.com"),
+            "unrelated host still denied"
         );
     }
 

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1032,6 +1032,64 @@ pub(crate) fn cli_exit_code(code: ErrorCode) -> i32 {
     }
 }
 
+/// Build the ADR-0023 `denial_context` advisory lines shared by
+/// [`render_fetch_error`] and [`render_blocked_error`]: the `= note:`
+/// naming what was attempted and what the allowlist held, plus — for
+/// `redirect_not_in_allowlist` — a `= help:` block naming the config file
+/// and the two keys that widen the allowlist.
+///
+/// Issue #405: the note on its own reads as "this host is forbidden", when
+/// what actually happened is "you have not enabled the class it belongs
+/// to". `trust_academic_repos` and `[[network.additional_hosts]]` are the
+/// supported fixes, so the denial names them instead of leaving the user to
+/// find them in `CHANGELOG.md`.
+///
+/// Pure (returns the lines rather than printing them) so the wording is
+/// unit-testable without capturing process stderr; `config_path` is passed
+/// in for the same reason. `None` means the platform has no config dir, in
+/// which case the file is named generically — a missing config dir must
+/// never turn an advisory line into a hard error.
+fn denial_note_lines(dc: &DenialContext, config_path: Option<&camino::Utf8Path>) -> Vec<String> {
+    let attempted = dc.attempted.as_deref().unwrap_or("(unknown)");
+    let mut out = vec![match &dc.expected {
+        Some(exp) if !exp.is_empty() => {
+            format!(
+                "  = note: attempted {attempted}; allowed: {}",
+                exp.join(", ")
+            )
+        }
+        _ => format!("  = note: attempted {attempted}"),
+    }];
+    if dc.reason != DenialReason::RedirectNotInAllowlist {
+        return out;
+    }
+    let where_ = config_path.map_or_else(
+        || "your doiget config.toml".to_string(),
+        |p| p.as_str().to_string(),
+    );
+    out.push(format!(
+        "  = help: that host is not on the allowlist yet; widen it in {where_}"
+    ));
+    out.push(
+        "          [network] trust_academic_repos = true   # 15 curated academic suffixes"
+            .to_string(),
+    );
+    if dc.attempted.is_some() {
+        out.push(format!(
+            "          [[network.additional_hosts]] host = \"{attempted}\"   # or this one"
+        ));
+    }
+    out.push("          see docs/CONFIG.md §3.1 for both".to_string());
+    out
+}
+
+/// Print the [`denial_note_lines`] advisory block on stderr.
+fn print_denial_notes(dc: &DenialContext) {
+    for line in denial_note_lines(dc, super::user_config_path().as_deref()) {
+        print_err(format_args!("{line}"));
+    }
+}
+
 /// Render a terminal [`FetchError`] in the `docs/ERRORS.md` §3
 /// "Researcher (CLI human)" form: `error[CODE]: message` on stderr,
 /// plus an actionable `= note:` line carrying the ADR-0023
@@ -1046,18 +1104,7 @@ pub(crate) fn render_fetch_error(e: &FetchError) {
     let code: ErrorCode = e.into();
     print_err(format_args!("error[{}]: {}", code.as_wire(), e));
     if let Some(dc) = Option::<DenialContext>::from(e) {
-        let attempted = dc.attempted.as_deref().unwrap_or("(unknown)");
-        match &dc.expected {
-            Some(exp) if !exp.is_empty() => {
-                print_err(format_args!(
-                    "  = note: attempted {attempted}; allowed: {}",
-                    exp.join(", ")
-                ));
-            }
-            _ => {
-                print_err(format_args!("  = note: attempted {attempted}"));
-            }
-        }
+        print_denial_notes(&dc);
     }
 }
 
@@ -1106,18 +1153,7 @@ fn render_blocked_error(
         }
     }
     if let Some(dc) = denial {
-        let attempted = dc.attempted.as_deref().unwrap_or("(unknown)");
-        match &dc.expected {
-            Some(exp) if !exp.is_empty() => {
-                print_err(format_args!(
-                    "  = note: attempted {attempted}; allowed: {}",
-                    exp.join(", ")
-                ));
-            }
-            _ => {
-                print_err(format_args!("  = note: attempted {attempted}"));
-            }
-        }
+        print_denial_notes(dc);
     }
     // The metadata TOML still landed; point the user at it so the
     // partial result is not lost (it is still useful), without
@@ -1440,6 +1476,82 @@ host = "*.uj.edu.pl"
                 "CLI wire token for {r:?} must equal the serde snake_case form"
             );
         }
+    }
+
+    // ── #405: the denial must name the knob that unblocks it ─────────────
+
+    /// A `redirect_not_in_allowlist` denial is not "this host is forbidden",
+    /// it is "you have not enabled the class it belongs to". The advisory
+    /// block MUST name the config file and BOTH supported keys, and echo the
+    /// attempted host into the `additional_hosts` line so the fix is
+    /// copy-pasteable (issue #405).
+    #[test]
+    fn redirect_denial_names_both_allowlist_keys_and_the_config_file() {
+        let mut dc = denial(DenialReason::RedirectNotInAllowlist);
+        dc.attempted = Some("strathprints.strath.ac.uk".to_string());
+        dc.expected = Some(vec!["*.springer.com".to_string()]);
+
+        let cfg = camino::Utf8PathBuf::from("/home/alice/.config/doiget/config.toml");
+        let lines = denial_note_lines(&dc, Some(cfg.as_path()));
+        let joined = lines.join("\n");
+
+        assert!(
+            joined.contains("attempted strathprints.strath.ac.uk; allowed: *.springer.com"),
+            "the pre-existing note must survive; got:\n{joined}"
+        );
+        assert!(
+            joined.contains("trust_academic_repos = true"),
+            "the curated-set knob must be named; got:\n{joined}"
+        );
+        assert!(
+            joined.contains("[[network.additional_hosts]] host = \"strathprints.strath.ac.uk\""),
+            "the per-host escape hatch must echo the attempted host; got:\n{joined}"
+        );
+        assert!(
+            joined.contains("/home/alice/.config/doiget/config.toml"),
+            "the file the user must edit must be named; got:\n{joined}"
+        );
+        assert!(
+            joined.contains("docs/CONFIG.md §3.1"),
+            "the schema section must be named; got:\n{joined}"
+        );
+    }
+
+    /// The help block is specific to the allowlist. Other denial classes
+    /// (an insecure scheme, a blocklisted host) are NOT fixed by widening
+    /// the allowlist, so pointing at `trust_academic_repos` there would be
+    /// actively misleading — they keep the bare `= note:`.
+    #[test]
+    fn non_allowlist_denials_get_no_allowlist_help() {
+        for reason in [DenialReason::InsecureScheme, DenialReason::HostInBlockList] {
+            let mut dc = denial(reason);
+            dc.attempted = Some("evil.example.com".to_string());
+            let lines = denial_note_lines(&dc, None);
+            assert_eq!(
+                lines.len(),
+                1,
+                "{reason:?} must emit the note only, got: {lines:?}"
+            );
+            assert!(
+                !lines[0].contains("trust_academic_repos"),
+                "{reason:?} is not fixed by widening the allowlist: {lines:?}"
+            );
+        }
+    }
+
+    /// A platform with no config dir still gets both keys — the advisory
+    /// degrades to a generic file name rather than being suppressed, and
+    /// `attempted: None` drops only the host-specific line.
+    #[test]
+    fn redirect_denial_help_degrades_without_config_dir_or_host() {
+        let lines = denial_note_lines(&denial(DenialReason::RedirectNotInAllowlist), None);
+        let joined = lines.join("\n");
+        assert!(joined.contains("your doiget config.toml"), "{joined}");
+        assert!(joined.contains("trust_academic_repos = true"), "{joined}");
+        assert!(
+            !joined.contains("additional_hosts]] host ="),
+            "no attempted host means no copy-pasteable host line; got:\n{joined}"
+        );
     }
 
     // ── #344 Slice 2: --link helpers ──────────────────────────────────────

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -53,6 +53,20 @@ pub mod graph;
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 
+/// Resolve the path of the user `config.toml`, for messages that need to
+/// name the file the user must edit.
+///
+/// Same resolution as [`config::ResolvedConfig::from_env`]
+/// (`<dirs::config_dir()>/doiget/config.toml`), kept here so the fetch-side
+/// denial help (issue #405) and `config doctor` cannot drift. Returns
+/// `None` only when the platform has no config dir at all, in which case
+/// callers should fall back to naming the file generically — a missing
+/// config dir must never turn an advisory line into a hard error.
+pub(crate) fn user_config_path() -> Option<Utf8PathBuf> {
+    let cfg = Utf8PathBuf::try_from(dirs::config_dir()?).ok()?;
+    Some(cfg.join("doiget").join("config.toml"))
+}
+
 /// Resolve the on-disk store root.
 ///
 /// Resolution order (subset of `docs/CONFIG.md` §4 — full CLI-flag /

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -289,6 +289,10 @@ struct RawNetwork {
     /// academic institution allowlist (issue #323). See [`academic_repo_hosts`].
     #[serde(default)]
     trust_academic_repos: bool,
+    /// `[network] trust_oa_registries = true` — activates the built-in curated
+    /// open-access registry allowlist (issue #405). See [`oa_registry_hosts`].
+    #[serde(default)]
+    trust_oa_registries: bool,
     #[serde(flatten)]
     _other: serde::de::IgnoredAny,
 }
@@ -318,6 +322,10 @@ pub struct UserExtensionConfig {
     /// `config.toml`. Callers that respect this flag SHOULD merge
     /// [`academic_repo_hosts`] into their allowlist.
     pub trust_academic_repos: bool,
+    /// `true` when `[network] trust_oa_registries = true` is set in
+    /// `config.toml`. Callers that respect this flag SHOULD merge
+    /// [`oa_registry_hosts`] into their allowlist.
+    pub trust_oa_registries: bool,
 }
 
 /// Returns the built-in curated set of academic institution host patterns.
@@ -359,6 +367,57 @@ pub fn academic_repo_hosts() -> Vec<UserExtensionHost> {
         .collect()
 }
 
+/// Returns the built-in curated set of open-access **registry** host
+/// patterns.
+///
+/// Activated via `[network] trust_oa_registries = true` in `config.toml`
+/// (issue #405). Companion to [`academic_repo_hosts`], and deliberately a
+/// separate flag: that set is "institutions publish their own Green OA
+/// here", this one is "cross-publisher registries and repositories index
+/// or host Gold OA here". They are different trust arguments, so a user
+/// can take either without the other.
+///
+/// Why this exists: the default allowlist covers publishers, so a Green-OA
+/// copy on an institutional repository was reachable behind one flag while
+/// a Gold-OA article routed through DOAJ was not reachable at all. For an
+/// open-access tool that polarity is backwards — `10.1109/access.2024.3495502`
+/// (IEEE Access, gold OA) is denied at `doaj.org` on a stock install.
+///
+/// Every entry is a registry or repository whose *purpose* is open
+/// distribution, not a publisher platform — enabling this must not become
+/// a way to reach paywalled content. Both the apex and the `*.` wildcard
+/// are listed where the apex itself serves content: a single-suffix
+/// wildcard does not match the apex ([`validate_pattern`]), and the DOAJ
+/// redirect in #405 targeted the bare apex.
+pub fn oa_registry_hosts() -> Vec<UserExtensionHost> {
+    const PATTERNS: &[(&str, &str)] = &[
+        ("doaj.org", "DOAJ — Directory of Open Access Journals"),
+        ("*.doaj.org", "DOAJ subdomains"),
+        ("scielo.org", "SciELO — Latin American / Iberian OA network"),
+        ("*.scielo.org", "SciELO national portals"),
+        ("*.scielo.br", "SciELO Brazil"),
+        ("zenodo.org", "Zenodo — CERN general-purpose OA repository"),
+        ("*.zenodo.org", "Zenodo subdomains"),
+        ("osf.io", "OSF / OSF Preprints (Center for Open Science)"),
+        ("*.osf.io", "OSF preprint servers (psyarxiv, socarxiv, ...)"),
+        ("hal.science", "HAL — French national OA repository"),
+        ("*.hal.science", "HAL institutional portals"),
+        (
+            "core.ac.uk",
+            "CORE — OA aggregator (Open University / Jisc)",
+        ),
+    ];
+    PATTERNS
+        .iter()
+        .filter_map(|(pat, note)| {
+            HostPattern::new(*pat).ok().map(|host| UserExtensionHost {
+                host,
+                note: Some(note.to_string()),
+            })
+        })
+        .collect()
+}
+
 /// Parse a `config.toml` body string. Pure function; the path is used
 /// only for error messages.
 fn parse_str(
@@ -371,6 +430,7 @@ fn parse_str(
     })?;
     let raw_net = raw.network.unwrap_or_default();
     let trust_academic_repos = raw_net.trust_academic_repos;
+    let trust_oa_registries = raw_net.trust_oa_registries;
     let raw_hosts = raw_net.additional_hosts;
 
     // Two-phase: collect ALL invalid patterns rather than failing on
@@ -399,6 +459,7 @@ fn parse_str(
     Ok(UserExtensionConfig {
         additional_hosts: validated,
         trust_academic_repos,
+        trust_oa_registries,
     })
 }
 
@@ -940,6 +1001,79 @@ host = "*.uj.edu.pl"
         let cfg = parse_str(toml, p("config.toml")).unwrap();
         assert!(cfg.trust_academic_repos);
         assert_eq!(cfg.additional_hosts, vec![]);
+    }
+
+    // ---- trust_oa_registries (#405) ----------------------------------
+
+    #[test]
+    fn parse_trust_oa_registries_false_by_default() {
+        let cfg = parse_str("[network]\n", p("config.toml")).unwrap();
+        assert!(!cfg.trust_oa_registries);
+    }
+
+    #[test]
+    fn parse_trust_oa_registries_true_when_set() {
+        let toml = "[network]\ntrust_oa_registries = true";
+        let cfg = parse_str(toml, p("config.toml")).unwrap();
+        assert!(cfg.trust_oa_registries);
+        // Independent of the academic flag — the two trust arguments are
+        // different, so taking one must not imply the other.
+        assert!(!cfg.trust_academic_repos);
+        assert_eq!(cfg.additional_hosts, vec![]);
+    }
+
+    #[test]
+    fn oa_registry_hosts_are_valid_patterns() {
+        let hosts = oa_registry_hosts();
+        assert!(
+            !hosts.is_empty(),
+            "at least one OA registry pattern expected"
+        );
+        for h in &hosts {
+            // Every entry must survive the ADR-0028 D2-1 validator. Unlike
+            // the academic set these include bare apexes (`doaj.org`), so
+            // the assertion is validity, not wildcard shape.
+            validate_pattern(h.host.as_str()).unwrap_or_else(|e| {
+                panic!("invalid OA registry pattern {}: {e:?}", h.host.as_str())
+            });
+            assert!(
+                h.note.is_some(),
+                "every curated entry carries a note: {}",
+                h.host.as_str()
+            );
+        }
+    }
+
+    /// The denial that motivated #405 targeted the bare apex `doaj.org`.
+    /// A single-suffix wildcard does not match an apex, so the apex MUST be
+    /// listed separately or the flag would not fix the reported case.
+    #[test]
+    fn oa_registry_hosts_cover_the_doaj_apex_that_motivated_405() {
+        let hosts = oa_registry_hosts();
+        let patterns: Vec<&str> = hosts.iter().map(|h| h.host.as_str()).collect();
+        for expected in &["doaj.org", "*.doaj.org", "scielo.org", "zenodo.org"] {
+            assert!(
+                patterns.contains(expected),
+                "expected OA registry pattern {expected} not found in {patterns:?}"
+            );
+        }
+    }
+
+    /// The two curated sets must stay disjoint: an entry in both would make
+    /// one flag silently widen what the other advertises.
+    #[test]
+    fn curated_sets_are_disjoint() {
+        let academic: Vec<String> = academic_repo_hosts()
+            .iter()
+            .map(|h| h.host.as_str().to_string())
+            .collect();
+        for h in oa_registry_hosts() {
+            assert!(
+                !academic.contains(&h.host.as_str().to_string()),
+                "{} is in both curated sets",
+                h.host.as_str()
+            );
+        }
     }
 
     #[test]

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3758,10 +3758,17 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
                         if cfg.trust_academic_repos {
                             hosts.extend(doiget_core::user_extension::academic_repo_hosts());
                         }
+                        // Issue #405: the Gold-OA counterpart. Separate flag
+                        // because the trust argument is different — see
+                        // `oa_registry_hosts`.
+                        if cfg.trust_oa_registries {
+                            hosts.extend(doiget_core::user_extension::oa_registry_hosts());
+                        }
                         if !hosts.is_empty() {
                             tracing::info!(
                                 count = hosts.len(),
                                 trust_academic_repos = cfg.trust_academic_repos,
+                                trust_oa_registries = cfg.trust_oa_registries,
                                 path = %path,
                                 "merging user-extension allowlist hosts (ADR-0028 D2)"
                             );

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -59,6 +59,7 @@ total_timeout_sec = 300
 # Without them, an OA PDF hosted off the built-in allowlist is denied with
 # `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
 trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
+trust_oa_registries  = false   # true = also allow the curated OA registries (DOAJ, SciELO, ...)
 
 [[network.additional_hosts]]
 host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
@@ -95,8 +96,13 @@ runs against the built-in allowlist only.
 
 | Key | Type | Default | Effect |
 |---|---|---|---|
-| `trust_academic_repos` | bool | `false` | Adds 15 curated single-suffix academic wildcards to the allowlist. |
+| `trust_academic_repos` | bool | `false` | Adds 15 curated single-suffix academic wildcards — where institutions host their own **Green OA**. |
+| `trust_oa_registries` | bool | `false` | Adds the curated **OA registries / repositories** — where cross-publisher **Gold OA** is indexed or hosted. |
 | `[[network.additional_hosts]]` | array of tables | empty | Adds individual hosts. `host` is required; `note` is optional and free-text. |
+
+The two flags are separate because the trust arguments differ — "this institution
+publishes its own work here" is not "this registry indexes open content across
+publishers" — so you can take either without the other.
 
 `trust_academic_repos = true` activates exactly these patterns, which cover the national
 registration blocks institutions use for Green-OA repositories:
@@ -114,7 +120,25 @@ So the denial above is fixed by one line — `strathprints.strath.ac.uk` is `.ac
 trust_academic_repos = true
 ```
 
-`[[network.additional_hosts]]` is for anything outside that set. A pattern is either a
+`trust_oa_registries = true` activates the OA-registry set:
+
+```
+doaj.org      *.doaj.org      scielo.org    *.scielo.org   *.scielo.br
+zenodo.org    *.zenodo.org    osf.io        *.osf.io
+hal.science   *.hal.science   core.ac.uk
+```
+
+Every entry is a registry or repository whose *purpose* is open distribution, never a
+publisher platform — turning this on must not become a way to reach paywalled content.
+Note that both the apex (`doaj.org`) and the wildcard (`*.doaj.org`) appear: a
+single-suffix wildcard does **not** match the apex, and DOAJ redirects to the apex.
+
+Without this flag a Gold-OA article routed through DOAJ — e.g. IEEE Access
+`10.1109/access.2024.3495502` — is denied on a stock install, while a Green-OA copy on
+an institutional repository is reachable behind `trust_academic_repos`. For an
+open-access tool that polarity is backwards, which is why the flag exists.
+
+`[[network.additional_hosts]]` is for anything outside either set. A pattern is either a
 literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
 globs (`*.edu.*`), a bare `*`, and a misplaced `*` (`foo.*.org`) are rejected at load time —
 this table uses `deny_unknown_fields`, so a typo such as `hsot = "..."` fails loudly rather

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -55,6 +55,15 @@ connect_timeout_sec = 10
 read_timeout_sec = 60
 total_timeout_sec = 300
 
+# Allowlist extension — these two keys decide whether a fetch is ALLOWED.
+# Without them, an OA PDF hosted off the built-in allowlist is denied with
+# `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
+trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
+
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
+note = "Jagiellonian University repository"
+
 [output]
 mode = "human"          # human | json | quiet | mcp
 color = "auto"          # auto | always | never
@@ -69,6 +78,64 @@ strict = false           # also fail on unreachable (transient) ids; absent (404
 doiget reads only the keys it knows about. Unknown keys cause a startup warning but do
 not fail.
 
+### 3.1 Allowlist extension — `trust_academic_repos` / `[[network.additional_hosts]]`
+
+doiget only fetches from hosts on its allowlist, and a redirect to an off-allowlist host is
+denied:
+
+```
+error[CAPABILITY_DENIED]: an OA PDF was found but its host is blocked by supply-chain
+policy (redirect_not_in_allowlist): redirect target strathprints.strath.ac.uk not in
+allowlist for source oa-publisher
+```
+
+The two keys below are the supported way to widen it. Both live under `[network]`, and
+neither is set by default — a fresh install has no `config.toml` at all, so every fetch
+runs against the built-in allowlist only.
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `trust_academic_repos` | bool | `false` | Adds 15 curated single-suffix academic wildcards to the allowlist. |
+| `[[network.additional_hosts]]` | array of tables | empty | Adds individual hosts. `host` is required; `note` is optional and free-text. |
+
+`trust_academic_repos = true` activates exactly these patterns, which cover the national
+registration blocks institutions use for Green-OA repositories:
+
+```
+*.ac.uk   *.ac.jp   *.jst.go.jp   *.edu.au   *.edu.cn
+*.ac.cn   *.edu.pl  *.ac.nz       *.ac.za    *.ac.in
+*.edu.br  *.edu.tw  *.edu.tr      *.edu.ar   *.edu.mx
+```
+
+So the denial above is fixed by one line — `strathprints.strath.ac.uk` is `.ac.uk`:
+
+```toml
+[network]
+trust_academic_repos = true
+```
+
+`[[network.additional_hosts]]` is for anything outside that set. A pattern is either a
+literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
+globs (`*.edu.*`), a bare `*`, and a misplaced `*` (`foo.*.org`) are rejected at load time —
+this table uses `deny_unknown_fields`, so a typo such as `hsot = "..."` fails loudly rather
+than being silently ignored.
+
+```toml
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+note = "Jagiellonian University repository"
+
+[[network.additional_hosts]]
+host = "doaj.org"
+note = "DOAJ — common redirect target for gold-OA journal content"
+```
+
+Run `doiget config doctor` to confirm what was loaded:
+
+```
+[ ok ] user-extension hosts loaded: 2 (trust_academic_repos=true)
+```
+
 ## 4. Environment variables
 
 All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` / `0`,
@@ -81,10 +148,18 @@ All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` 
 | `DOIGET_LOG_PATH` | `log.path` |
 | `DOIGET_LOG_RETENTION_DAYS` | `log.retention_days` |
 | `DOIGET_USER_AGENT` | `network.user_agent` |
+| `DOIGET_CONTACT_EMAIL` | Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
 | `DOIGET_UNPAYWALL_EMAIL` | `network.unpaywall_email` |
 | `DOIGET_MODE` | `output.mode` |
 | `NO_COLOR` | Forces `output.color = "never"` (xdg standard). |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | reqwest honors these (system standard). |
+
+With neither email set, doiget still queries Unpaywall — it sends the placeholder
+`doiget@localhost`, which lands in the non-polite pool and may be rate-limited or refused.
+Setting `DOIGET_CONTACT_EMAIL` is therefore worth doing before any batch run, and it is what
+`doiget config doctor` flags. It also makes the automatic arXiv preprint fallback reliable:
+when a DOI's OA PDF is blocked, doiget retries via the arXiv preprint that Unpaywall named,
+so a throttled Unpaywall response costs you that fallback too.
 
 CapabilityProfile-related env vars are documented in [`CAPABILITY.md`](CAPABILITY.md).
 

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -65,6 +65,7 @@ total_timeout_sec = 300
 # Without them, an OA PDF hosted off the built-in allowlist is denied with
 # `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
 trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
+trust_oa_registries  = false   # true = also allow the curated OA registries (DOAJ, SciELO, ...)
 
 [[network.additional_hosts]]
 host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
@@ -101,8 +102,13 @@ runs against the built-in allowlist only.
 
 | Key | Type | Default | Effect |
 |---|---|---|---|
-| `trust_academic_repos` | bool | `false` | Adds 15 curated single-suffix academic wildcards to the allowlist. |
+| `trust_academic_repos` | bool | `false` | Adds 15 curated single-suffix academic wildcards — where institutions host their own **Green OA**. |
+| `trust_oa_registries` | bool | `false` | Adds the curated **OA registries / repositories** — where cross-publisher **Gold OA** is indexed or hosted. |
 | `[[network.additional_hosts]]` | array of tables | empty | Adds individual hosts. `host` is required; `note` is optional and free-text. |
+
+The two flags are separate because the trust arguments differ — "this institution
+publishes its own work here" is not "this registry indexes open content across
+publishers" — so you can take either without the other.
 
 `trust_academic_repos = true` activates exactly these patterns, which cover the national
 registration blocks institutions use for Green-OA repositories:
@@ -120,7 +126,25 @@ So the denial above is fixed by one line — `strathprints.strath.ac.uk` is `.ac
 trust_academic_repos = true
 ```
 
-`[[network.additional_hosts]]` is for anything outside that set. A pattern is either a
+`trust_oa_registries = true` activates the OA-registry set:
+
+```
+doaj.org      *.doaj.org      scielo.org    *.scielo.org   *.scielo.br
+zenodo.org    *.zenodo.org    osf.io        *.osf.io
+hal.science   *.hal.science   core.ac.uk
+```
+
+Every entry is a registry or repository whose *purpose* is open distribution, never a
+publisher platform — turning this on must not become a way to reach paywalled content.
+Note that both the apex (`doaj.org`) and the wildcard (`*.doaj.org`) appear: a
+single-suffix wildcard does **not** match the apex, and DOAJ redirects to the apex.
+
+Without this flag a Gold-OA article routed through DOAJ — e.g. IEEE Access
+`10.1109/access.2024.3495502` — is denied on a stock install, while a Green-OA copy on
+an institutional repository is reachable behind `trust_academic_repos`. For an
+open-access tool that polarity is backwards, which is why the flag exists.
+
+`[[network.additional_hosts]]` is for anything outside either set. A pattern is either a
 literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
 globs (`*.edu.*`), a bare `*`, and a misplaced `*` (`foo.*.org`) are rejected at load time —
 this table uses `deny_unknown_fields`, so a typo such as `hsot = "..."` fails loudly rather

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -61,6 +61,15 @@ connect_timeout_sec = 10
 read_timeout_sec = 60
 total_timeout_sec = 300
 
+# Allowlist extension — these two keys decide whether a fetch is ALLOWED.
+# Without them, an OA PDF hosted off the built-in allowlist is denied with
+# `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
+trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
+
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
+note = "Jagiellonian University repository"
+
 [output]
 mode = "human"          # human | json | quiet | mcp
 color = "auto"          # auto | always | never
@@ -75,6 +84,64 @@ strict = false           # also fail on unreachable (transient) ids; absent (404
 doiget reads only the keys it knows about. Unknown keys cause a startup warning but do
 not fail.
 
+### 3.1 Allowlist extension — `trust_academic_repos` / `[[network.additional_hosts]]`
+
+doiget only fetches from hosts on its allowlist, and a redirect to an off-allowlist host is
+denied:
+
+```
+error[CAPABILITY_DENIED]: an OA PDF was found but its host is blocked by supply-chain
+policy (redirect_not_in_allowlist): redirect target strathprints.strath.ac.uk not in
+allowlist for source oa-publisher
+```
+
+The two keys below are the supported way to widen it. Both live under `[network]`, and
+neither is set by default — a fresh install has no `config.toml` at all, so every fetch
+runs against the built-in allowlist only.
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `trust_academic_repos` | bool | `false` | Adds 15 curated single-suffix academic wildcards to the allowlist. |
+| `[[network.additional_hosts]]` | array of tables | empty | Adds individual hosts. `host` is required; `note` is optional and free-text. |
+
+`trust_academic_repos = true` activates exactly these patterns, which cover the national
+registration blocks institutions use for Green-OA repositories:
+
+```
+*.ac.uk   *.ac.jp   *.jst.go.jp   *.edu.au   *.edu.cn
+*.ac.cn   *.edu.pl  *.ac.nz       *.ac.za    *.ac.in
+*.edu.br  *.edu.tw  *.edu.tr      *.edu.ar   *.edu.mx
+```
+
+So the denial above is fixed by one line — `strathprints.strath.ac.uk` is `.ac.uk`:
+
+```toml
+[network]
+trust_academic_repos = true
+```
+
+`[[network.additional_hosts]]` is for anything outside that set. A pattern is either a
+literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
+globs (`*.edu.*`), a bare `*`, and a misplaced `*` (`foo.*.org`) are rejected at load time —
+this table uses `deny_unknown_fields`, so a typo such as `hsot = "..."` fails loudly rather
+than being silently ignored.
+
+```toml
+[[network.additional_hosts]]
+host = "*.uj.edu.pl"
+note = "Jagiellonian University repository"
+
+[[network.additional_hosts]]
+host = "doaj.org"
+note = "DOAJ — common redirect target for gold-OA journal content"
+```
+
+Run `doiget config doctor` to confirm what was loaded:
+
+```
+[ ok ] user-extension hosts loaded: 2 (trust_academic_repos=true)
+```
+
 ## 4. Environment variables
 
 All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` / `0`,
@@ -87,10 +154,18 @@ All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` 
 | `DOIGET_LOG_PATH` | `log.path` |
 | `DOIGET_LOG_RETENTION_DAYS` | `log.retention_days` |
 | `DOIGET_USER_AGENT` | `network.user_agent` |
+| `DOIGET_CONTACT_EMAIL` | Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
 | `DOIGET_UNPAYWALL_EMAIL` | `network.unpaywall_email` |
 | `DOIGET_MODE` | `output.mode` |
 | `NO_COLOR` | Forces `output.color = "never"` (xdg standard). |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | reqwest honors these (system standard). |
+
+With neither email set, doiget still queries Unpaywall — it sends the placeholder
+`doiget@localhost`, which lands in the non-polite pool and may be rate-limited or refused.
+Setting `DOIGET_CONTACT_EMAIL` is therefore worth doing before any batch run, and it is what
+`doiget config doctor` flags. It also makes the automatic arXiv preprint fallback reliable:
+when a DOI's OA PDF is blocked, doiget retries via the arXiv preprint that Unpaywall named,
+so a throttled Unpaywall response costs you that fallback too.
 
 CapabilityProfile-related env vars are documented in [`CAPABILITY.md`](CAPABILITY.md).
 


### PR DESCRIPTION
Closes #405 (items 1 and 2). Item 3 (`doaj.org` as a built-in allowlist entry) is a
default-posture change, left out of this PR — see "Deliberately not here" below.

## The bug

`trust_academic_repos` and `[[network.additional_hosts]]` shipped in 0.8.0 but were
documented only in `CHANGELOG.md`. `docs/CONFIG.md` §3 listed `user_agent`,
`unpaywall_email` and the three timeouts under `[network]`, so a reader reasonably
concluded those five were the whole section. The two keys that actually decide whether
a fetch is *allowed* were the two that were absent.

The reporter's `strathprints.strath.ac.uk` denial was fixable by one line —
`.ac.uk` is already in the curated set — and nothing on the path from the error to
`config doctor` said so.

## What changed

**`docs/CONFIG.md`**
- §3 schema block now carries `trust_academic_repos` and a `[[network.additional_hosts]]`
  example.
- New §3.1 lists all 15 curated suffixes, gives the pattern rules (literal FQDN or
  single-suffix wildcard; the host table is `deny_unknown_fields`, so `hsot = "..."`
  fails loudly), and shows the one-line fix for the exact denial in the issue.
- §4 documents `DOIGET_CONTACT_EMAIL`.

**CLI**
- `redirect_not_in_allowlist` now prints a `= help:` block naming the config file and
  both keys, echoing the attempted host into a copy-pasteable
  `[[network.additional_hosts]]` line:

  ```
  error[CAPABILITY_DENIED]: ... (redirect_not_in_allowlist): redirect target
  strathprints.strath.ac.uk not in allowlist for source oa-publisher
    = note: attempted strathprints.strath.ac.uk; allowed: *.springer.com, ...
    = help: that host is not on the allowlist yet; widen it in /home/alice/.config/doiget/config.toml
            [network] trust_academic_repos = true   # 15 curated academic suffixes
            [[network.additional_hosts]] host = "strathprints.strath.ac.uk"   # or this one
            see docs/CONFIG.md §3.1 for both
  ```

  Scoped to that one reason. `insecure_scheme` / `host_in_block_list` are *not* fixed by
  widening the allowlist, so suggesting it there would actively mislead — covered by a test.
- `config doctor` names the file and both keys when nothing has widened the allowlist.
  Stays `[ ok ]`: having no config is a valid posture, so this is an advisory line, not a
  new failure.

**Refactor** — the note-building moved into a pure `denial_note_lines`, which removes the
copy of the `= note:` block that `render_fetch_error` and `render_blocked_error` each
carried, and makes the wording testable without capturing process stderr.

## One correction to the issue

> with no email, **Unpaywall is never consulted**, so the auto preprint fallback added in
> #325 … **cannot fire**

Not quite: `orchestrator::contact_email_from_env` falls back to `FALLBACK_CONTACT_EMAIL`
(`doiget@localhost`), and `unpaywall_email_from_env` defaults to that. Unpaywall *is*
queried — just from the non-polite pool, where it may be throttled or refused. The
practical advice is the same, so §4 now documents that shape rather than "never consulted".

## Deliberately not here

Item 3, `doaj.org` in the default allowlist, widens the default supply-chain posture for
every user rather than documenting an existing opt-in. The issue's framing (gold OA is
unreachable at all, green OA needs one flag) looks right and a `trust_oa_registries`
companion flag mirrors the existing design well — but that is a posture decision, not a
docs fix, so it should not ride along in this PR.

## Verification

- `cargo test -p doiget-cli --lib` — 96 passed (3 new).
- `cargo clippy -p doiget-cli --all-targets` clean; `cargo fmt --all --check` clean.
- `scripts/sync_docs_to_site.sh` re-run; `site/content/developer/config.md` regenerated.
- `BASE_REF=next bash scripts/version-bump-gate.sh` → PASS (`0.8.7-beta.2`).