### PR TITLE
fix(cli,mcp): two path-resolution bugs found reviewing the 0.8.7 promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,16 @@ a health check no longer creates the store it was only meant to inspect.
   is green again.
 
 ### Fixed
+- **[cli]** The `redirect_not_in_allowlist` `= help:` line names the `config.toml`
+  the **reader** actually loads. `user_config_path` used `dirs::config_dir()`, which
+  ignores `XDG_CONFIG_HOME` on Windows, so on a machine with cross-platform dotfiles
+  the denial pointed at a file `doiget fetch` never opened — the same drift already
+  fixed for `config show` / `path` / `doctor`. Naming the wrong file is worse than
+  naming none (#405).
+- **[mcp]** `doiget_health`'s `store_writable` probe handles a relative
+  `DOIGET_STORE_ROOT`. The ancestor walk bottomed out at `""` and answered `false`
+  for a directory a write would happily create; `""` now resolves against the cwd,
+  matching the pre-#406 behaviour (#406).
 - **[cli]** `doiget config show` / `config path` / `config doctor` now resolve
   `config.toml` through the same resolver the reader uses
   (`fetch::config_dir_utf8`) instead of `dirs::config_dir()`. The two diverged:

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1577,6 +1577,50 @@ host = "*.uj.edu.pl"
         }
     }
 
