### PR TITLE
fix(mcp,cli): stop probes and tests from materialising papers/ in the cwd (#406)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ lcov.info
 # Test scratch
 /tmp/
 /scratch/
+
+# Default store root (ADR-0036: `./papers` under the CWD). Running doiget
+# — or the test suite — inside the repo materialises this; it is never
+# repo content. Issue #406.
+papers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.7-beta.2] - 2026-08-22
+
+### Fixed
+- **[mcp]** `doiget_health` no longer creates the store root. Its `store_writable`
+  probe called `create_dir_all`, so a tool annotated `read_only_hint = true`
+  materialised `papers/` in whatever directory the server was started from —
+  indeterminate for a daemon, and usually an unrelated source repository for an
+  agent. The probe now walks up to the nearest existing ancestor and reports
+  whether that is a writable directory (#406).
+- **[test]** `initialize_handshake` no longer leaks `crates/doiget-mcp/papers/`.
+  Three `doiget_metadata_only` tests did not pin `DOIGET_STORE_ROOT`, so their
+  records landed in the ADR-0036 cwd default — the crate directory. `papers/` was
+  not in `.gitignore`, so a `git add -A` would have committed them (#406).
+
+### Added
+- **[cli]** `doiget config doctor` reports the **resolved** `store_root` path, and
+  notes that it is cwd-relative when `DOIGET_STORE_ROOT` is unset. Reporting only
+  "store_root parent exists" confirmed a path the user could not see (#406).
+- **[repo]** `.gitignore` ignores `papers/`.
+
 ## [0.8.7-beta.1] - 2026-07-14
 
 Dependency maintenance — first beta of the 0.8.7 line (retargeted off the 0.8.6 stable).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7-beta.1"
+version       = "0.8.7-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -158,6 +158,23 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
         "doctor" => {
             let mut all_ok = true;
             let store_parent = cfg.store_root.parent().map(|p| p.as_str()).unwrap_or("");
+            // Issue #406: the default store root is `./papers` under the
+            // CWD (ADR-0036), so it MOVES every time the user `cd`s. A
+            // check that says only "parent exists" confirms a path the
+            // user cannot see; naming it is what makes the cwd-relative
+            // default self-evident instead of surprising.
+            check(
+                &format!("store_root: {}", cfg.store_root),
+                true,
+                None,
+                &mut all_ok,
+            );
+            if std::env::var_os("DOIGET_STORE_ROOT").is_none() {
+                eprintln!(
+                    "       note: relative to the current directory (ADR-0036). Set                      DOIGET_STORE_ROOT"
+                );
+                eprintln!("             (or store.root in config.toml) for one central library.");
+            }
             check(
                 "store_root parent exists",
                 cfg.store_root.parent().map(|p| p.exists()).unwrap_or(true),

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -137,18 +137,17 @@ impl Server {
     /// test to validate the rmcp wiring. The output shape is
     /// `{ ok: true, version, schema_version, store_writable }`.
     ///
-    /// `store_writable` is a best-effort probe: we attempt
-    /// `std::fs::create_dir_all(<store_root>)` and report whether it
-    /// succeeded. Per `docs/SECURITY.md` §1.5 directory creation is
-    /// idempotent and is not user-data write — this matches the spec's
-    /// "read-only check" framing.
+    /// `store_writable` is a best-effort probe of the nearest existing
+    /// ancestor of the store root — see [`probe_store_writable`]. It
+    /// creates nothing, which is what lets this tool honour its
+    /// `read_only_hint = true` annotation (issue #406).
     #[tool(
         description = "WHEN TO USE: Operational sanity check for the doiget MCP server.\n\
                        INPUTS: none.\n\
                        OUTPUTS: { ok: true, version, schema_version, store_writable }.\n\
                        COSTS: <1 ms.\n\
-                       SIDE EFFECTS: idempotent mkdir of the store root.\n\
-                       LIMITS: none.",
+                       SIDE EFFECTS: none.\n\
+                       LIMITS: store_writable is a best-effort probe of the nearest existing ancestor; it never creates the store.",
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -3951,11 +3950,34 @@ fn resolve_store_root() -> Option<Utf8PathBuf> {
 
 /// Best-effort writability probe for the resolved store root.
 ///
-/// Returns `true` iff `std::fs::create_dir_all(path)` succeeds. The probe
-/// is idempotent (per `docs/SECURITY.md` §1.5 — directory creation is
-/// not considered a user-data write) and non-destructive.
+/// Walks up to the nearest **existing** ancestor of `path` and reports
+/// whether it is a directory that is not marked read-only. Returns `false`
+/// if no ancestor exists at all.
+///
+/// Issue #406: this used to answer the question by calling
+/// `std::fs::create_dir_all(path)`, which made `doiget_health` — a tool
+/// annotated `read_only_hint = true` — materialise `papers/` inside
+/// whatever directory the server happened to be started from. For a daemon
+/// that directory is indeterminate, and for an agent it is usually an
+/// unrelated source repository. A probe must not be the thing that creates
+/// the store.
+///
+/// The trade-off is deliberate: an existing, writable ancestor does not
+/// prove the mkdir would succeed. That is why the field is documented as
+/// best-effort — a wrong `true` costs a clear error on the first real
+/// write, whereas the old approach cost a stray directory on every health
+/// check.
 fn probe_store_writable(path: &camino::Utf8Path) -> bool {
-    std::fs::create_dir_all(path).is_ok()
+    let mut cur = Some(path);
+    while let Some(p) = cur {
+        match std::fs::metadata(p.as_std_path()) {
+            Ok(md) => return md.is_dir() && !md.permissions().readonly(),
+            // Not found (or not statable) — try the parent. `parent()`
+            // yields `None` at the root, which ends the walk.
+            Err(_) => cur = p.parent(),
+        }
+    }
+    false
 }
 
 /// Serialize a [`CapabilityProfile`] to the JSON surface defined by
@@ -4028,6 +4050,59 @@ fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// #406: the store-writability probe MUST NOT create anything.
+    /// `doiget_health` is annotated `read_only_hint = true`, and the old
+    /// `create_dir_all` implementation made a health check materialise
+    /// `papers/` in whatever directory the server was started from — for
+    /// a daemon, an indeterminate one; for an agent, usually an unrelated
+    /// source repository.
+    #[test]
+    fn probe_store_writable_creates_nothing() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let base = camino::Utf8Path::from_path(td.path()).expect("tempdir is utf-8");
+        let missing = base.join("papers");
+
+        assert!(
+            probe_store_writable(&missing),
+            "an absent root under a writable parent must still probe writable"
+        );
+        assert!(
+            !missing.exists(),
+            "the probe must not create {missing} — see #406"
+        );
+
+        // Nested-absent: the walk has to climb more than one level.
+        let deep = base.join("a").join("b").join("papers");
+        assert!(
+            probe_store_writable(&deep),
+            "nested-absent must climb to {base}"
+        );
+        assert!(
+            !base.join("a").exists(),
+            "the probe must not create intermediates"
+        );
+    }
+
+    /// An existing store root reports writable, and a path whose nearest
+    /// existing ancestor is a FILE reports not-writable — a file cannot
+    /// hold a store, so `true` there would be a lie the first write pays for.
+    #[test]
+    fn probe_store_writable_distinguishes_dir_from_file() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let base = camino::Utf8Path::from_path(td.path()).expect("tempdir is utf-8");
+
+        let real = base.join("papers");
+        std::fs::create_dir_all(real.as_std_path()).expect("mkdir");
+        assert!(probe_store_writable(&real), "an existing dir is writable");
+
+        let file = base.join("not-a-dir");
+        std::fs::write(file.as_std_path(), b"x").expect("write");
+        assert!(
+            !probe_store_writable(&file.join("papers")),
+            "a file ancestor must not report writable"
+        );
+    }
 
     /// #370: numeric tool params accept a JSON number OR a stringified
     /// number (`"10"`); absent / `null` / empty-string stay `None`.

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -470,18 +470,26 @@ async fn doiget_metadata_only_arxiv_happy_path_returns_metadata_envelope() -> an
         .await;
 
     let td = tempfile::TempDir::new().expect("tempdir");
-    let log_path = camino::Utf8Path::from_path(td.path())
-        .expect("tempdir is utf-8")
-        .join("mcp-meta.jsonl");
+    let tmp = camino::Utf8Path::from_path(td.path()).expect("tempdir is utf-8");
+    let log_path = tmp.join("mcp-meta.jsonl");
+    let store_root = tmp.join("papers");
 
     let env = EnvGuard::new(&[
         "DOIGET_ARXIV_BASE",
         "DOIGET_CROSSREF_BASE",
         "DOIGET_UNPAYWALL_BASE",
         "DOIGET_LOG_PATH",
+        // Issue #406: without this, `doiget_metadata_only` writes its
+        // record to the ADR-0036 default store root — `./papers` under
+        // the CWD, which for a test binary is the crate directory. The
+        // suite used to leave `crates/doiget-mcp/papers/` behind, and
+        // `papers/` is not in `.gitignore`, so a `git add -A` would
+        // commit it.
+        "DOIGET_STORE_ROOT",
     ]);
     env.set("DOIGET_ARXIV_BASE", &server.uri());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
 
     let (client, server_handle) = boot_in_memory_server().await?;
 
@@ -543,18 +551,26 @@ async fn doiget_metadata_only_doi_crossref_happy_path_returns_metadata_envelope(
         .await;
 
     let td = tempfile::TempDir::new().expect("tempdir");
-    let log_path = camino::Utf8Path::from_path(td.path())
-        .expect("tempdir is utf-8")
-        .join("mcp-meta.jsonl");
+    let tmp = camino::Utf8Path::from_path(td.path()).expect("tempdir is utf-8");
+    let log_path = tmp.join("mcp-meta.jsonl");
+    let store_root = tmp.join("papers");
 
     let env = EnvGuard::new(&[
         "DOIGET_ARXIV_BASE",
         "DOIGET_CROSSREF_BASE",
         "DOIGET_UNPAYWALL_BASE",
         "DOIGET_LOG_PATH",
+        // Issue #406: without this, `doiget_metadata_only` writes its
+        // record to the ADR-0036 default store root — `./papers` under
+        // the CWD, which for a test binary is the crate directory. The
+        // suite used to leave `crates/doiget-mcp/papers/` behind, and
+        // `papers/` is not in `.gitignore`, so a `git add -A` would
+        // commit it.
+        "DOIGET_STORE_ROOT",
     ]);
     env.set("DOIGET_CROSSREF_BASE", &server.uri());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
 
     let (client, server_handle) = boot_in_memory_server().await?;
 
@@ -710,19 +726,27 @@ async fn doiget_metadata_only_network_failure_returns_network_error_envelope() -
         .await;
 
     let td = tempfile::TempDir::new().expect("tempdir");
-    let log_path = camino::Utf8Path::from_path(td.path())
-        .expect("tempdir is utf-8")
-        .join("mcp-meta.jsonl");
+    let tmp = camino::Utf8Path::from_path(td.path()).expect("tempdir is utf-8");
+    let log_path = tmp.join("mcp-meta.jsonl");
+    let store_root = tmp.join("papers");
 
     let env = EnvGuard::new(&[
         "DOIGET_ARXIV_BASE",
         "DOIGET_CROSSREF_BASE",
         "DOIGET_UNPAYWALL_BASE",
         "DOIGET_LOG_PATH",
+        // Issue #406: without this, `doiget_metadata_only` writes its
+        // record to the ADR-0036 default store root — `./papers` under
+        // the CWD, which for a test binary is the crate directory. The
+        // suite used to leave `crates/doiget-mcp/papers/` behind, and
+        // `papers/` is not in `.gitignore`, so a `git add -A` would
+        // commit it.
+        "DOIGET_STORE_ROOT",
     ]);
     env.set("DOIGET_CROSSREF_BASE", &server.uri());
     env.set("DOIGET_UNPAYWALL_BASE", &server.uri());
     env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_STORE_ROOT", store_root.as_str());
 
     let (client, server_handle) = boot_in_memory_server().await?;
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -22,7 +22,7 @@ speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal
 | `doiget_list_recent` | Last N fetched entries. |
 | `doiget_paper_pdf_path` | Return the local path of a cached PDF. **Does not read, parse, or transmit content.** |
 | `doiget_capability_profile` | Report which sources this instance is allowed to use. |
-| `doiget_health` | Operational sanity (store writable, version, schema). |
+| `doiget_health` | Operational sanity (store writable, version, schema). `store_writable` is a best-effort probe of the nearest **existing** ancestor of the store root — it creates nothing, so calling this tool never materialises `papers/` (#406). |
 
 Additional tools:
 

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -28,7 +28,7 @@ speaks **stdio only** ([ADR-0001](DECISIONS/), [`SCOPE.md`](SCOPE.md) §non-goal
 | `doiget_list_recent` | Last N fetched entries. |
 | `doiget_paper_pdf_path` | Return the local path of a cached PDF. **Does not read, parse, or transmit content.** |
 | `doiget_capability_profile` | Report which sources this instance is allowed to use. |
-| `doiget_health` | Operational sanity (store writable, version, schema). |
+| `doiget_health` | Operational sanity (store writable, version, schema). `store_writable` is a best-effort probe of the nearest **existing** ancestor of the store root — it creates nothing, so calling this tool never materialises `papers/` (#406). |
 
 Additional tools:
 


### PR DESCRIPTION
Refs #406. Addresses the parts that are bugs under ADR-0036; the "default to XDG"
suggestion is left for you — see the bottom.

## Two things were creating the store that had no business doing so

### 1. `doiget_health` created it — while annotated `read_only_hint = true`

`probe_store_writable` answered "is the root writable?" with
`std::fs::create_dir_all(root)`. So a **health check** materialised `papers/` in
whatever directory the MCP server was started from. The tool's own description
admitted it (`SIDE EFFECTS: idempotent mkdir of the store root`) while the rmcp
annotation said `read_only_hint = true` — an MCP host gating on that annotation was
being told the wrong thing.

This is very likely the mechanism behind the reported case: nothing else runs on a
denied fetch, but a health probe runs unconditionally.

The probe now walks up to the nearest **existing** ancestor and reports whether it is
a directory that is not read-only.

**The trade-off is deliberate and weaker than before:** an existing writable ancestor
does not prove the `mkdir` would succeed. That is the right direction — a wrong `true`
costs a clear error on the first real write; the old version cost a stray directory on
every call. The field was already documented as best-effort. Annotation and description
now match the behaviour.

### 2. Our own test suite leaked into the repo

```
crates/doiget-mcp/papers/.metadata/arxiv_2401.12345.toml
crates/doiget-mcp/papers/.metadata/doi_10.1234_example.toml
```

Three `doiget_metadata_only` tests in `initialize_handshake` pinned
`DOIGET_ARXIV_BASE` / `DOIGET_LOG_PATH` but not `DOIGET_STORE_ROOT`, so their records
went to the ADR-0036 cwd default — the crate directory. `papers/` was not in
`.gitignore`, so `git add -A` would commit them. This nearly rode along in #411.

All three now pin the store to their tempdir, and `papers/` is ignored. Verified: a
full `cargo test --workspace` now leaves no `papers/` anywhere in the tree.

## Plus item 3 of the issue

`config doctor` reported `[ ok ] store_root parent exists` without naming the path.
With a cwd-relative default that confirms a location the user cannot see. It now prints:

```
[ ok ] store_root: /home/alice/some-worktree/papers
       note: relative to the current directory (ADR-0036). Set DOIGET_STORE_ROOT
             (or store.root in config.toml) for one central library.
```

## Tests

- Two new unit tests on `probe_store_writable`: it must report writable for an absent
  root under a writable parent **and create nothing** (including nested-absent, so the
  ancestor walk is exercised), and it must report *not* writable when the nearest
  existing ancestor is a file.
- `cargo test --workspace` — 50 suites green, and the tree is clean afterwards.
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --all --check` clean,
  `scripts/sync_docs_to_site.sh` re-run.

## Deliberately not here — two calls that are yours

**Item 1, XDG default.** This would reverse ADR-0036, which you accepted three months
ago with this exact consequence written into it:

> A `papers/` directory now appears in whatever directory doiget is first run from.
> This is intentional (visibility) but means a user fetching from many directories
> accrues several small stores unless they set `DOIGET_STORE_ROOT`.

The dogfooding that motivated ADR-0036 (#344: artifacts landing in `~/papers` where
neither agent nor human sees them) and the dogfooding in #406 point in opposite
directions, and picking between them needs a superseding ADR, not a bug fix.

**Item 2, "do not create the tree until a fetch actually succeeds."** The metadata
record written on a denied PDF leg is deliberate — #145 made a blocked OA leg write
the metadata and print `= note: metadata-only record written to <path>`, because the
metadata *did* resolve and is useful. Suppressing it would undo that. The genuinely
unwanted writes were the two above, which are fixed here.