### PR TITLE
feat(mcp): drop doiget_expand_citation_graph from feature-off builds (#379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.7-beta.2] - 2026-08-22
+
+### Changed
+- **[mcp]** `doiget_expand_citation_graph` is no longer advertised in `tools/list`
+  when the binary was built without `--features citation`. It previously appeared in
+  every build and answered `NOT_IMPLEMENTED` to every call, so an agent could plan
+  around a tool it could never use. The route is now dropped in `Server::new` for
+  feature-off builds, which also makes `tools/call` report an unknown tool instead of
+  a dead end (#379, closing the open half of #373). The shipped `.mcpb` and the
+  Claude Desktop Extension enable the feature, so they are unaffected.
+
 ## [0.8.7-beta.1] - 2026-07-14
 
 Dependency maintenance — first beta of the 0.8.7 line (retargeted off the 0.8.6 stable).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7-beta.1"
+version       = "0.8.7-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -89,12 +89,13 @@ use serde_json::{json, Value};
 pub struct Server {
     profile: CapabilityProfile,
     /// rmcp tool dispatch table, populated by the `#[tool_router]` macro
-    /// on the inherent impl block below. `#[tool_handler]` (in its default
-    /// configuration) uses the associated fn `Self::tool_router()` rather
-    /// than this field, but holding the router on the struct keeps the
-    /// type valid for `router = self.tool_router` if a future refactor
-    /// (e.g., merging multiple tool routers) needs that form.
-    #[allow(dead_code)]
+    /// on the inherent impl block below and then trimmed per build
+    /// features in [`Server::new`].
+    ///
+    /// `#[tool_handler(router = self.tool_router)]` reads THIS field rather
+    /// than the associated fn `Self::tool_router()`, which is what makes
+    /// the per-instance trimming visible to `tools/list` and `tools/call`
+    /// (issue #379). Do not switch the handler back to the associated fn.
     tool_router: ToolRouter<Server>,
 }
 
@@ -102,9 +103,28 @@ pub struct Server {
 impl Server {
     /// Construct a server with the given runtime capability profile.
     pub fn new(profile: CapabilityProfile) -> Self {
+        let mut tool_router = Self::tool_router();
+        // Issue #379 / #373(b): a tool that can only ever answer
+        // NOT_IMPLEMENTED is worse than an absent one — an agent will
+        // plan around it, call it, and get a dead end it cannot act on.
+        // `doiget_expand_citation_graph` needs the `citation` Cargo
+        // feature (ADR-0010), which the default `cargo install` build
+        // does not enable, so drop it from the router in that build and
+        // it disappears from `tools/list` and `tools/call` alike.
+        //
+        // The `#[tool]` method itself stays unconditional: rmcp's
+        // `#[tool_router]` macro generates registration code that names
+        // every `#[tool]` method, so `#[cfg]`-gating the method out does
+        // not compile (E0599 on the generated `..._tool_attr`). Removing
+        // the route at construction is the supported way to express this
+        // — `ToolRouter::remove_route` landed in rmcp 2.x, which is why
+        // #379 was blocked when the repo was on 1.7.
+        if !cfg!(feature = "citation") {
+            tool_router.remove_route("doiget_expand_citation_graph");
+        }
         Self {
             profile,
-            tool_router: Self::tool_router(),
+            tool_router,
         }
     }
 
@@ -3881,12 +3901,15 @@ fn resolve_log_path() -> anyhow::Result<Utf8PathBuf> {
 }
 
 // `tool_handler` wires the router into rmcp's `ServerHandler` trait — it
-// generates `call_tool`, `list_tools`, and `get_tool` from
-// `Self::tool_router()`. We provide `get_info` ourselves so the server
-// identifies itself as `name = "doiget"`, advertises
-// `protocolVersion = "2024-11-05"` (the version the smoke test asserts),
-// and includes capability-aware `instructions`.
-#[tool_handler]
+// generates `call_tool`, `list_tools`, and `get_tool`. `router =
+// self.tool_router` points those at the per-instance field built in
+// `Server::new` instead of the macro's default `Self::tool_router()`, so
+// the feature-gated trimming done there is what the peer actually sees
+// (issue #379). We provide `get_info` ourselves so the server identifies
+// itself as `name = "doiget"`, advertises `protocolVersion =
+// "2024-11-05"` (the version the smoke test asserts), and includes
+// capability-aware `instructions`.
+#[tool_handler(router = self.tool_router)]
 impl ServerHandler for Server {
     fn get_info(&self) -> ServerInfo {
         // Both `ServerInfo` and `Implementation` are `#[non_exhaustive]`

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -120,13 +120,22 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
         names.contains(&"doiget_paper_pdf_path"),
         "tools/list must include doiget_paper_pdf_path; got: {names:?}"
     );
-    // Slice 15: doiget_expand_citation_graph is always advertised
-    // (the tool method is always present; body returns NOT_IMPLEMENTED
-    // when this binary was built without --features citation).
-    assert!(
-        names.contains(&"doiget_expand_citation_graph"),
-        "tools/list must include doiget_expand_citation_graph; got: {names:?}"
-    );
+    // Issue #379: doiget_expand_citation_graph is advertised ONLY when
+    // the `citation` feature is compiled in. A feature-off build used to
+    // list it and answer NOT_IMPLEMENTED to every call, which is a tool
+    // an agent can plan around but never use; now the route is removed
+    // in `Server::new` so it is absent from tools/list entirely.
+    if cfg!(feature = "citation") {
+        assert!(
+            names.contains(&"doiget_expand_citation_graph"),
+            "--features citation must advertise the tool; got: {names:?}"
+        );
+    } else {
+        assert!(
+            !names.contains(&"doiget_expand_citation_graph"),
+            "feature-off must NOT advertise it (#379: NOT_IMPLEMENTED-only); got: {names:?}"
+        );
+    }
     // Slice 15b: BibTeX / CSL export tools.
     assert!(
         names.contains(&"doiget_bibtex_export"),

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -28,7 +28,7 @@ Additional tools:
 
 | Tool | Purpose |
 |---|---|
-| `doiget_expand_citation_graph` | BFS expansion of citations. Hard-capped. |
+| `doiget_expand_citation_graph` | BFS expansion of citations. Hard-capped. **Build-gated:** advertised only when compiled with `--features citation` (ADR-0010); a default `cargo install` build omits it from `tools/list` entirely rather than advertising a tool that can only answer `NOT_IMPLEMENTED` (#379). The shipped `.mcpb` enables the feature, so Claude Desktop always sees it. |
 | `doiget_bibtex_export` | BibTeX for one or many entries. |
 | `doiget_csl_export` | CSL JSON for one or many entries. |
 | `doiget_resolve_citation` | Resolve a free-form bibliographic citation string to ranked DOI candidates. |

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -34,7 +34,7 @@ Additional tools:
 
 | Tool | Purpose |
 |---|---|
-| `doiget_expand_citation_graph` | BFS expansion of citations. Hard-capped. |
+| `doiget_expand_citation_graph` | BFS expansion of citations. Hard-capped. **Build-gated:** advertised only when compiled with `--features citation` (ADR-0010); a default `cargo install` build omits it from `tools/list` entirely rather than advertising a tool that can only answer `NOT_IMPLEMENTED` (#379). The shipped `.mcpb` enables the feature, so Claude Desktop always sees it. |
 | `doiget_bibtex_export` | BibTeX for one or many entries. |
 | `doiget_csl_export` | CSL JSON for one or many entries. |
 | `doiget_resolve_citation` | Resolve a free-form bibliographic citation string to ranked DOI candidates. |


### PR DESCRIPTION
Closes #379. Also closes #373 — its part (a) shipped in #378, and this is part (b), the
last open half.

## The blocker in #379 is gone

The issue was filed against rmcp 1.7, where `#[cfg]` on a `#[tool]` method fails to
compile (the `#[tool_router]` macro emits registration code naming every method →
`E0599` on the generated `..._tool_attr`), and there was no way to unregister a route
afterwards. #395 moved the repo to **rmcp 2.2**, which added
`ToolRouter::remove_route`. So the "runtime `list_tools` filter" approach the issue
sketched is now directly expressible.

## What changed

- `Server::new` removes the `doiget_expand_citation_graph` route when
  `cfg!(feature = "citation")` is false. The `#[tool]` method stays unconditional —
  that part of the constraint has not changed.
- `#[tool_handler]` → `#[tool_handler(router = self.tool_router)]`. This is
  load-bearing: the default form regenerates the router from `Self::tool_router()` on
  every request, which would throw away the per-instance trimming. The struct field
  existed already but was `#[allow(dead_code)]`; it is now the real source.
- `tools/call` on a feature-off build now reports an unknown tool rather than a
  `NOT_IMPLEMENTED` stub — the stub body stays for the compile constraint above, but
  is unreachable.

## Behaviour

| build | `tools/list` | `tools/call` |
|---|---|---|
| `cargo install doiget` (default) | tool absent | unknown tool |
| `--features citation` | tool present | works |
| shipped `.mcpb` / Desktop Extension | tool present (feature is on) | works — **unchanged** |

## Tests

`initialize_handshake` asserted the tool was *always* advertised. It now asserts
presence under `--features citation` and **absence** without, so both directions are
pinned rather than just the new one.

- `cargo test -p doiget-mcp` (feature off) — green
- `cargo test -p doiget-mcp --features citation` — green
- `cargo clippy -p doiget-mcp --all-targets` in both modes — clean
- `cargo fmt --all --check` — clean
- `scripts/sync_docs_to_site.sh` re-run for the `docs/MCP_TOOLS.md` edit

No hardcoded tool-count assertion exists anywhere in the repo, so nothing else needed
updating for the 22 → 21 change in feature-off builds.

**Ordering note:** #401, #410 and #411 also target `next` at `0.8.7-beta.2`. Whichever
lands first, I will rebase the rest to `beta.3`.