### PR TITLE
refactor(cli): single print_err in commands::output (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.7-beta.2] - 2026-08-22
+
+### Changed
+- **[cli/refactor]** `print_err` moves to `commands::output` as a single
+  `pub(crate)` function. Ten command modules each carried a byte-identical
+  private copy with its own `#[allow(clippy::print_stderr)]`; the workspace
+  denies that lint to protect MCP stdio purity, so the exception is now
+  auditable in one place instead of ten (#346 item 2). Quality only — no
+  behaviour change; net −45 lines.
+
 ## [0.8.7-beta.1] - 2026-07-14
 
 Dependency maintenance — first beta of the 0.8.7 line (retargeted off the 0.8.6 stable).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7-beta.1"
+version = "0.8.7-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7-beta.1"
+version       = "0.8.7-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/audit_log.rs
+++ b/crates/doiget-cli/src/commands/audit_log.rs
@@ -42,15 +42,7 @@ use camino::Utf8PathBuf;
 use doiget_core::provenance::{verify_all, VerifyIssueKind};
 
 use super::fetch::CliExit;
-
-/// Stderr sink for the `docs/ERRORS.md` §3 human-error lines. Mirrors
-/// the `print_err` helper in `commands::fetch`; the localized `#[allow]`
-/// is the minimal intervention for the workspace `clippy::print_stderr`
-/// lint.
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
+use super::output::print_err;
 
 /// Run the `audit-log` subcommand.
 ///

--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -22,14 +22,8 @@ use doiget_core::store::{render, FsStore, Metadata, Store};
 use doiget_core::{Ref, Safekey};
 
 use super::fetch::CliExit;
+use super::output::print_err;
 use super::resolve_store_root;
-
-/// Stderr sink for progress / skip notes (`docs/ERRORS.md` §3); stdout
-/// carries only the `.bib` artifact (ADR-0001).
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
 
 /// Run the `bib` subcommand against the configured store.
 ///

--- a/crates/doiget-cli/src/commands/cite.rs
+++ b/crates/doiget-cli/src/commands/cite.rs
@@ -43,15 +43,8 @@ use doiget_core::orchestrator::{cite_metadata, resolve_only, MetadataOnlyOutcome
 use doiget_core::store::{render, FsStore, Metadata, Store};
 use doiget_core::{CapabilityProfile, Ref};
 
+use super::output::print_err;
 use super::resolve_store_root;
-
-/// Stderr sink for the offline-fallback `note:` line (mirrors the
-/// `print_err` helper in sibling commands). Kept off stdout so the BibTeX
-/// artifact stays clean (ADR-0001).
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
 
 /// Run the `cite` subcommand.
 ///

--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -22,14 +22,8 @@ use doiget_core::store::{render, FsStore, Metadata, Store};
 use doiget_core::{Ref, Safekey};
 
 use super::fetch::CliExit;
+use super::output::print_err;
 use super::resolve_store_root;
-
-/// Stderr sink for progress / skip notes (`docs/ERRORS.md` §3); stdout
-/// carries only the CSL JSON artifact (ADR-0001).
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
 
 /// Run the `csl` subcommand against the configured store.
 ///

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -45,6 +45,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 
+use super::output::print_err;
 #[cfg(feature = "citation")]
 use doiget_core::http::tier_2_allowlist;
 use doiget_core::http::{
@@ -934,14 +935,6 @@ fn make_symlink(_src: &Utf8Path, _dst: &Utf8Path) -> std::io::Result<()> {
 /// minimal intervention.
 #[allow(clippy::print_stderr)]
 fn print_success(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
-
-/// Stderr sink for the `docs/ERRORS.md` §3 human-error lines. Mirrors
-/// [`print_success`]; the localized `#[allow]` is the minimal
-/// intervention for the workspace `clippy::print_stderr` lint.
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
     eprintln!("{args}");
 }
 

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -34,15 +34,7 @@ use doiget_core::sources::openalex::OpenalexSource;
 use doiget_core::{ErrorCode, Ref};
 
 use super::fetch::{cli_exit_code, CliExit, FetchHarness};
-
-/// Stderr sink for the `docs/ERRORS.md` §3 human-error lines. Mirrors
-/// the `print_err` helper in `commands::fetch`; the localized `#[allow]`
-/// is the minimal intervention for the workspace `clippy::print_stderr`
-/// lint.
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
+use super::output::print_err;
 
 /// Run the `graph` subcommand against the live source set.
 ///

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -61,6 +61,23 @@
 
 use clap::ValueEnum;
 
+/// Stderr sink for the `docs/ERRORS.md` §3 human lines — errors, `= note:`
+/// advisories, progress and skip notes.
+///
+/// stdout is reserved for the requested artifact (ADR-0001), and the
+/// workspace denies `clippy::print_stderr` so that MCP stdio purity cannot
+/// be broken by an accidental `println!`. This function is the one
+/// sanctioned exception, and the `#[allow]` lives here rather than being
+/// re-stated per command module.
+///
+/// Issue #346: ten command modules each carried a byte-identical private
+/// copy of this two-liner with its own `#[allow]`. One copy means the lint
+/// exception is auditable in one place.
+#[allow(clippy::print_stderr)]
+pub fn print_err(args: std::fmt::Arguments<'_>) {
+    eprintln!("{args}");
+}
+
 /// The four output modes from `docs/CONFIG.md` §3 / ADR-0017.
 ///
 /// - `Human`: line-oriented text, intended for a terminal.

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -29,6 +29,7 @@ use doiget_core::store::{EntryInfo, FsStore, Store};
 use doiget_core::ErrorCode;
 
 use super::fetch::{cli_exit_code, CliExit, FetchHarness};
+use super::output::print_err;
 use super::output::OutputMode;
 use super::resolve_store_root;
 
@@ -97,13 +98,6 @@ pub struct ExternalArgs {
     pub publisher: Option<String>,
     /// Result ordering.
     pub sort: SortArg,
-}
-
-/// Stderr sink for `docs/ERRORS.md` §3 human-error lines (mirrors the
-/// `print_err` helper in `commands::fetch` / `commands::graph`).
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
 }
 
 /// Run the `search` subcommand.

--- a/crates/doiget-cli/src/commands/source.rs
+++ b/crates/doiget-cli/src/commands/source.rs
@@ -31,12 +31,8 @@ use doiget_core::paper_tex_source::{
 use doiget_core::{ArxivId, ErrorCode, Ref};
 
 use super::fetch::{build_resolve_context, cli_exit_code, CliExit};
+use super::output::print_err;
 use super::output::OutputMode;
-
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
 
 /// Run the `source` subcommand.
 ///

--- a/crates/doiget-cli/src/commands/tex_source.rs
+++ b/crates/doiget-cli/src/commands/tex_source.rs
@@ -18,12 +18,8 @@ use doiget_core::paper_tex_source::{paper_tex_source, resolve_arxiv_src_base, Pa
 use doiget_core::{ArxivId, ErrorCode, Ref};
 
 use super::fetch::{build_resolve_context, cli_exit_code, CliExit};
+use super::output::print_err;
 use super::output::OutputMode;
-
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
 
 /// Run the `tex-source` subcommand.
 ///

--- a/crates/doiget-cli/src/commands/text.rs
+++ b/crates/doiget-cli/src/commands/text.rs
@@ -25,14 +25,8 @@ use doiget_core::paper_text::{paper_text, PaperText, AR5IV_DEFAULT_BASE};
 use doiget_core::{ArxivId, ErrorCode, Ref};
 
 use super::fetch::{build_resolve_context, cli_exit_code, CliExit};
+use super::output::print_err;
 use super::output::OutputMode;
-
-/// Stderr sink for `docs/ERRORS.md` §3 human-error lines (mirrors the
-/// `print_err` helper in `commands::search` / `commands::fetch`).
-#[allow(clippy::print_stderr)]
-fn print_err(args: std::fmt::Arguments<'_>) {
-    eprintln!("{args}");
-}
 
 /// Run the `text` subcommand.
 ///


### PR DESCRIPTION
Closes #346.

## Item 1 was already done

The issue's first item — share the arXiv `/src` gzip+ustar prologue — **shipped in
0.8.0-beta.4**, exactly as proposed:

```rust
fn classify_src(bytes: &[u8], max_decompressed: Option<u64>) -> Result<SrcPayload, FetchError>
```

`paper_tex_source.rs:235`, called from `extract_tex` (line 293) and `extract_bundle`
(line 621). CHANGELOG 0.8.0-beta.4 records it under `#346 / ADR-0034 D6`. Nothing to
do there.

## Item 2 — the `print_err` dedupe

Ten command modules, not the two the issue named, each carried a byte-identical copy:

`audit_log` `bib` `cite` `csl` `fetch` `graph` `search` `source` `tex_source` `text`

```rust
#[allow(clippy::print_stderr)]
fn print_err(args: std::fmt::Arguments<'_>) { eprintln!("{args}"); }
```

The workspace **denies** `clippy::print_stderr` so MCP stdio purity cannot be broken by
a stray `println!`. Ten copies means ten places where that deny is waived, each with its
own comment restating why. It is now one `pub(crate)` fn in `commands::output`, so the
lint exception is auditable in one place.

Quality only — same signature, same body, same stderr. Net **−45 lines**.

## Verification

- `cargo test --workspace` — 50 suites green
- `cargo clippy --workspace --all-targets` clean (this is the real check: if any call
  site had lost its exception, the workspace deny would fire)
- `cargo fmt --all --check` clean

`print_success` in `fetch.rs` is left alone — it has only one definition, so there is
nothing to dedupe.

**Ordering note:** #401, #410, #412 and #419 also target `next` at `0.8.7-beta.2`.
Whichever lands first, I will rebase the rest.