### PR TITLE
feat(cli): doiget config doctor --network (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   has widened the allowlist, instead of reporting a bare `trust_academic_repos=false`
   (#405).
 
+- **[cli]** `doiget config doctor --network` — the outbound half of the report
+  (#407): proxy configuration in effect, which Unpaywall pool you are in, how many
+  host patterns the `oa-publisher` allowlist holds, and one GET per well-known
+  publisher showing which will talk to a scripted client. Opt-in because it makes
+  real requests; no retries; probes only hosts already on the allowlist, so it
+  cannot be pointed at an arbitrary host. A `2xx` with an **empty body** is
+  reported as a bot challenge rather than a success — that is the case a status
+  code alone cannot diagnose, and the one that makes a subscribing university
+  network still fail. Egress address is deliberately not probed: that needs a
+  third-party echo service, i.e. a new outbound dependency and a new `PRIVACY.md`
+  entry, for a diagnostic.
+- **[core]** New `HttpClient::probe` / `ProbeOutcome` behind the above.
+- **[docs]** `docs/CONFIG.md` §6.1 "Institutional networks: what works and what
+  does not" — IP-based subscription does not imply fetchability (#407).
+
 ### Fixed
 - **[cli]** `doiget config show` / `config path` / `config doctor` now resolve
   `config.toml` through the same resolver the reader uses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.7-beta.8] - 2026-08-22
+
+### Added
+- **[cli]** `doiget config doctor --network` — the outbound half of the report
+  (#407): proxy configuration in effect, which Unpaywall pool you are in, how many
+  host patterns the `oa-publisher` allowlist holds, and one GET per well-known
+  publisher showing which will talk to a scripted client. Opt-in because it makes
+  real requests; no retries; probes only hosts already on the allowlist, so it
+  cannot be pointed at an arbitrary host. A `2xx` with an **empty body** is
+  reported as a bot challenge rather than a success — that is the case a status
+  code alone cannot diagnose, and the one that makes a subscribing university
+  network still fail. Egress address is deliberately not probed: that needs a
+  third-party echo service, i.e. a new outbound dependency and a new `PRIVACY.md`
+  entry, for a diagnostic.
+- **[core]** New `HttpClient::probe` / `ProbeOutcome` behind the above.
+- **[docs]** `docs/CONFIG.md` §6.1 "Institutional networks: what works and what
+  does not" — IP-based subscription does not imply fetchability (#407).
+
 ## [0.8.7-beta.7] - 2026-08-22
 
 ### Added
@@ -43,21 +61,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[cli]** `doiget config doctor` names the config file and both keys when nothing
   has widened the allowlist, instead of reporting a bare `trust_academic_repos=false`
   (#405).
-
-- **[cli]** `doiget config doctor --network` — the outbound half of the report
-  (#407): proxy configuration in effect, which Unpaywall pool you are in, how many
-  host patterns the `oa-publisher` allowlist holds, and one GET per well-known
-  publisher showing which will talk to a scripted client. Opt-in because it makes
-  real requests; no retries; probes only hosts already on the allowlist, so it
-  cannot be pointed at an arbitrary host. A `2xx` with an **empty body** is
-  reported as a bot challenge rather than a success — that is the case a status
-  code alone cannot diagnose, and the one that makes a subscribing university
-  network still fail. Egress address is deliberately not probed: that needs a
-  third-party echo service, i.e. a new outbound dependency and a new `PRIVACY.md`
-  entry, for a diagnostic.
-- **[core]** New `HttpClient::probe` / `ProbeOutcome` behind the above.
-- **[docs]** `docs/CONFIG.md` §6.1 "Institutional networks: what works and what
-  does not" — IP-based subscription does not imply fetchability (#407).
 
 ### Fixed
 - **[cli]** `doiget config show` / `config path` / `config doctor` now resolve

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7-beta.7"
+version = "0.8.7-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7-beta.7"
+version = "0.8.7-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7-beta.7"
+version = "0.8.7-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7-beta.7"
+version       = "0.8.7-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -353,7 +353,8 @@ pub enum ProbeVerdict {
 }
 
 impl ProbeVerdict {
-    /// Map a [`ProbeOutcome`] to a verdict. Pure, so the classification —
+    /// Map a [`doiget_core::http::ProbeOutcome`] to a verdict. Pure, so
+    /// the classification —
     /// the part with the actual judgement in it — is unit-testable without
     /// a network or a mock server.
     pub fn classify(status: u16, body_bytes: usize) -> Self {

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -129,13 +129,17 @@ impl ResolvedConfig {
 // belong on stderr by design (stdout stays clean for `| jq` style pipes
 // when we add `--json` later).
 #[allow(clippy::print_stdout, clippy::print_stderr)]
-pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
+pub async fn run(action: String, mode: super::output::OutputMode, network: bool) -> Result<()> {
     // `mode` honors ADR-0017: `Quiet` suppresses the TOML dump (`show`)
     // and the path println! (`path`); `doctor` is unaffected because its
     // per-check output is on stderr and only the failure/success exit
     // code is the user-visible signal (#203). Json body for `show` is
     // tracked in #204.
     let cfg = ResolvedConfig::from_env()?;
+    if network && action != "doctor" {
+        eprintln_err("error: --network applies to `config doctor` only");
+        return Err(anyhow::Error::new(CliExit(2)));
+    }
     match action.as_str() {
         "show" => match mode {
             super::output::OutputMode::Quiet => {}
@@ -260,6 +264,13 @@ pub fn run(action: String, mode: super::output::OutputMode) -> Result<()> {
                     &mut all_ok,
                 ),
             }
+            // Issue #407: the network section is opt-in behind `--network`
+            // because it makes real outbound requests. Everything above is
+            // local and always runs, so `--network` extends the report
+            // rather than replacing it.
+            if network {
+                network_report(&cfg).await;
+            }
             // Trying to actually create the dirs would have side-effects;
             // keep doctor read-only and just check existence of parents.
             if !all_ok {
@@ -299,6 +310,179 @@ fn eprintln_err(msg: &str) {
 /// When `ok` is `false` and `tip` is `Some`, a remediation tip is printed
 /// on the next line, indented so it is visually attached to the failed
 /// check (issue #322).
+/// Classification of a single publisher probe (issue #407).
+///
+/// The point of the enum is the `BotChallenge` arm. A publisher WAF answers
+/// a scripted client with `202 Accepted` and an empty body; a report that
+/// only printed the status would call that a success and send the user off
+/// to debug their subscription, when the binding constraint is that they
+/// are not a browser. Status and body size together separate the two.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeVerdict {
+    /// 2xx with a non-empty body — the host served this client.
+    Ok {
+        /// HTTP status observed.
+        status: u16,
+        /// Body size in bytes.
+        bytes: usize,
+    },
+    /// 2xx with an empty body. Almost always a bot-challenge holding
+    /// response, not a paywall and not an outage.
+    BotChallenge {
+        /// HTTP status observed (typically 202).
+        status: u16,
+    },
+    /// 401 / 403 — reached the host, which refused. A subscription or
+    /// credential question, not a transport one.
+    Refused {
+        /// HTTP status observed (401 or 403).
+        status: u16,
+    },
+    /// Any other status.
+    Status {
+        /// HTTP status observed.
+        status: u16,
+    },
+    /// The host is not on the source allowlist, so no request was sent.
+    NotAllowlisted,
+    /// Transport failure — DNS, TLS, connect, or timeout.
+    Unreachable {
+        /// Rendered transport error.
+        reason: String,
+    },
+}
+
+impl ProbeVerdict {
+    /// Map a [`ProbeOutcome`] to a verdict. Pure, so the classification —
+    /// the part with the actual judgement in it — is unit-testable without
+    /// a network or a mock server.
+    pub fn classify(status: u16, body_bytes: usize) -> Self {
+        match status {
+            200..=299 if body_bytes == 0 => Self::BotChallenge { status },
+            200..=299 => Self::Ok {
+                status,
+                bytes: body_bytes,
+            },
+            401 | 403 => Self::Refused { status },
+            other => Self::Status { status: other },
+        }
+    }
+
+    /// One-line rendering: what happened, then what it means.
+    pub fn render(&self) -> String {
+        match self {
+            Self::Ok { status, bytes } => format!("{status} {bytes} bytes    ok"),
+            Self::BotChallenge { status } => {
+                format!("{status} empty body  bot challenge — needs a TDM key or a real browser")
+            }
+            Self::Refused { status } => {
+                format!("{status}               reached, refused — subscription or credential")
+            }
+            Self::Status { status } => format!("{status}               unexpected status"),
+            Self::NotAllowlisted => {
+                "not allowlisted   no request sent; add the host or enable a trust flag".to_string()
+            }
+            Self::Unreachable { reason } => format!("unreachable       {reason}"),
+        }
+    }
+}
+
+/// `doiget config doctor --network` — the outbound half of the report
+/// (issue #407).
+///
+/// Answers the question a user on an institutional network actually has:
+/// *which publishers will talk to me?* One GET per probed host, no retries,
+/// and only against hosts already on the `oa-publisher` allowlist — a
+/// doctor that probed arbitrary hosts would be an SSRF gadget wearing a
+/// diagnostic hat.
+///
+/// **Egress address is deliberately not reported.** Determining it requires
+/// asking a third-party echo service, which would be a new outbound
+/// dependency and a new `PRIVACY.md` entry for a diagnostic. The report
+/// names the proxy configuration in effect — the part doiget actually
+/// knows — and leaves the address to `curl`.
+#[allow(clippy::print_stderr)]
+async fn network_report(cfg: &ResolvedConfig) {
+    eprintln!();
+    eprintln!("network (--network):");
+
+    for var in ["HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy"] {
+        if let Ok(v) = std::env::var(var) {
+            if !v.is_empty() {
+                eprintln!("  proxy           {var}={v}");
+            }
+        }
+    }
+    eprintln!(
+        "  egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)"
+    );
+    eprintln!("                  a proxy fixes addressing, never a bot wall");
+
+    match &cfg.contact_email {
+        Some(e) => eprintln!("  unpaywall       polite pool as {e}"),
+        None => eprintln!(
+            "  unpaywall       non-polite pool (no DOIGET_CONTACT_EMAIL; may be throttled)"
+        ),
+    }
+
+    let client = match crate::commands::fetch::build_http_client(None) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("  probes          unavailable: {e}");
+            return;
+        }
+    };
+    let Some(allow) = client.source_allowlist("oa-publisher") else {
+        eprintln!("  probes          unavailable: oa-publisher source not registered");
+        return;
+    };
+    eprintln!(
+        "  oa-publisher    {} host patterns allowlisted",
+        allow.redirect_hosts.len()
+    );
+
+    // Publishers a paywalled-literature user is most likely to ask about.
+    // Listed whether or not they are allowlisted: "ieee.org NOT
+    // allowlisted" is the single most useful line in the report for the
+    // #407 case, and it can only be printed for a host we name up front.
+    const PROBES: &[(&str, &str)] = &[
+        ("link.springer.com", "https://link.springer.com/robots.txt"),
+        ("www.mdpi.com", "https://www.mdpi.com/robots.txt"),
+        ("journals.plos.org", "https://journals.plos.org/robots.txt"),
+        ("arxiv.org", "https://arxiv.org/robots.txt"),
+        (
+            "ieeexplore.ieee.org",
+            "https://ieeexplore.ieee.org/robots.txt",
+        ),
+        ("dl.acm.org", "https://dl.acm.org/robots.txt"),
+        ("epubs.siam.org", "https://epubs.siam.org/robots.txt"),
+        ("doaj.org", "https://doaj.org/robots.txt"),
+    ];
+    for (host, url) in PROBES {
+        let verdict = if !allow.matches(host) {
+            ProbeVerdict::NotAllowlisted
+        } else {
+            match url::Url::parse(url) {
+                Err(e) => ProbeVerdict::Unreachable {
+                    reason: format!("bad probe URL: {e}"),
+                },
+                Ok(u) => match client.probe("oa-publisher", u).await {
+                    Ok(o) => ProbeVerdict::classify(o.status, o.body_bytes),
+                    Err(e) => ProbeVerdict::Unreachable {
+                        reason: e.to_string(),
+                    },
+                },
+            }
+        };
+        eprintln!("  probe {host:<22} {}", verdict.render());
+    }
+    eprintln!();
+    eprintln!("  IP-based subscription does not imply fetchability: a publisher WAF can");
+    eprintln!("  answer a scripted client with a challenge regardless of entitlement. The");
+    eprintln!("  routes that work are per-publisher TDM credentials (docs/CONFIG.md §6)");
+    eprintln!("  or a real browser on the subscribing network.");
+}
+
 #[allow(clippy::print_stderr)]
 fn check(label: &str, ok: bool, tip: Option<&str>, all_ok: &mut bool) {
     let mark = if ok { "[ ok ]" } else { "[FAIL]" };
@@ -470,15 +654,95 @@ mod tests {
         );
     }
 
+    // ── #407: probe classification ───────────────────────────────────────
+
+    /// The load-bearing case. A publisher WAF answers a scripted client
+    /// with `202 Accepted` and an empty body. Status alone reads that as
+    /// success and sends the user off to debug a subscription that is not
+    /// the problem — the measurement in #407 was exactly
+    /// `status=202 body=0 bytes` from a subscribing university address.
     #[test]
+    fn empty_2xx_body_is_a_bot_challenge_not_a_success() {
+        assert_eq!(
+            ProbeVerdict::classify(202, 0),
+            ProbeVerdict::BotChallenge { status: 202 }
+        );
+        assert_eq!(
+            ProbeVerdict::classify(200, 0),
+            ProbeVerdict::BotChallenge { status: 200 },
+            "an empty 200 is the same holding response wearing a different code"
+        );
+        assert!(
+            ProbeVerdict::classify(202, 0)
+                .render()
+                .contains("bot challenge"),
+            "the verdict must name the diagnosis, not just the status"
+        );
+    }
+
+    #[test]
+    fn non_empty_2xx_is_ok() {
+        assert_eq!(
+            ProbeVerdict::classify(200, 1234),
+            ProbeVerdict::Ok {
+                status: 200,
+                bytes: 1234
+            }
+        );
+    }
+
+    /// 401/403 is a different diagnosis from a challenge: the host talked
+    /// to us and declined, so the next step is credentials, not a browser.
+    #[test]
+    fn auth_statuses_are_refused_not_challenged() {
+        for code in [401u16, 403] {
+            assert_eq!(
+                ProbeVerdict::classify(code, 0),
+                ProbeVerdict::Refused { status: code },
+                "{code} must not be misread as a bot challenge"
+            );
+        }
+        assert_eq!(
+            ProbeVerdict::classify(404, 0),
+            ProbeVerdict::Status { status: 404 }
+        );
+    }
+
+    /// Every verdict renders something a user can act on; none is blank.
+    #[test]
+    fn every_verdict_renders_non_empty_advice() {
+        let all = [
+            ProbeVerdict::Ok {
+                status: 200,
+                bytes: 1,
+            },
+            ProbeVerdict::BotChallenge { status: 202 },
+            ProbeVerdict::Refused { status: 403 },
+            ProbeVerdict::Status { status: 500 },
+            ProbeVerdict::NotAllowlisted,
+            ProbeVerdict::Unreachable {
+                reason: "dns".into(),
+            },
+        ];
+        for v in &all {
+            assert!(!v.render().trim().is_empty(), "{v:?} rendered empty");
+        }
+    }
+
+    #[tokio::test]
     #[serial_test::serial]
-    fn doctor_fails_without_contact_email() {
+    async fn doctor_fails_without_contact_email() {
         // Issue #149: a failing doctor is "missing config" → exit 2.
         // The human-readable line moved to stderr; the error now carries
         // a `CliExit(2)` rather than a Display-formatted anyhow string.
         let _g = unset_all_doiget_config_env();
-        let err = run("doctor".into(), crate::commands::output::OutputMode::Human)
-            .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
+        let err = run(
+            "doctor".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+        )
+        .await
+        .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
         let cli_exit = err
             .downcast_ref::<CliExit>()
             .expect("failing doctor must carry a CliExit (issue #149)");
@@ -488,15 +752,20 @@ mod tests {
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial_test::serial]
-    fn doctor_passes_with_contact_email() {
+    async fn doctor_passes_with_contact_email() {
         let _g = unset_all_doiget_config_env();
         let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
         // config_dir() and the cwd resolve to real, existing parents on every
         // supported test host (store root defaults to <cwd>/papers, ADR-0036).
-        run("doctor".into(), crate::commands::output::OutputMode::Human)
-            .expect("doctor should pass with contact email + valid config dir and cwd");
+        run(
+            "doctor".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+        )
+        .await
+        .expect("doctor should pass with contact email + valid config dir and cwd");
     }
 
     /// ADR-0028 D2: a malformed `<config_dir>/doiget/config.toml`
@@ -541,8 +810,13 @@ mod tests {
         // our crafted file.
         let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
 
-        let err = run("doctor".into(), crate::commands::output::OutputMode::Human)
-            .expect_err("doctor should fail when user-extension config is malformed");
+        let err = run(
+            "doctor".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+        )
+        .await
+        .expect_err("doctor should fail when user-extension config is malformed");
         let cli_exit = err
             .downcast_ref::<CliExit>()
             .expect("failing doctor must carry a CliExit");
@@ -569,15 +843,20 @@ mod tests {
         assert!(!flag, "all_ok must flip to false on a failing check");
     }
 
-    #[test]
+    #[tokio::test]
     #[serial_test::serial]
-    fn unknown_action_errors() {
+    async fn unknown_action_errors() {
         // Issue #149: an unknown action is clear argument misuse →
         // `docs/ERRORS.md` §4 exit 2. The descriptive line moved to
         // stderr; the error carries `CliExit(2)`.
         let _g = unset_all_doiget_config_env();
-        let err = run("bogus".into(), crate::commands::output::OutputMode::Human)
-            .expect_err("bogus action should error");
+        let err = run(
+            "bogus".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+        )
+        .await
+        .expect_err("bogus action should error");
         let cli_exit = err
             .downcast_ref::<CliExit>()
             .expect("unknown config action must carry a CliExit (issue #149)");

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -784,9 +784,9 @@ mod tests {
     /// test covers the wiring on the one platform where it CAN be
     /// exercised in a hermetic test.
     #[cfg(target_os = "linux")]
-    #[test]
+    #[tokio::test]
     #[serial_test::serial]
-    fn doctor_fails_with_malformed_user_extension_config() {
+    async fn doctor_fails_with_malformed_user_extension_config() {
         let _g = unset_all_doiget_config_env();
         let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
 
@@ -805,9 +805,10 @@ mod tests {
         )
         .expect("write config.toml");
 
-        // POSIX `dirs::config_dir()` honors `XDG_CONFIG_HOME` first,
-        // so pointing it at our tempdir routes `cfg.config_path` to
-        // our crafted file.
+        // `fetch::config_dir_utf8()` — which `ResolvedConfig` now shares
+        // with the reader — honors `XDG_CONFIG_HOME` first on every
+        // platform, so pointing it at our tempdir routes
+        // `cfg.config_path` to our crafted file.
         let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
 
         let err = run(

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -567,6 +567,13 @@ enum Command {
     Config {
         /// `show` / `path` / `doctor`
         action: String,
+        /// `doctor` only: also run the outbound network report — proxy
+        /// configuration, Unpaywall pool, allowlist coverage, and one
+        /// GET per well-known publisher to show which will talk to a
+        /// scripted client (issue #407). Opt-in because it makes real
+        /// requests.
+        #[arg(long)]
+        network: bool,
     },
     /// Expand a DOI's citation neighborhood via OpenAlex (BFS,
     /// ADR-0010 hard caps). Requires `--features citation` AND
@@ -753,7 +760,9 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
                 doiget_cli::commands::provenance::migrate(dry_run, mode)
             }
         },
-        Some(Command::Config { action }) => doiget_cli::commands::config::run(action, mode),
+        Some(Command::Config { action, network }) => {
+            doiget_cli::commands::config::run(action, mode, network).await
+        }
         Some(Command::Info { ref_ }) => {
             doiget_cli::commands::info::run(ref_, mode, out.quiet_was_explicit)
         }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -121,6 +121,23 @@ fn backoff_delay(attempt: u32) -> Duration {
 // ---------------------------------------------------------------------------
 
 /// Per-source allowlist entry. Matches the schema in
+/// What a [`HttpClient::probe`] observed (issue #407).
+///
+/// `body_bytes` is load-bearing, not decoration: a publisher WAF answers a
+/// scripted client with `202 Accepted` and an empty body, which a
+/// status-only report reads as success. Status plus body size separates
+/// "the publisher served me" from "the publisher is holding me at a bot
+/// challenge".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeOutcome {
+    /// HTTP status of the (post-redirect) response.
+    pub status: u16,
+    /// Bytes of body received.
+    pub body_bytes: usize,
+    /// Host of the final URL, after any allowlisted redirects.
+    pub final_host: Option<String>,
+}
+
 /// `docs/REDIRECT_ALLOWLIST.md` §2.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -770,6 +787,73 @@ impl HttpClient {
     /// Any [`HttpError`] variant including [`HttpError::NotAPdf`].
     pub async fn fetch_pdf(&self, source: &str, url: Url) -> Result<(Bytes, Url), HttpError> {
         self.fetch_inner(source, url, &[], true).await
+    }
+
+    /// Single diagnostic request against `url`, reporting what came back
+    /// instead of turning it into an error.
+    ///
+    /// This is the primitive behind `doiget config doctor --network`
+    /// (issue #407). It differs from [`Self::fetch_bytes`] in three ways
+    /// that matter for a diagnostic:
+    ///
+    /// - **Non-2xx is data, not failure.** "403" is the answer to the
+    ///   question the user is asking, so it comes back in
+    ///   [`ProbeOutcome::status`] rather than as `HttpError::HttpStatus`.
+    /// - **No retries.** A probe that silently retried would hide the
+    ///   very flakiness it is meant to expose, and would multiply load on
+    ///   a publisher for a question that is not a fetch.
+    /// - **The host is checked against the source allowlist up front.**
+    ///   A doctor that probed arbitrary user-supplied hosts would be an
+    ///   SSRF gadget wearing a diagnostic hat; the allowlist is the same
+    ///   one a real fetch would enforce, which is also what makes
+    ///   "not allowlisted" a meaningful answer.
+    ///
+    /// The body is read so that [`ProbeOutcome::body_bytes`] can
+    /// distinguish a real `200` from the `202` + empty-body holding
+    /// response publisher WAFs return to scripted clients — the case in
+    /// #407 that a status code alone cannot diagnose. The read is capped
+    /// by the same size limits as any other fetch.
+    ///
+    /// # Errors
+    ///
+    /// [`HttpError::UnknownSource`] if `source` is not registered,
+    /// [`HttpError::RedirectDenied`] if the host is off the allowlist
+    /// (before any request is sent), or [`HttpError::Network`] for a
+    /// transport failure — a timeout IS the diagnosis, so it is returned
+    /// rather than retried.
+    pub async fn probe(&self, source: &str, url: Url) -> Result<ProbeOutcome, HttpError> {
+        let client = self
+            .clients
+            .get(source)
+            .ok_or_else(|| HttpError::UnknownSource {
+                source_key: source.to_string(),
+            })?;
+        let host = url.host_str().unwrap_or_default().to_string();
+        let allow = self
+            .source_allowlist(source)
+            .ok_or_else(|| HttpError::UnknownSource {
+                source_key: source.to_string(),
+            })?;
+        if !allow.matches(&host) {
+            return Err(HttpError::RedirectDenied {
+                source_key: source.to_string(),
+                host,
+                expected_hosts: allow.redirect_hosts.clone(),
+            });
+        }
+        let response = client.get(url).send().await.map_err(HttpError::Network)?;
+        let status = response.status().as_u16();
+        let final_host = response.url().host_str().map(str::to_string);
+        let body_bytes = response
+            .bytes()
+            .await
+            .map(|b| b.len())
+            .map_err(HttpError::Network)?;
+        Ok(ProbeOutcome {
+            status,
+            body_bytes,
+            final_host,
+        })
     }
 
     async fn fetch_inner(

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -226,6 +226,54 @@ agreed = true
 
 If both env var and credentials.toml provide the same key, env var wins.
 
+## 6.1 Institutional networks: what works and what does not
+
+Being on a subscribing university network does **not** make paywalled content
+fetchable. Two independent things sit in the way, and only one of them is doiget's:
+
+1. **The allowlist.** IEEE, ACM, SIAM and AMS are not on the default `oa-publisher`
+   allowlist, so doiget will not attempt the publisher leg for them at all.
+2. **The publisher's bot wall.** Even from a subscribing address, a scripted client
+   commonly gets `202 Accepted` with an **empty body** — a challenge holding response,
+   not a paywall and not a 403. The subscription is not the binding constraint; being a
+   program is.
+
+So widening the allowlist alone would not fix such a fetch; it would move the failure
+one step later. `HTTPS_PROXY` is honoured (§4), but a proxy fixes *addressing*, never
+the bot wall — and if you are already on the subscribing network, tunnelling elsewhere
+routes you away from your entitlement.
+
+The two routes that do work:
+
+- **Per-publisher TDM credentials** (§6). This is the interface publishers intend
+  programs to use, and it sidesteps the WAF by not being the web front end.
+- **A real browser** on the subscribing network.
+
+`doiget config doctor --network` reports which of your publishers will actually talk to
+this client:
+
+```
+$ doiget config doctor --network
+network (--network):
+  egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)
+                  a proxy fixes addressing, never a bot wall
+  unpaywall       polite pool as you@institution.edu
+  oa-publisher    22 host patterns allowlisted
+  probe link.springer.com      200 3100 bytes    ok
+  probe arxiv.org              200 5854 bytes    ok
+  probe ieeexplore.ieee.org    not allowlisted   no request sent; ...
+  probe doaj.org               not allowlisted   no request sent; ...
+```
+
+The flag is opt-in because it makes real outbound requests: one GET per listed host, no
+retries, and only against hosts already on the allowlist — the probe enforces the same
+allowlist a fetch would, so it cannot be pointed at an arbitrary host. Hosts that are
+**not** allowlisted are still listed, reported as `not allowlisted` with no request
+sent; that line is usually the answer.
+
+`202` with an empty body is called out as a bot challenge rather than reported as a
+success, because a status code alone cannot distinguish the two.
+
 ## 7. Inspecting effective config
 
 ```sh

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -232,6 +232,54 @@ agreed = true
 
 If both env var and credentials.toml provide the same key, env var wins.
 
+## 6.1 Institutional networks: what works and what does not
+
+Being on a subscribing university network does **not** make paywalled content
+fetchable. Two independent things sit in the way, and only one of them is doiget's:
+
+1. **The allowlist.** IEEE, ACM, SIAM and AMS are not on the default `oa-publisher`
+   allowlist, so doiget will not attempt the publisher leg for them at all.
+2. **The publisher's bot wall.** Even from a subscribing address, a scripted client
+   commonly gets `202 Accepted` with an **empty body** — a challenge holding response,
+   not a paywall and not a 403. The subscription is not the binding constraint; being a
+   program is.
+
+So widening the allowlist alone would not fix such a fetch; it would move the failure
+one step later. `HTTPS_PROXY` is honoured (§4), but a proxy fixes *addressing*, never
+the bot wall — and if you are already on the subscribing network, tunnelling elsewhere
+routes you away from your entitlement.
+
+The two routes that do work:
+
+- **Per-publisher TDM credentials** (§6). This is the interface publishers intend
+  programs to use, and it sidesteps the WAF by not being the web front end.
+- **A real browser** on the subscribing network.
+
+`doiget config doctor --network` reports which of your publishers will actually talk to
+this client:
+
+```
+$ doiget config doctor --network
+network (--network):
+  egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)
+                  a proxy fixes addressing, never a bot wall
+  unpaywall       polite pool as you@institution.edu
+  oa-publisher    22 host patterns allowlisted
+  probe link.springer.com      200 3100 bytes    ok
+  probe arxiv.org              200 5854 bytes    ok
+  probe ieeexplore.ieee.org    not allowlisted   no request sent; ...
+  probe doaj.org               not allowlisted   no request sent; ...
+```
+
+The flag is opt-in because it makes real outbound requests: one GET per listed host, no
+retries, and only against hosts already on the allowlist — the probe enforces the same
+allowlist a fetch would, so it cannot be pointed at an arbitrary host. Hosts that are
+**not** allowlisted are still listed, reported as `not allowlisted` with no request
+sent; that line is usually the answer.
+
+`202` with an empty body is called out as a bot challenge rather than reported as a
+success, because a status code alone cannot distinguish the two.
+
 ## 7. Inspecting effective config
 
 ```sh


### PR DESCRIPTION
Refs #407 items 2 and 3, per your call to do the network doctor.

> **Stacked on #410.** Base is `fix/405-document-allowlist-knobs`, so the diff here is
> only this feature. Merge #410 first and this retargets to `next` cleanly; say the word
> and I will rebase it onto `next` standalone instead.

## What it does

```
$ doiget config doctor --network
[ ok ] store_root parent exists
[ ok ] contact_email set
[ ok ] user-extension hosts loaded: 0 (academic=false, oa_registries=false)

network (--network):
  egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)
                  a proxy fixes addressing, never a bot wall
  unpaywall       polite pool as you@institution.edu
  oa-publisher    22 host patterns allowlisted
  probe link.springer.com      200 3100 bytes    ok
  probe www.mdpi.com           403               reached, refused — subscription or credential
  probe arxiv.org              200 5854 bytes    ok
  probe ieeexplore.ieee.org    not allowlisted   no request sent; add the host or enable a trust flag
  probe dl.acm.org             not allowlisted   no request sent; ...
  probe doaj.org               not allowlisted   no request sent; ...
```

That is real output from this branch, not a mock.

## The load-bearing part is the classification, not the probe

Your measurement was `status=202 body=0 bytes` from a subscribing UTNET address. A report
that printed the status would call that a **success** and send the user off to debug a
subscription that is not the problem. So:

| observed | verdict |
|---|---|
| 2xx, non-empty | `ok` |
| **2xx, empty body** | **`bot challenge — needs a TDM key or a real browser`** |
| 401 / 403 | `reached, refused — subscription or credential` |
| other | `unexpected status` |
| off-allowlist | `not allowlisted`, no request sent |
| transport error | `unreachable <reason>` |

`ProbeVerdict::classify` is pure, so that judgement is unit-tested without a network or a
mock server. Four tests, including one that pins an empty `200` as a challenge too and
one that pins 401/403 as *not* a challenge (different next step).

Non-allowlisted hosts are still **listed**. For your case `probe ieeexplore.ieee.org
not allowlisted` is the entire answer, and it can only be printed for hosts named up front.

## `HttpClient::probe` — three deliberate differences from `fetch_bytes`

- **Non-2xx is data, not an error.** "403" is the answer to the question being asked.
- **No retries.** A probe that retried would hide the flakiness it exists to expose, and
  would multiply load on a publisher for something that is not a fetch.
- **Host checked against the source allowlist before anything is sent.** A doctor that
  probed arbitrary hosts would be an SSRF gadget wearing a diagnostic hat — and it is
  what makes `not allowlisted` a meaningful answer rather than a network error.

Body is read (capped as usual) purely so `body_bytes` can separate a real 200 from the
202-empty holding response.

## Egress is deliberately not probed

Getting the public address means asking a third-party echo service — a new outbound
dependency and a new `PRIVACY.md` entry, for a diagnostic. I did not want to make that
call unilaterally in a supply-chain-strict tool. The report names the proxy configuration
(what doiget actually knows), states that a proxy fixes addressing but never a bot wall,
and points at `curl` for the address. **Say the word if you want the echo-service
variant** — probably as `--egress` with a configurable endpoint, default off.

## Also here — item 3

`docs/CONFIG.md` §6.1 "Institutional networks: what works and what does not": IP-based
subscription does not imply fetchability; the two routes that work are per-publisher TDM
credentials and a real browser; a tunnel out of a subscribing network is counterproductive.

## Not here — item 1

`[tdm.ieee]` credentials. It is the right next step and the shape already exists
(`[tdm.elsevier]` / `[tdm.aps]` / `[tdm.springer]`), but it needs the actual IEEE TDM API
contract — endpoint, auth header, response shape, and terms — which I cannot verify from
here without signing up. Worth its own issue.

## Verification

- `cargo test --workspace` — 50 suites green
- `cargo clippy --workspace --all-targets` clean; `cargo fmt --all --check` clean
- Ran `config doctor --network` against the live network (output above), and confirmed
  `probe doaj.org` flips from `not allowlisted` to `200 793 bytes ok` with
  `trust_oa_registries = true` — end-to-end confirmation of both this and #410.
- `scripts/sync_docs_to_site.sh` re-run.

`config::run` becomes async to carry the probes (main already dispatches async); the flag
is rejected for `config show` / `config path`.