+    /// The `= help:` line names a file for the user to edit, so it MUST be
+    /// the file `build_http_client` actually reads. `user_config_path` used
+    /// `dirs::config_dir()`, which ignores `XDG_CONFIG_HOME` on Windows —
+    /// so on a machine with cross-platform dotfiles the denial pointed at a
+    /// `config.toml` the fetch path never opened. Naming the wrong file is
+    /// worse than naming none.
+    #[test]
+    #[serial]
+    fn denial_help_names_the_file_the_reader_loads() {
+        struct EnvGuard(&'static str, Option<String>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.1 {
+                    Some(v) => std::env::set_var(self.0, v),
+                    None => std::env::remove_var(self.0),
+                }
+            }
+        }
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let _g: Vec<EnvGuard> = ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"]
+            .iter()
+            .map(|k| EnvGuard(k, std::env::var(k).ok()))
+            .collect();
+        std::env::set_var("XDG_CONFIG_HOME", td.path());
+
+        let reader = super::config_dir_utf8()
+            .expect("reader resolves")
+            .join("doiget")
+            .join("config.toml");
+        let helped = crate::commands::user_config_path().expect("help path resolves");
+        assert_eq!(
+            helped, reader,
+            "the denial help must name the config.toml the reader loads"
+        );
+
+        let mut dc = denial(DenialReason::RedirectNotInAllowlist);
+        dc.attempted = Some("strathprints.strath.ac.uk".to_string());
+        let joined = denial_note_lines(&dc, Some(helped.as_path())).join("\n");
+        assert!(
+            joined.contains(reader.as_str()),
+            "rendered help must carry that path; got:\n{joined}"
+        );
+    }
+
     // ── #405: the denial must name the knob that unblocks it ─────────────
 
     /// A `redirect_not_in_allowlist` denial is not "this host is forbidden",

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -63,8 +63,18 @@ use camino::Utf8PathBuf;
 /// callers should fall back to naming the file generically — a missing
 /// config dir must never turn an advisory line into a hard error.
 pub(crate) fn user_config_path() -> Option<Utf8PathBuf> {
-    let cfg = Utf8PathBuf::try_from(dirs::config_dir()?).ok()?;
-    Some(cfg.join("doiget").join("config.toml"))
+    // MUST stay `config_dir_utf8` — the resolver the READER uses. This
+    // shipped as `dirs::config_dir()`, which ignores `XDG_CONFIG_HOME` on
+    // Windows, so the denial help named `%APPDATA%\doiget\config.toml`
+    // while `build_http_client` was loading the XDG one. Naming the wrong
+    // file is worse than naming none, and it is the whole point of the
+    // #405 help line. Same fix as `ResolvedConfig::from_env`.
+    Some(
+        fetch::config_dir_utf8()
+            .ok()?
+            .join("doiget")
+            .join("config.toml"),
+    )
 }
 
 /// Resolve the on-disk store root.

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4000,7 +4000,17 @@ fn resolve_store_root() -> Option<Utf8PathBuf> {
 fn probe_store_writable(path: &camino::Utf8Path) -> bool {
     let mut cur = Some(path);
     while let Some(p) = cur {
-        match std::fs::metadata(p.as_std_path()) {
+        // A relative root (`DOIGET_STORE_ROOT=papers`) walks up to `""`,
+        // whose implicit base is the current directory — stat that rather
+        // than reporting the root unwritable. `docs/CONFIG.md` §4 asks for
+        // absolute paths, but answering "not writable" for a directory we
+        // would happily create is a worse failure than being lenient.
+        let probe = if p.as_str().is_empty() {
+            camino::Utf8Path::new(".")
+        } else {
+            p
+        };
+        match std::fs::metadata(probe.as_std_path()) {
             Ok(md) => return md.is_dir() && !md.permissions().readonly(),
             // Not found (or not statable) — try the parent. `parent()`
             // yields `None` at the root, which ends the walk.
@@ -4117,6 +4127,26 @@ mod tests {
     /// An existing store root reports writable, and a path whose nearest
     /// existing ancestor is a FILE reports not-writable — a file cannot
     /// hold a store, so `true` there would be a lie the first write pays for.
+    /// A relative `DOIGET_STORE_ROOT` walks up to `""`, whose implicit base
+    /// is the cwd. Reporting it unwritable would be wrong — a write there
+    /// succeeds — and the pre-#406 `create_dir_all` probe got this right.
+    #[test]
+    fn probe_store_writable_handles_a_relative_root() {
+        // `papers` (no `./`) is the case that exhausts the walk.
+        assert!(
+            probe_store_writable(camino::Utf8Path::new("papers")),
+            "a bare relative root resolves against the cwd, which is writable"
+        );
+        assert!(
+            probe_store_writable(camino::Utf8Path::new("./papers")),
+            "the dotted form must agree with the bare form"
+        );
+        assert!(
+            !camino::Utf8Path::new("papers").exists(),
+            "still creates nothing"
+        );
+    }
+
     #[test]
     fn probe_store_writable_distinguishes_dir_from_file() {
         let td = tempfile::TempDir::new().expect("tempdir");


### PR DESCRIPTION
Found while reviewing #423. Both are in code cut for **0.8.7**, so the version stays
`0.8.7` and the entries fold into the existing `## [0.8.7]` CHANGELOG section rather than
opening a new beta. `version-bump` will be red for the same reason the release cut was —
advisory, not required.

## 1. The #405 denial help named the wrong file (the more serious one)

`user_config_path` — the resolver behind the `= help:` line — still used
`dirs::config_dir()`, while the code that actually loads the file
(`build_http_client` → `fetch::config_dir_utf8`) checks `XDG_CONFIG_HOME` first. On
Windows `dirs::config_dir()` goes through the known-folder API and ignores that
variable, so a user with cross-platform dotfiles was told:

```
= help: that host is not on the allowlist yet; widen it in C:\Users\x\AppData\Roaming\doiget\config.toml
```

…while `doiget fetch` was reading `$XDG_CONFIG_HOME/doiget/config.toml`. They edit the
named file, nothing changes.

This is the same drift I fixed in #410 for `config show` / `path` / `doctor` — I missed
the one place where it matters most. The whole value of that help line is that the path
is right; naming the wrong file is worse than naming none.

## 2. The #406 store probe was wrong for a relative root

The ancestor walk bottoms out at `""` for `DOIGET_STORE_ROOT=papers` and returned
`false` — reporting a directory unwritable that a write would happily create. The
`create_dir_all` probe it replaced got this right, so it is a regression from #419.
`""` now resolves against the cwd.

`docs/CONFIG.md` §4 does ask for absolute paths, so this is out-of-contract input —
but of the two ways to be wrong, "not writable" for a writable location is the worse one.
Note `./papers` was already fine (its parent `.` exists); only the bare form broke.

## Tests

- `denial_help_names_the_file_the_reader_loads` — asserts `user_config_path()` equals the
  reader's resolution under `XDG_CONFIG_HOME`, and that the rendered help carries it.
- `probe_store_writable_handles_a_relative_root` — bare and dotted forms both writable,
  and still creates nothing.

## Verification

`fmt --check`, `clippy` on both feature sets, `rustdoc -D warnings`, and
`cargo test --workspace` (50 suites) all clean locally. Also re-ran the
"non-async fn containing `.await`" scan that caught the ubuntu-only breakage earlier —
clean.

Merging this updates #423 automatically, since its head is `next`.