### PR TITLE
release: 0.8.7 (strip beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-## [0.8.7-beta.8] - 2026-08-22
+## [0.8.7] - 2026-08-22
+
+Security, allowlist visibility, and a network doctor. The two config keys that decide
+whether a fetch is allowed are finally documented and named in the denial that hits them;
+`doiget config doctor --network` answers "which publishers will actually talk to me?"; and
+a health check no longer creates the store it was only meant to inspect.
+
+### Security
+- **[deps]** Bump `h2` 0.4.14 → 0.4.18 for **RUSTSEC-2026-0258** /
+  GHSA-q83h-524g-xf6h ("h2 unbounded empty DATA frames", low severity, patched
+  in 0.4.16). `h2` is transitive via `reqwest`/`hyper`; doiget is an HTTP client
+  and does not accept inbound HTTP/2, so the DoS is not reachable from an
+  attacker-chosen peer in normal use — but the advisory made `cargo audit` and
+  `cargo deny` red on `next`, and the fix is a lockfile bump.
+- **[supply-chain]** Refresh the `cargo vet` exemption for `h2` to 0.4.18.
 
 ### Added
 - **[cli]** `doiget config doctor --network` — the outbound half of the report
@@ -27,10 +41,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[core]** New `HttpClient::probe` / `ProbeOutcome` behind the above.
 - **[docs]** `docs/CONFIG.md` §6.1 "Institutional networks: what works and what
   does not" — IP-based subscription does not imply fetchability (#407).
-
-## [0.8.7-beta.7] - 2026-08-22
-
-### Added
 - **[docs]** `docs/CONFIG.md` §3.1 documents the two `[network]` keys that decide
   whether a fetch is allowed — `trust_academic_repos` (the 15 curated academic
   suffixes) and `[[network.additional_hosts]]`. Both shipped in 0.8.0 but appeared
@@ -39,8 +49,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[docs]** `docs/CONFIG.md` §4 lists `DOIGET_CONTACT_EMAIL` and states what an
   unset contact address actually costs: Unpaywall is still queried, but with the
   `doiget@localhost` placeholder, i.e. from the non-polite pool (#405).
-
-### Added
 - **[network]** New opt-in `[network] trust_oa_registries = true`, the Gold-OA
   companion to `trust_academic_repos`. Adds a curated set of open-access
   **registries / repositories** — DOAJ, SciELO, Zenodo, OSF, HAL, CORE — to the
@@ -51,6 +59,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   routed through DOAJ was not reachable at all, which is backwards for an
   open-access tool (#405). Both the apex (`doaj.org`) and the wildcard are listed:
   a single-suffix wildcard does not match an apex, and DOAJ redirects to the apex.
+- **[cli]** `doiget config doctor` reports the **resolved** `store_root` path, and
+  notes that it is cwd-relative when `DOIGET_STORE_ROOT` is unset. Reporting only
+  "store_root parent exists" confirmed a path the user could not see (#406).
+- **[repo]** `.gitignore` ignores `papers/`.
 
 ### Changed
 - **[cli]** A `redirect_not_in_allowlist` denial now emits a `= help:` block naming
@@ -61,6 +73,33 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[cli]** `doiget config doctor` names the config file and both keys when nothing
   has widened the allowlist, instead of reporting a bare `trust_academic_repos=false`
   (#405).
+- **[mcp]** `doiget_expand_citation_graph` is no longer advertised in `tools/list`
+  when the binary was built without `--features citation`. It previously appeared in
+  every build and answered `NOT_IMPLEMENTED` to every call, so an agent could plan
+  around a tool it could never use. The route is now dropped in `Server::new` for
+  feature-off builds, which also makes `tools/call` report an unknown tool instead of
+  a dead end (#379, closing the open half of #373). The shipped `.mcpb` and the
+  Claude Desktop Extension enable the feature, so they are unaffected.
+- **[cli/refactor]** `print_err` moves to `commands::output` as a single
+  `pub(crate)` function. Ten command modules each carried a byte-identical
+  private copy with its own `#[allow(clippy::print_stderr)]`; the workspace
+  denies that lint to protect MCP stdio purity, so the exception is now
+  auditable in one place instead of ten (#346 item 2). Quality only — no
+  behaviour change; net −45 lines.
+- **[deps]** Bump `ulid` 1.2.1 → 3.0.0. Breaking upstream: `Ulid::new()` was removed
+  in favour of `Ulid::generate()`. Both call sites — the CLI and MCP `session_id`
+  generators — were updated; the emitted id is unchanged (26-char Crockford base32,
+  `docs/PROVENANCE_LOG.md` §3), which `new_session_id_is_26_chars` pins.
+- **[supply-chain]** `cargo vet` exemptions for `ulid` 3.0.0 and its new random
+  backend (`rand` 0.10.2, `rand_core` 0.10.1, `chacha20` 0.10.1). `rand` 0.9.4 stays
+  in the tree for other consumers, so its exemption is kept alongside.
+- **[deps]** Bump `rustls` 0.23.41 → 0.23.42 (patch release; no API change, no
+  advisory — `cargo audit` / `cargo deny` stay green).
+- **[supply-chain]** Refresh the `cargo vet` exemptions in
+  `supply-chain/config.toml` to match the current lockfile (`rustls` 0.23.42,
+  plus `bytes` 1.12.1, `quick-xml` 0.41.0, `rmcp` / `rmcp-macros` 2.2.0 and
+  `uuid` 1.23.5, which had already landed on `next`), so `cargo vet --locked`
+  is green again.
 
 ### Fixed
 - **[cli]** `doiget config show` / `config path` / `config doctor` now resolve
@@ -70,10 +109,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   variable set — normal for cross-platform dotfiles — had `doiget fetch` read one
   `config.toml` while `doiget config doctor` validated a different one and reported
   "user-extension hosts loaded: 0" about a file the fetch path never opened (#405).
-
-## [0.8.7-beta.6] - 2026-08-22
-
-### Fixed
 - **[mcp]** `doiget_health` no longer creates the store root. Its `store_writable`
   probe called `create_dir_all`, so a tool annotated `read_only_hint = true`
   materialised `papers/` in whatever directory the server was started from —
@@ -84,68 +119,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   Three `doiget_metadata_only` tests did not pin `DOIGET_STORE_ROOT`, so their
   records landed in the ADR-0036 cwd default — the crate directory. `papers/` was
   not in `.gitignore`, so a `git add -A` would have committed them (#406).
-
-### Added
-- **[cli]** `doiget config doctor` reports the **resolved** `store_root` path, and
-  notes that it is cwd-relative when `DOIGET_STORE_ROOT` is unset. Reporting only
-  "store_root parent exists" confirmed a path the user could not see (#406).
-- **[repo]** `.gitignore` ignores `papers/`.
-
-## [0.8.7-beta.5] - 2026-08-22
-
-### Changed
-- **[mcp]** `doiget_expand_citation_graph` is no longer advertised in `tools/list`
-  when the binary was built without `--features citation`. It previously appeared in
-  every build and answered `NOT_IMPLEMENTED` to every call, so an agent could plan
-  around a tool it could never use. The route is now dropped in `Server::new` for
-  feature-off builds, which also makes `tools/call` report an unknown tool instead of
-  a dead end (#379, closing the open half of #373). The shipped `.mcpb` and the
-  Claude Desktop Extension enable the feature, so they are unaffected.
-
-## [0.8.7-beta.4] - 2026-08-22
-
-### Changed
-- **[cli/refactor]** `print_err` moves to `commands::output` as a single
-  `pub(crate)` function. Ten command modules each carried a byte-identical
-  private copy with its own `#[allow(clippy::print_stderr)]`; the workspace
-  denies that lint to protect MCP stdio purity, so the exception is now
-  auditable in one place instead of ten (#346 item 2). Quality only — no
-  behaviour change; net −45 lines.
-
-## [0.8.7-beta.3] - 2026-08-22
-
-### Changed
-- **[deps]** Bump `ulid` 1.2.1 → 3.0.0. Breaking upstream: `Ulid::new()` was removed
-  in favour of `Ulid::generate()`. Both call sites — the CLI and MCP `session_id`
-  generators — were updated; the emitted id is unchanged (26-char Crockford base32,
-  `docs/PROVENANCE_LOG.md` §3), which `new_session_id_is_26_chars` pins.
-- **[supply-chain]** `cargo vet` exemptions for `ulid` 3.0.0 and its new random
-  backend (`rand` 0.10.2, `rand_core` 0.10.1, `chacha20` 0.10.1). `rand` 0.9.4 stays
-  in the tree for other consumers, so its exemption is kept alongside.
-
-## [0.8.7-beta.2] - 2026-08-22
-
-### Security
-- **[deps]** Bump `h2` 0.4.14 → 0.4.18 for **RUSTSEC-2026-0258** /
-  GHSA-q83h-524g-xf6h ("h2 unbounded empty DATA frames", low severity, patched
-  in 0.4.16). `h2` is transitive via `reqwest`/`hyper`; doiget is an HTTP client
-  and does not accept inbound HTTP/2, so the DoS is not reachable from an
-  attacker-chosen peer in normal use — but the advisory made `cargo audit` and
-  `cargo deny` red on `next`, and the fix is a lockfile bump.
-- **[supply-chain]** Refresh the `cargo vet` exemption for `h2` to 0.4.18.
-
-## [0.8.7-beta.1] - 2026-07-14
-
-Dependency maintenance — first beta of the 0.8.7 line (retargeted off the 0.8.6 stable).
-
-### Changed
-- **[deps]** Bump `rustls` 0.23.41 → 0.23.42 (patch release; no API change, no
-  advisory — `cargo audit` / `cargo deny` stay green).
-- **[supply-chain]** Refresh the `cargo vet` exemptions in
-  `supply-chain/config.toml` to match the current lockfile (`rustls` 0.23.42,
-  plus `bytes` 1.12.1, `quick-xml` 0.41.0, `rmcp` / `rmcp-macros` 2.2.0 and
-  `uuid` 1.23.5, which had already landed on `next`), so `cargo vet --locked`
-  is green again.
 
 ## [0.8.6] - 2026-06-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7-beta.8"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7-beta.8"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7-beta.8"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7-beta.8"
+version       = "0.8.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "doiget",
   "display_name": "doiget",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
   "long_description": "doiget is a single-binary, stdio MCP server that turns DOIs and arXiv IDs into local PDFs and structured metadata through official Open-Access APIs (Crossref, Unpaywall, arXiv, OpenAlex). It never bypasses paywalls and makes no network call that is not the direct result of a fetch you ask for. PDFs and metadata are saved to a local store; nothing is redistributed or phoned home. It is the agent-facing companion to BiblioFetch.jl and shares the same on-disk paper store.",
   "author": {


### PR DESCRIPTION
Release cut for **0.8.7**, per the ADR-0025 lane flow: strip the beta on `next` first, then
open the `next` → `main` promotion once this lands.

## Changes

- `0.8.7-beta.8` → `0.8.7` in `Cargo.toml` (4 sites), `Cargo.lock` (3), and
  **`mcpb/manifest.json`** — the manifest is required for release-version-gate **G6**
  (prerelease consistency: tag has `-PRE` ⇔ manifest has `-PRE`), and it is the one version
  site the per-PR bump gate does not touch, so it was still on 0.8.6.
- The eight `## [0.8.7-beta.N]` CHANGELOG sections are consolidated into one
  `## [0.8.7] - 2026-08-22`. All 21 bullets are carried over **verbatim** and regrouped:
  2 Security / 8 Added / 8 Changed / 3 Fixed. Required for **G5** (non-empty `## [X.Y.Z]`).

## Expected red

`version-bump (ADR-0033)` will fail — a beta strip is not a `beta.N+1` step. That is the
documented release-cut exception, and the check is advisory, not required.

## Verified locally

- `cargo metadata --locked` succeeds → **G2** (lockfile in sync).
- `cargo test --workspace` — 50 suites green.
- `mcpb/manifest.json` version is a clean `0.8.7` → **G6**.
- `## [0.8.7]` section is non-empty → **G5**.

G3/G4 (not yet on crates.io, strictly greater than the published 0.8.6) and G7 (signed,
annotated tag reachable from `main`) are checked at tag time.