### PR TITLE
feat(docs,network): settle four deferred decisions as ADRs 0037-0040

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.2] - 2026-08-22
+
+### Changed
+- **[network]** `doaj.org` / `*.doaj.org` are on the **default** `oa-publisher`
+  allowlist (ADR-0037). They were already trusted under the `doaj` *metadata*
+  source key, which the CLI wires in only under `#[cfg(feature = "citation")]`, so
+  the two keys disagreed about a host the project had already accepted and a stock
+  build could not reach it at all. Promoted on the ADR-0027 precedent that made
+  `*.aps.org` unconditional. A gold-OA article routed through DOAJ now works with
+  no configuration (#405).
+- **[network]** DOAJ is removed from the `trust_oa_registries` curated set — it no
+  longer needs a flag. The remaining five (SciELO, Zenodo, OSF, HAL, CORE) appear
+  nowhere in `http.rs`, so for them the flag is genuinely new trust and stays
+  opt-in (#405).
+- **[docs]** `metadata` is redefined in `SOURCES.md` §3 and `CAPABILITY.md` as the
+  optional non-Tier-1 source surface as a whole — enrichment, resolution and
+  retrieval — with the runtime `DOIGET_ENABLE_<NAME>` flags, not the Cargo feature,
+  as the boundary that keeps sources inert (ADR-0040, #413).
+
+### Added
+- **[docs]** ADR-0037 (DOAJ on `oa-publisher`), ADR-0038 (store root stays
+  cwd-relative; 0036 reaffirmed against #406), ADR-0039 (IEEE / ACM / SIAM / AMS
+  stay off the allowlist; TDM credentials are the route, #407), ADR-0040 (source
+  expansion gated by `metadata`, #413).
+
 ## [0.8.8-beta.1] - 2026-08-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.1"
+version = "0.8.8-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.1"
+version = "0.8.8-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.1"
+version = "0.8.8-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.1"
+version       = "0.8.8-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1373,13 +1373,16 @@ host = "*.uj.edu.pl"
             .source_allowlist("oa-publisher")
             .expect("oa-publisher source registered");
 
+        // ADR-0037: DOAJ is a DEFAULT allowlist entry now, so it is not
+        // evidence that the flag worked. Assert on a host only the flag can
+        // provide.
         assert!(
-            oa.matches("doaj.org"),
-            "the apex that denied 10.1109/access.2024.3495502 MUST match; got {:?}",
+            oa.matches("zenodo.org"),
+            "the zenodo apex must match with the flag set; got {:?}",
             oa.redirect_hosts
         );
-        assert!(oa.matches("www.doaj.org"), "wildcard covers subdomains");
-        assert!(oa.matches("zenodo.org"), "zenodo apex must match");
+        assert!(oa.matches("data.zenodo.org"), "wildcard covers subdomains");
+        assert!(oa.matches("hal.science"), "hal apex must match");
         assert!(
             oa.redirect_hosts.iter().any(|p| p == "*.aps.org"),
             "the curated allowlist MUST survive the merge"

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -432,6 +432,20 @@ pub fn oa_publisher_allowlist() -> Vec<SourceAllowlist> {
             "*.scipost.org".to_string(),
             // IOP Publishing — iopscience.iop.org (New J. Phys. etc.).
             "*.iop.org".to_string(),
+            // DOAJ — the canonical redirect host for gold-OA journal
+            // content. ADR-0037: this domain was ALREADY trusted in this
+            // file under the `"doaj"` metadata key (`tier_2_allowlist`),
+            // which the CLI wires in only under
+            // `#[cfg(feature = "citation")]` — so the two keys disagreed
+            // about a host the project had already accepted, and a stock
+            // build could not reach it at all. Promoted here on the
+            // ADR-0027 precedent that made `*.aps.org` unconditional
+            // rather than feature-gated. The apex is listed separately
+            // because a single-suffix wildcard does not match it and the
+            // observed redirect (10.1109/access.2024.3495502, #405)
+            // targeted the bare apex.
+            "doaj.org".to_string(),
+            "*.doaj.org".to_string(),
             // arXiv — already on the `arxiv` tier-1 allowlist, but the
             // Unpaywall-driven path uses the `oa-publisher` source key,
             // so we mirror the host list here too. See REDIRECT_ALLOWLIST.md
@@ -1376,6 +1390,52 @@ fn build_client(allowlist: SourceAllowlist, ua: &str) -> Result<Client, reqwest:
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// ADR-0037: `doaj.org` must be reachable on the `oa-publisher` key with
+    /// NO config file and NO feature flags — that is the whole point of
+    /// promoting it. Pinned on the apex specifically: a single-suffix
+    /// wildcard does not match an apex, and the redirect that motivated
+    /// #405 (10.1109/access.2024.3495502, IEEE Access gold OA) targeted the
+    /// bare apex.
+    #[test]
+    fn doaj_is_on_the_default_oa_publisher_allowlist() {
+        let lists = oa_publisher_allowlist();
+        let oa = lists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .expect("oa-publisher entry");
+        assert!(
+            oa.matches("doaj.org"),
+            "apex must match: {:?}",
+            oa.redirect_hosts
+        );
+        assert!(oa.matches("www.doaj.org"), "subdomains must match");
+        assert!(
+            !oa.matches("doaj.org.evil.test"),
+            "suffix confusion must not match"
+        );
+    }
+
+    /// The `"doaj"` metadata key and the `"oa-publisher"` PDF-redirect key
+    /// must now agree about DOAJ. Their disagreement was the defect ADR-0037
+    /// fixed; this pins that they cannot silently drift apart again.
+    #[test]
+    fn doaj_metadata_and_oa_publisher_keys_agree() {
+        let meta = tier_2_allowlist();
+        let doaj = meta.iter().find(|a| a.source == "doaj").expect("doaj key");
+        let lists = oa_publisher_allowlist();
+        let oa = lists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .expect("oa key");
+        for pat in &doaj.redirect_hosts {
+            let sample = pat.strip_prefix("*.").unwrap_or(pat);
+            assert!(
+                oa.matches(sample),
+                "{pat} is trusted on the doaj key but not on oa-publisher"
+            );
+        }
+    }
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -379,9 +379,14 @@ pub fn academic_repo_hosts() -> Vec<UserExtensionHost> {
 ///
 /// Why this exists: the default allowlist covers publishers, so a Green-OA
 /// copy on an institutional repository was reachable behind one flag while
-/// a Gold-OA article routed through DOAJ was not reachable at all. For an
-/// open-access tool that polarity is backwards — `10.1109/access.2024.3495502`
-/// (IEEE Access, gold OA) is denied at `doaj.org` on a stock install.
+/// cross-publisher OA registries were not reachable at all.
+///
+/// DOAJ is deliberately NOT in this set. ADR-0037 promoted `doaj.org` to the
+/// default `oa_publisher_allowlist` unconditionally, because the project had
+/// already trusted it under the `"doaj"` metadata key and the two keys simply
+/// disagreed. The hosts below are different: none of them appears anywhere in
+/// `http.rs`, so for them this flag is genuinely new trust and opt-in is
+/// correct.
 ///
 /// Every entry is a registry or repository whose *purpose* is open
 /// distribution, not a publisher platform — enabling this must not become
@@ -391,8 +396,6 @@ pub fn academic_repo_hosts() -> Vec<UserExtensionHost> {
 /// redirect in #405 targeted the bare apex.
 pub fn oa_registry_hosts() -> Vec<UserExtensionHost> {
     const PATTERNS: &[(&str, &str)] = &[
-        ("doaj.org", "DOAJ — Directory of Open Access Journals"),
-        ("*.doaj.org", "DOAJ subdomains"),
         ("scielo.org", "SciELO — Latin American / Iberian OA network"),
         ("*.scielo.org", "SciELO national portals"),
         ("*.scielo.br", "SciELO Brazil"),
@@ -1031,7 +1034,7 @@ host = "*.uj.edu.pl"
         );
         for h in &hosts {
             // Every entry must survive the ADR-0028 D2-1 validator. Unlike
-            // the academic set these include bare apexes (`doaj.org`), so
+            // the academic set these include bare apexes (`osf.io`), so
             // the assertion is validity, not wildcard shape.
             validate_pattern(h.host.as_str()).unwrap_or_else(|e| {
                 panic!("invalid OA registry pattern {}: {e:?}", h.host.as_str())
@@ -1044,14 +1047,26 @@ host = "*.uj.edu.pl"
         }
     }
 
-    /// The denial that motivated #405 targeted the bare apex `doaj.org`.
-    /// A single-suffix wildcard does not match an apex, so the apex MUST be
-    /// listed separately or the flag would not fix the reported case.
+    /// ADR-0037 moved DOAJ out of this set and into the DEFAULT
+    /// `oa_publisher_allowlist`, so the flag must NOT carry it — otherwise
+    /// the two places disagree again, in the other direction.
     #[test]
-    fn oa_registry_hosts_cover_the_doaj_apex_that_motivated_405() {
+    fn oa_registry_hosts_exclude_doaj_which_is_now_a_default() {
         let hosts = oa_registry_hosts();
         let patterns: Vec<&str> = hosts.iter().map(|h| h.host.as_str()).collect();
-        for expected in &["doaj.org", "*.doaj.org", "scielo.org", "zenodo.org"] {
+        for gone in &["doaj.org", "*.doaj.org"] {
+            assert!(
+                !patterns.contains(gone),
+                "{gone} belongs to oa_publisher_allowlist since ADR-0037, not to this flag;                  got {patterns:?}"
+            );
+        }
+        for expected in &[
+            "scielo.org",
+            "zenodo.org",
+            "osf.io",
+            "hal.science",
+            "core.ac.uk",
+        ] {
             assert!(
                 patterns.contains(expected),
                 "expected OA registry pattern {expected} not found in {patterns:?}"

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -157,6 +157,13 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 
 | Variable | Type | Effect |
 |---|---|---|
+> **The `metadata` Cargo feature vs. these variables (ADR-0040, NORMATIVE).** The
+> feature decides what is *compiled*; the variables below decide what is *reachable*.
+> As of 0.8.8 `metadata` gates the whole optional non-Tier-1 source surface —
+> enrichment, resolution and retrieval — and release binaries compile it in. A source
+> is inert until its own `DOIGET_ENABLE_<NAME>` is set, so with all of them unset the
+> binary behaves exactly as a Tier-1-only build.
+
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -59,7 +59,7 @@ total_timeout_sec = 300
 # Without them, an OA PDF hosted off the built-in allowlist is denied with
 # `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
 trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
-trust_oa_registries  = false   # true = also allow the curated OA registries (DOAJ, SciELO, ...)
+trust_oa_registries  = false   # true = also allow the curated OA registries (SciELO, Zenodo, ...)
 
 [[network.additional_hosts]]
 host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
@@ -123,20 +123,21 @@ trust_academic_repos = true
 `trust_oa_registries = true` activates the OA-registry set:
 
 ```
-doaj.org      *.doaj.org      scielo.org    *.scielo.org   *.scielo.br
+scielo.org    *.scielo.org    *.scielo.br
 zenodo.org    *.zenodo.org    osf.io        *.osf.io
 hal.science   *.hal.science   core.ac.uk
 ```
 
 Every entry is a registry or repository whose *purpose* is open distribution, never a
 publisher platform — turning this on must not become a way to reach paywalled content.
-Note that both the apex (`doaj.org`) and the wildcard (`*.doaj.org`) appear: a
-single-suffix wildcard does **not** match the apex, and DOAJ redirects to the apex.
+Note that both the apex and the wildcard are listed where the apex serves content: a
+single-suffix wildcard does **not** match the apex.
 
-Without this flag a Gold-OA article routed through DOAJ — e.g. IEEE Access
-`10.1109/access.2024.3495502` — is denied on a stock install, while a Green-OA copy on
-an institutional repository is reachable behind `trust_academic_repos`. For an
-open-access tool that polarity is backwards, which is why the flag exists.
+**DOAJ is not in this set — it needs no flag.** `doaj.org` is on the *default*
+allowlist as of 0.8.8 (ADR-0037), because the project already trusted it under the
+`doaj` metadata source key and the two keys simply disagreed. So a Gold-OA article
+routed through DOAJ — e.g. IEEE Access `10.1109/access.2024.3495502` — works on a
+stock install with no configuration at all.
 
 `[[network.additional_hosts]]` is for anything outside either set. A pattern is either a
 literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
@@ -150,8 +151,8 @@ host = "*.uj.edu.pl"
 note = "Jagiellonian University repository"
 
 [[network.additional_hosts]]
-host = "doaj.org"
-note = "DOAJ — common redirect target for gold-OA journal content"
+host = "repository.example.edu"
+note = "a repository outside both curated sets"
 ```
 
 Run `doiget config doctor` to confirm what was loaded:
@@ -262,7 +263,7 @@ network (--network):
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...
-  probe doaj.org               not allowlisted   no request sent; ...
+  probe doaj.org               200 793 bytes     ok
 ```
 
 The flag is opt-in because it makes real outbound requests: one GET per listed host, no

--- a/docs/DECISIONS/0037-doaj-on-oa-publisher.md
+++ b/docs/DECISIONS/0037-doaj-on-oa-publisher.md
@@ -1,0 +1,81 @@
+# 0037 - `doaj.org` on `oa-publisher` unconditionally; `trust_oa_registries` for the rest
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (amends the `docs/REDIRECT_ALLOWLIST.md` §3.4 NORMATIVE host set, in the manner of [0027](0027-redirect-allowlist-society-hosts.md))
+- **Source:** #405 item 3, #409 (which found the asymmetry), #410
+
+## Context
+
+0.8.7 shipped `[network] trust_oa_registries` (#410), an opt-in flag adding a
+curated set of OA registries — DOAJ, SciELO, Zenodo, OSF, HAL, CORE — to the
+allowlist. It was chosen over widening the default because widening a default
+supply-chain posture deserves an ADR, and there was not one.
+
+#409 then established a fact that changes the DOAJ half of that argument:
+
+```rust
+// crates/doiget-core/src/http.rs, tier_2_allowlist()
+SourceAllowlist::new("doaj", vec!["doaj.org".to_string(), "*.doaj.org".to_string()]),
+```
+
+**`doaj.org` is already trusted in this codebase.** Just under the `"doaj"`
+*metadata* source key, not under `"oa-publisher"` — the key a Unpaywall-discovered
+PDF redirect is actually checked against. And `tier_2_allowlist()` is wired into
+the CLI only under `#[cfg(feature = "citation")]`, so in a stock `cargo install`
+build that trust is not reachable at all.
+
+So the question is not "should doiget extend trust to DOAJ" — the project already
+decided it trusts DOAJ. It is "why do two keys disagree about a host we have
+already accepted".
+
+[ADR-0027](0027-redirect-allowlist-society-hosts.md) answered exactly this shape
+for `*.aps.org`, which was trusted under the feature-gated `tdm-aps` key and was
+promoted to `oa-publisher` — in its words, "making the trust unconditional across
+feature configurations rather than feature-gated".
+
+0027 also drew a line for what it would *not* add: `hdl.handle.net` and
+`ruj.uj.edu.pl`, "open-ended repository / handle surfaces, not a bounded
+society-publisher host". DOAJ falls on the include side of that line — it is a
+bounded, curated index of vetted open-access journals, not an open-ended surface.
+
+The cost of the disagreement is concrete. `10.1109/access.2024.3495502` (IEEE
+Access, **gold OA**) is denied at `doaj.org` on a stock install, while a green-OA
+copy on an institutional repository is reachable behind one documented flag. For
+an OA-first tool that polarity is backwards.
+
+## Decision
+
+**Add `doaj.org` and `*.doaj.org` to `oa_publisher_allowlist()`** (`http.rs` +
+`REDIRECT_ALLOWLIST.md` §3.4 + the site projection), unconditionally, on the
+0027 precedent.
+
+**Keep `trust_oa_registries` for the remaining five** — SciELO, Zenodo, OSF, HAL,
+CORE. None of them appears anywhere in `http.rs` today, so for those the flag is
+genuinely *new* trust, not the repair of an internal disagreement, and opt-in is
+the right default. DOAJ is removed from the flag's curated set: keeping it in both
+places would be harmless but misleading about where the trust comes from.
+
+This is option 3 of the three laid out on #410.
+
+## Consequences
+
+**Positive.**
+
+- The two keys agree. A host the project already trusts for metadata is trusted
+  for the PDF leg it was always going to redirect to.
+- Gold OA is reachable out of the box, matching the tool's stated purpose.
+- Consistent with 0027 rather than a new principle.
+
+**Negative / accepted.**
+
+- The default allowlist grows by one registrable domain plus its subdomains. DOAJ
+  is a non-profit index that serves article links, not arbitrary content; the
+  supply-chain exposure is a redirect target we already accept from the same
+  organisation on another key.
+- `trust_oa_registries`, shipped one release earlier with DOAJ in it, changes
+  meaning slightly. It is one release old, opt-in, off by default, and documented
+  in `CONFIG.md` §3.1; the section is updated in the same change.
+
+**Explicitly still out of scope.** IEEE / ACM / SIAM / AMS — see
+[0039](0039-publisher-hosts-stay-off-allowlist.md).

--- a/docs/DECISIONS/0038-store-root-cwd-reaffirmed.md
+++ b/docs/DECISIONS/0038-store-root-cwd-reaffirmed.md
@@ -1,0 +1,68 @@
+# 0038 - Default store root stays `./papers` (cwd); 0036 reaffirmed against #406
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (reaffirms [0036](0036-default-store-cwd.md) unchanged)
+- **Source:** #406, dogfood 2026-08-22
+
+## Context
+
+[ADR-0036](0036-default-store-cwd.md) made the default store root `./papers`
+under the current working directory, so that fetched artifacts are visible where
+an agent or human is actually working. Its Consequences section already recorded
+the cost:
+
+> A `papers/` directory now appears in whatever directory doiget is first run
+> from. This is intentional (visibility) …
+
+#406 reported that exact symptom from a real session, plus a sharper one: a
+*denied* fetch, run inside an unrelated git worktree, left
+`<worktree>/papers/.metadata/…` behind. The issue proposed defaulting to an XDG
+data directory instead.
+
+Investigating it turned up two things that were **not** ADR-0036 working as
+designed, and one that was:
+
+1. `doiget_health` — annotated `read_only_hint = true` — answered "is the store
+   writable?" by calling `create_dir_all` on it. A *health check* created the
+   tree, in a directory that is indeterminate for a daemon. Fixed in 0.8.7.
+2. Our own test suite leaked `crates/doiget-mcp/papers/` into the repo, and
+   `papers/` was not in `.gitignore`. Fixed in 0.8.7.
+3. The metadata-only record written when the PDF leg is denied. That is
+   [#145](https://github.com/QAtlasHub/doiget/issues/145) working as intended:
+   the metadata *did* resolve, it is useful, and the CLI names its path.
+
+## Decision
+
+**Keep the cwd default. ADR-0036 stands unamended.**
+
+The evidence in #406 is real but it is evidence for (1) and (2), which are now
+fixed without moving the default. What remains — `papers/` appearing where you
+run doiget — is the accepted consequence 0036 wrote down in advance, and it is
+the property that closed the #344 agent-invisibility failure mode.
+
+Reversing it would re-open #344: artifacts landing in `~/.local/share` where
+"neither the agent nor the human sees it". The two dogfooding reports point in
+opposite directions, and 0036's is the one about the tool's primary user.
+
+Users who want a central library set `DOIGET_STORE_ROOT` or `[store] root`; 0.8.7
+makes `doiget config doctor` print the resolved path and say that it is
+cwd-relative, so the default is now self-describing rather than surprising.
+
+## Consequences
+
+**Positive.**
+
+- No breaking change to where 0.8.x writes.
+- The two genuine defects are fixed; the remaining behaviour is documented and
+  discoverable from `config doctor`.
+
+**Negative / accepted.**
+
+- Unchanged from 0036: a user who fetches from many directories accrues several
+  small stores unless they set `DOIGET_STORE_ROOT`.
+- A denied fetch still writes a metadata-only record. Anyone who wants that
+  changed should reopen it against #145's reasoning, not this ADR.
+
+**If this is revisited**, the superseding ADR needs an answer to #344 that does
+not rely on `--link`, since that was already available when #344 was filed.

--- a/docs/DECISIONS/0039-publisher-hosts-stay-off-allowlist.md
+++ b/docs/DECISIONS/0039-publisher-hosts-stay-off-allowlist.md
@@ -1,0 +1,77 @@
+# 0039 - IEEE / ACM / SIAM / AMS stay off `oa-publisher`; TDM credentials are the route
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (settles the question [0027](0027-redirect-allowlist-society-hosts.md) §"Out of scope" deferred)
+- **Source:** #407 (measured from a subscribing university network), #409
+
+## Context
+
+#407 reports that on a machine sitting directly on a subscribing university
+network — egress `157.82.60.8`, RDAP `UTNET`, no tunnel — paywalled fetches still
+fail, and identifies two independent causes:
+
+1. `oa_publisher_allowlist()` has no `*.ieee.org`, `*.acm.org`, `*.siam.org` or
+   `*.ams.org`, so doiget will not attempt the publisher leg for them.
+2. The publisher's bot wall. One diagnostic request from that address, with a
+   desktop browser User-Agent:
+
+   ```
+   $ curl -A "Mozilla/5.0 ... Chrome/120 ..." https://ieeexplore.ieee.org/document/8319344
+   status=202   body=0 bytes
+   ```
+
+   `202 Accepted` with an empty body is a challenge holding response. The
+   subscription is not the binding constraint; **being a scripted client is.**
+
+Cause 1 is not an oversight. [ADR-0027](0027-redirect-allowlist-society-hosts.md)
+scoped `oa-publisher` to physics-society and diamond-OA hosts and explicitly
+deferred open-ended surfaces "so a future ADR can revisit it on its own merits".
+This is that ADR.
+
+The measurement in #407 is what makes it decidable, and it decides it against
+adding them: **adding the hosts would not fix the fetch.** It would move the
+failure from an allowlist denial — which is honest, immediate, and names a
+policy — to a WAF challenge that looks like a successful `202`. That is strictly
+worse diagnostics for zero new capability.
+
+## Decision
+
+**Do not add IEEE, ACM, SIAM or AMS hosts to `oa-publisher`.**
+
+The supported route for programmatic access to those publishers is
+per-publisher **TDM credentials**, the mechanism ADR-0002 already established and
+`docs/CONFIG.md` §6 already documents for `[tdm.elsevier]`, `[tdm.aps]` and
+`[tdm.springer]`. That interface is the one publishers intend programs to use and
+it does not meet the web front end's bot wall at all.
+
+`[tdm.ieee]` is **deferred, not rejected.** Adding it means the four touch points
+an existing TDM source has (`sources/tdm_<vendor>.rs`, a transport allowlist in
+`http.rs`, a Cargo feature per ADR-0002, a `[tdm.<vendor>]` block in CONFIG.md §6)
+plus a ToS link in `SOURCES.md` — and it needs IEEE's actual API contract:
+endpoint, auth header, response shape, and terms. None of that can be written
+from the outside. Tracked as a follow-up.
+
+0.8.7 ships the diagnostic instead: `doiget config doctor --network` reports which
+publishers will talk to this client, classifies a `2xx` with an empty body as a
+bot challenge rather than a success, and lists non-allowlisted hosts as
+`not allowlisted` with no request sent. `docs/CONFIG.md` §6.1 states the honest
+conclusion — IP-based subscription does not imply fetchability, and a proxy fixes
+addressing but never a bot wall.
+
+## Consequences
+
+**Positive.**
+
+- The default allowlist keeps its stated shape: OA routes only. Adding
+  subscription publishers would blur the line that makes doiget deployable inside
+  institutions and eligible for directory listings.
+- The failure a user gets is the accurate one, at the earliest possible point,
+  naming a policy they can act on.
+
+**Negative / accepted.**
+
+- IEEE / ACM / SIAM / AMS literature is not fetchable by doiget today, including
+  from a subscribing network. For a corpus that is entirely IEEE — the case in
+  #407 — doiget can resolve metadata but not full text.
+- That gap closes only when someone signs up for the TDM APIs.

--- a/docs/DECISIONS/0040-source-expansion-feature-gating.md
+++ b/docs/DECISIONS/0040-source-expansion-feature-gating.md
@@ -1,0 +1,81 @@
+# 0040 - Source expansion is gated by the existing `metadata` feature, runtime-gated off
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (settles the "open decision" in #413 that blocks its child PRs)
+- **Source:** #413 (epic), #414–#418 (children)
+
+## Context
+
+#413 adds five optional OA sources — DataCite, Europe PMC, OpenAIRE, CORE, HAL —
+under a constraint it states plainly:
+
+> **With every flag unset, observable behaviour must be byte-identical to today.**
+
+and asks which Cargo feature should gate them, because `metadata` currently means
+*Tier 2 metadata enrichment*, while the new set includes **retrieval** sources and
+DataCite is a **resolution** source closer in role to Crossref. Three options were
+put:
+
+- **(a)** reuse `metadata` — zero release-workflow change, least honest naming
+- **(b)** a sibling feature, e.g. `oa-extra` — clearer, but the release build flags
+  and the CI feature matrix both grow
+- **(c)** DataCite as Tier 1 (always on) and the retrieval sources behind (b)
+
+## Decision
+
+**(a) — gate all five behind the existing `metadata` feature, each additionally
+runtime-gated by its own `DOIGET_ENABLE_<NAME>`, all off by default.**
+
+And redefine what `metadata` means, in `SOURCES.md` and `CAPABILITY.md`: *the
+optional non-Tier-1 source surface — enrichment, resolution and retrieval —
+compiled into release binaries and inert until a runtime flag turns a source on.*
+The naming objection in (a) is answered by fixing the definition rather than by
+adding a flag that carries the same code.
+
+Three reasons.
+
+**The Cargo feature is not the security boundary; the runtime flag is.** Both
+`metadata` and a hypothetical `oa-extra` ship in the release binary — `citation`
+already pulls `metadata` in, and release builds are
+`--no-default-features --features oa-only,citation`. What keeps a source inert is
+`CapabilityProfile::from_env` reading `DOIGET_ENABLE_<NAME>`, and that is
+unchanged either way. Choosing (b) would move code between two compiled-in
+buckets and change nothing observable.
+
+**(c) breaks the epic's own load-bearing constraint.** Making DataCite Tier 1
+means a DataCite-registered DOI that returns `NotFound` today would resolve — a
+behaviour change for every user with no opt-in, in direct conflict with
+"byte-identical to today". The motivation is real (a false `NotFound` in
+`doiget-citation-check`, the most visible downstream consumer), but the fix
+belongs there: that tool sets `DOIGET_ENABLE_DATACITE`. One line, in the place
+that wants the behaviour.
+
+**(b)'s cost lands where it cannot be verified before it bites.** The feature
+string appears in 13 places across the workflows; two of them —
+`release-plz.yml` and `release-sign.yml` — run **only on a tag push**, so a
+mistake there is invisible to every PR and surfaces as a broken release. Adding
+release-workflow surface is not worth a rename when the runtime gate already does
+the enforcing.
+
+## Consequences
+
+**Positive.**
+
+- Zero release-workflow change; the five child PRs are pure additive code + docs.
+- Default behaviour is byte-identical, enforced by a default-off regression test
+  per source (#413's checklist).
+- The tier vocabulary in `SOURCES.md` / `CAPABILITY.md` — which is the
+  user-facing one — keeps doing the explaining, instead of a Cargo feature name
+  that users never type.
+
+**Negative / accepted.**
+
+- `metadata` becomes a broader bucket than its name suggests, mitigated by an
+  explicit definition in both NORMATIVE docs rather than left implicit.
+- DataCite resolution stays opt-in, so the `doiget-citation-check` false positive
+  persists until that repo sets the flag.
+
+**Revisit** if the optional surface grows past this epic, or if a source ever
+needs to be excluded from release binaries — at which point the split is
+motivated by something other than naming, and (b) becomes the right answer.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -53,6 +53,10 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0034 | arXiv source bundle + individual figure download | Accepted (0.8.0, #352) | `feat/343-source-bundle-figures` | #343 / dogfood 2026-06-24 |
 | 0035 | `fetch --link`: surface fetched artifacts into the working tree | Accepted (0.8.0, #352) | `feat/344-fetch-link` | #344 / dogfood 2026-06-24 |
 | 0036 | Default store root → `./papers` (cwd); amends 0004 co-location | Accepted (0.8.0, #352) | `feat/344-default-store-cwd` | #344 problem 1 / dogfood 2026-06-24 |
+| 0037 | `doaj.org` promoted to the default `oa-publisher` allowlist; `trust_oa_registries` keeps the rest | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #405 item 3 / #409 |
+| 0038 | Store root stays cwd-relative; 0036 reaffirmed against new evidence | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #406 |
+| 0039 | IEEE / ACM / SIAM / AMS stay off `oa-publisher`; TDM credentials are the route | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #407 |
+| 0040 | Source expansion gated by the existing `metadata` feature, runtime-gated off | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #413 |
 
 ## Conventions
 

--- a/docs/REDIRECT_ALLOWLIST.md
+++ b/docs/REDIRECT_ALLOWLIST.md
@@ -137,7 +137,7 @@ Notes:
 | Field | Value |
 |---|---|
 | `source` | `oa-publisher` (synthetic — see notes) |
-| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `arxiv.org`, `*.arxiv.org` |
+| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `doaj.org`, `*.doaj.org`, `arxiv.org`, `*.arxiv.org` |
 
 Notes:
 
@@ -152,6 +152,15 @@ Notes:
   `HttpClient::fetch_pdf("oa-publisher", url)`.
 - **Documented OA hosts.** Each entry below is the documented OA host for the
   named publisher / repository. Changes follow the §5 update process.
+- **DOAJ (ADR-0037).** `doaj.org` + `*.doaj.org` were promoted here from the
+  `doaj` **metadata** source key (`tier_2_allowlist`), which the CLI wires in
+  only under `#[cfg(feature = "citation")]`. The two keys disagreed about a
+  host the project had already accepted, and a stock build could not reach it
+  at all — so a gold-OA article redirected through DOAJ was denied while a
+  green-OA copy on an institutional repository was reachable behind one flag.
+  Promoted on the ADR-0027 precedent that made `*.aps.org` unconditional
+  rather than feature-gated. Empirically observed via
+  `10.1109/access.2024.3495502` (IEEE Access, gold OA; #405).
 - **Empirical verification (ADR-0027).** The physics-society / diamond-OA
   hosts (`*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`) were
   added from a real `doiget batch` over 30 OpenAlex-OA

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -37,12 +37,25 @@ behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. Tier 2 metadata sources require
-an opt-in build:
+`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+requires an opt-in build:
 
 ```sh
 cargo install doiget --features metadata
 ```
+
+**What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
+it now carries. As of 0.8.8 it gates **the optional non-Tier-1 source surface as a
+whole** — enrichment, resolution *and* retrieval — not enrichment alone. Compiling it
+in makes that code present; it does **not** turn any source on. Every source under it
+is additionally gated at runtime by its own `DOIGET_ENABLE_<NAME>`, and with every such
+variable unset the observable behaviour of the binary is identical to a Tier-1-only
+build. The runtime flag is the boundary that matters; the Cargo feature only decides
+what is compiled.
+
+Published release binaries build `--no-default-features --features oa-only,citation`,
+and `citation = ["metadata"]`, so this code ships — inert — in the binaries you
+download.
 
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -163,6 +163,13 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 
 | Variable | Type | Effect |
 |---|---|---|
+> **The `metadata` Cargo feature vs. these variables (ADR-0040, NORMATIVE).** The
+> feature decides what is *compiled*; the variables below decide what is *reachable*.
+> As of 0.8.8 `metadata` gates the whole optional non-Tier-1 source surface —
+> enrichment, resolution and retrieval — and release binaries compile it in. A source
+> is inert until its own `DOIGET_ENABLE_<NAME>` is set, so with all of them unset the
+> binary behaves exactly as a Tier-1-only build.
+
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -65,7 +65,7 @@ total_timeout_sec = 300
 # Without them, an OA PDF hosted off the built-in allowlist is denied with
 # `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
 trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
-trust_oa_registries  = false   # true = also allow the curated OA registries (DOAJ, SciELO, ...)
+trust_oa_registries  = false   # true = also allow the curated OA registries (SciELO, Zenodo, ...)
 
 [[network.additional_hosts]]
 host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
@@ -129,20 +129,21 @@ trust_academic_repos = true
 `trust_oa_registries = true` activates the OA-registry set:
 
 ```
-doaj.org      *.doaj.org      scielo.org    *.scielo.org   *.scielo.br
+scielo.org    *.scielo.org    *.scielo.br
 zenodo.org    *.zenodo.org    osf.io        *.osf.io
 hal.science   *.hal.science   core.ac.uk
 ```
 
 Every entry is a registry or repository whose *purpose* is open distribution, never a
 publisher platform — turning this on must not become a way to reach paywalled content.
-Note that both the apex (`doaj.org`) and the wildcard (`*.doaj.org`) appear: a
-single-suffix wildcard does **not** match the apex, and DOAJ redirects to the apex.
+Note that both the apex and the wildcard are listed where the apex serves content: a
+single-suffix wildcard does **not** match the apex.
 
-Without this flag a Gold-OA article routed through DOAJ — e.g. IEEE Access
-`10.1109/access.2024.3495502` — is denied on a stock install, while a Green-OA copy on
-an institutional repository is reachable behind `trust_academic_repos`. For an
-open-access tool that polarity is backwards, which is why the flag exists.
+**DOAJ is not in this set — it needs no flag.** `doaj.org` is on the *default*
+allowlist as of 0.8.8 (ADR-0037), because the project already trusted it under the
+`doaj` metadata source key and the two keys simply disagreed. So a Gold-OA article
+routed through DOAJ — e.g. IEEE Access `10.1109/access.2024.3495502` — works on a
+stock install with no configuration at all.
 
 `[[network.additional_hosts]]` is for anything outside either set. A pattern is either a
 literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
@@ -156,8 +157,8 @@ host = "*.uj.edu.pl"
 note = "Jagiellonian University repository"
 
 [[network.additional_hosts]]
-host = "doaj.org"
-note = "DOAJ — common redirect target for gold-OA journal content"
+host = "repository.example.edu"
+note = "a repository outside both curated sets"
 ```
 
 Run `doiget config doctor` to confirm what was loaded:
@@ -268,7 +269,7 @@ network (--network):
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...
-  probe doaj.org               not allowlisted   no request sent; ...
+  probe doaj.org               200 793 bytes     ok
 ```
 
 The flag is opt-in because it makes real outbound requests: one GET per listed host, no

--- a/site/content/developer/redirect-allowlist.md
+++ b/site/content/developer/redirect-allowlist.md
@@ -143,7 +143,7 @@ Notes:
 | Field | Value |
 |---|---|
 | `source` | `oa-publisher` (synthetic — see notes) |
-| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `arxiv.org`, `*.arxiv.org` |
+| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `doaj.org`, `*.doaj.org`, `arxiv.org`, `*.arxiv.org` |
 
 Notes:
 
@@ -158,6 +158,15 @@ Notes:
   `HttpClient::fetch_pdf("oa-publisher", url)`.
 - **Documented OA hosts.** Each entry below is the documented OA host for the
   named publisher / repository. Changes follow the §5 update process.
+- **DOAJ (ADR-0037).** `doaj.org` + `*.doaj.org` were promoted here from the
+  `doaj` **metadata** source key (`tier_2_allowlist`), which the CLI wires in
+  only under `#[cfg(feature = "citation")]`. The two keys disagreed about a
+  host the project had already accepted, and a stock build could not reach it
+  at all — so a gold-OA article redirected through DOAJ was denied while a
+  green-OA copy on an institutional repository was reachable behind one flag.
+  Promoted on the ADR-0027 precedent that made `*.aps.org` unconditional
+  rather than feature-gated. Empirically observed via
+  `10.1109/access.2024.3495502` (IEEE Access, gold OA; #405).
 - **Empirical verification (ADR-0027).** The physics-society / diamond-OA
   hosts (`*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`) were
   added from a real `doiget batch` over 30 OpenAlex-OA

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -43,12 +43,25 @@ behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. Tier 2 metadata sources require
-an opt-in build:
+`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+requires an opt-in build:
 
 ```sh
 cargo install doiget --features metadata
 ```
+
+**What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
+it now carries. As of 0.8.8 it gates **the optional non-Tier-1 source surface as a
+whole** — enrichment, resolution *and* retrieval — not enrichment alone. Compiling it
+in makes that code present; it does **not** turn any source on. Every source under it
+is additionally gated at runtime by its own `DOIGET_ENABLE_<NAME>`, and with every such
+variable unset the observable behaviour of the binary is identical to a Tier-1-only
+build. The runtime flag is the boundary that matters; the Cargo feature only decides
+what is compiled.
+
+Published release binaries build `--no-default-features --features oa-only,citation`,
+and `citation = ["metadata"]`, so this code ships — inert — in the binaries you
+download.
 
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 


### PR DESCRIPTION
Four decisions were blocking issue closure or downstream PRs. You delegated them; I have
made the calls and written the reasoning **and the rejected alternatives** into the ADRs,
so the promotion review can argue with the substance rather than reconstruct it.

**Read the four ADRs — that is the reviewable content here.** The code change is small.

| ADR | Decision | Reversible? |
|---|---|---|
| **0037** | `doaj.org` → default `oa-publisher` allowlist; drop it from `trust_oa_registries` | yes, one-line |
| **0038** | Store root stays cwd-relative; 0036 reaffirmed | n/a (no change) |
| **0039** | IEEE/ACM/SIAM/AMS stay off; TDM is the route | n/a (no change) |
| **0040** | Source expansion rides the existing `metadata` feature | yes, before #414 lands |

## 0037 is the one with code

Reframed by #409: the question was never "should doiget trust DOAJ" — it already did,
under the `"doaj"` metadata key, which the CLI wires in only under
`#[cfg(feature = "citation")]`. The `"oa-publisher"` key that actually gates PDF
redirects had nothing. **Two keys disagreeing about a host we had already accepted.**

ADR-0027 answered this exact shape for `*.aps.org` — trusted under feature-gated
`tdm-aps`, promoted to `oa-publisher` "making the trust unconditional across feature
configurations rather than feature-gated". 0027 also drew its exclusion line at
"open-ended repository / handle surfaces"; DOAJ is a bounded curated index of vetted OA
journals, so it lands on the include side of that line.

DOAJ is **removed** from `trust_oa_registries` — the other five (SciELO, Zenodo, OSF,
HAL, CORE) appear nowhere in `http.rs`, so for them the flag is genuinely new trust and
opt-in stays correct.

Three tests pin it both ways: DOAJ resolves on the default allowlist with no config,
the two keys must agree (so they cannot drift again), and the flag must *not* carry it.

## 0040 is the one that unblocks work

#413 said its feature-gating question "wants an ADR before the first source PR lands".
Chose **(a)**, reuse `metadata`, over (b) a new `oa-extra` and (c) DataCite-as-Tier-1:

- **The Cargo feature is not the security boundary.** `DOIGET_ENABLE_<NAME>` is, and it
  is unchanged by the choice. `citation = ["metadata"]` and release builds carry
  `citation`, so both candidates ship in the binary regardless. (b) moves code between
  two compiled-in buckets and changes nothing observable.
- **(c) breaks the epic's own constraint.** "With every flag unset, observable behaviour
  must be byte-identical to today" — an always-on DataCite makes a DOI that returns
  `NotFound` today start resolving. The `doiget-citation-check` false positive that
  motivates it is fixed there, by setting the flag.
- **(b)'s cost lands where no PR can catch it.** The feature string appears in 13
  workflow sites; `release-plz.yml` and `release-sign.yml` run **only on a tag push**.
  I was not willing to spend unverifiable release surface on a rename while working
  unattended — especially the day we just fixed a release.

The naming objection is answered by redefining `metadata` in `SOURCES.md` §3 and
`CAPABILITY.md` (both NORMATIVE) as the optional non-Tier-1 surface as a whole, with the
runtime flag named as the boundary. **Revisit clause is in the ADR** if the surface grows
past this epic.

## 0038 / 0039 change no code

They record *why not*, which #406 and #407 both need in order to close. 0038 notes that
what #406 actually found were two defects — both fixed in 0.8.7 — and that the residue is
the consequence 0036 wrote down in advance. 0039 turns on your own measurement: adding
the publisher hosts would convert an honest allowlist denial into a `202` that looks like
success.

`[tdm.ieee]` is deferred in 0039, not rejected — it needs IEEE's real API contract. I
will file it as a follow-up so #407 can close.

## Verification

`fmt --check`, `clippy` (oa-only), full `cargo test --workspace` (50 suites),
`sync_docs_to_site.sh` re-run. Closes #405 and #406.