### PR TITLE
fix(ci): give cargo-audit the same ignore list as cargo-deny

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration.
+#
+# Mirrors the `[advisories] ignore` list in `deny.toml`. The two tools do not
+# share config: `cargo deny` reads `deny.toml`, `cargo audit` reads this file,
+# and neither reads the other's. Keeping only `deny.toml` meant `cargo audit`
+# re-reported an advisory the project had already assessed and accepted.
+#
+# It surfaced asymmetrically: `rustsec/audit-check` treats an informational
+# warning as fatal on a `push` event but not on `pull_request`, so every PR was
+# green and `main` went red the moment the 0.8.7 promotion landed.
+#
+# Any entry added here MUST also be in `deny.toml`, with the same rationale.
+
+[advisories]
+ignore = [
+    # paste — RUSTSEC-2024-0436: UNMAINTAINED (not a vulnerability). Pulled
+    # transitively by `biblatex` (the ADR-0030 D2 `.bib` parser, #258), a
+    # maintained, load-bearing dependency with no drop-in replacement.
+    # `paste` is a compile-time-only proc-macro (no runtime / network
+    # surface), so an unmaintained advisory carries no security exposure
+    # here. Revisit if biblatex drops it or adopts a maintained fork.
+    "RUSTSEC-2024-0436",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.1] - 2026-08-22
+
+### Fixed
+- **[ci]** Add `.cargo/audit.toml` mirroring the `[advisories] ignore` list in
+  `deny.toml`. The two tools do not share configuration — `cargo deny` reads
+  `deny.toml`, `cargo audit` reads `.cargo/audit.toml` — so the already-assessed
+  `paste` unmaintained advisory (RUSTSEC-2024-0436) was suppressed for one and
+  re-reported by the other. It stayed invisible because `rustsec/audit-check`
+  treats an informational warning as fatal on `push` but not on `pull_request`:
+  every PR was green while `main` had been red since 2026-08-10.
+
 ## [0.8.7] - 2026-08-22
 
 Security, allowlist visibility, and a network doctor. The two config keys that decide

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7"
+version = "0.8.8-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7"
+version = "0.8.8-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7"
+version = "0.8.8-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7"
+version       = "0.8.8-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
`main` has been red on `cargo audit` since **2026-08-10** — before any of today's work — on
**zero vulnerabilities**:

```
No vulnerabilities were found
Found 1 unmaintained
RUSTSEC-2024-0436  paste 1.0.15  "no longer maintained"
```

## Why it was invisible

Two independent reasons stacked:

1. **`cargo deny` and `cargo audit` do not share configuration.** `deny.toml` has ignored
   RUSTSEC-2024-0436 since #258 (it is a compile-time-only proc-macro from `biblatex`, no
   runtime or network surface). `cargo audit` reads `.cargo/audit.toml`, which did not
   exist, so it re-reported an advisory the project had already assessed.
2. **`rustsec/audit-check` treats an informational warning as fatal on `push` but not on
   `pull_request`.** So every PR was green and only `main` was red. Verified against the
   runs: #421 and #423 both logged the identical `Found 1 unmaintained` and both **passed**.

## Change

`.cargo/audit.toml` with the same single entry and the same rationale, plus a note in the
file that it must be kept in step with `deny.toml`.

No dependency change, no code change.

## Note

This opens the **0.8.8 beta lane** (`0.8.7` → `0.8.8-beta.1`), first of the batch clearing
the remaining issues.

One thing worth flagging for whoever reviews the lane: bumping a *clean* `0.8.7` is more
dangerous than bumping `0.8.7-beta.N`, because `0.8.7` is not a unique string in
`Cargo.lock` — `core-foundation-sys` happens to be at 0.8.7 too. A blanket replace
corrupts it, and `cargo metadata --locked` is what catches it. This PR bumps only the three
workspace crates, matched by name.