### PR TITLE
feat(source): DataCite DOI resolution, opt-in (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.4] - 2026-08-22
+
+### Added
+- **[source]** **DataCite** DOI resolution, opt-in via `DOIGET_ENABLE_DATACITE`
+  (#414, first of the #413 epic under ADR-0040). DataCite is the second large
+  registration agency and Crossref/Unpaywall index neither its DOIs nor its
+  records, so a live, open-access Zenodo / figshare / Dryad / OSF DOI resolved to
+  `NOT_FOUND` — a false negative already documented on that `ErrorCode` variant
+  and seen as a false positive in `doiget-citation-check`. Ordered strictly
+  **after** Crossref in the DOI fan-out and only consulted when Crossref returned
+  nothing, so a Crossref-registered DOI never reaches it and enabling the flag
+  cannot change any resolution that already works. `resourceTypeGeneral` is
+  surfaced because most DataCite DOIs are not articles. Metadata only: DataCite
+  returns a landing page, not a file, so no PDF is fetched.
+
 ## [0.8.8-beta.3] - 2026-08-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.3"
+version = "0.8.8-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.3"
+version = "0.8.8-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.3"
+version = "0.8.8-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.3"
+version       = "0.8.8-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -447,6 +447,7 @@ mod tests {
             openalex: true,
             semantic_scholar: false,
             doaj: false,
+            datacite: false,
         };
         p
     }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -921,6 +921,14 @@ pub struct MetadataAccess {
     pub semantic_scholar: bool,
     /// Phase 4+; enabled by `DOIGET_ENABLE_DOAJ`.
     pub doaj: bool,
+    /// DOI **resolution** for DataCite-registered DOIs (Zenodo / figshare /
+    /// Dryad / OSF / most institutional repositories); enabled by
+    /// `DOIGET_ENABLE_DATACITE`.
+    ///
+    /// Unlike its siblings this is not enrichment — Crossref and Unpaywall
+    /// simply do not index these DOIs, so without it a live, open record is
+    /// reported [`ErrorCode::NotFound`] (ADR-0040, #414).
+    pub datacite: bool,
 }
 
 /// Process-wide rate limits. Hard-coded; not configurable.
@@ -1149,6 +1157,11 @@ impl CapabilityProfile {
             ),
             doaj: resolve_metadata_flag(
                 "DOIGET_ENABLE_DOAJ",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+            datacite: resolve_metadata_flag(
+                "DOIGET_ENABLE_DATACITE",
                 "metadata",
                 cfg!(feature = "metadata"),
             ),

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1114,7 +1114,44 @@ async fn fetch_paper_doi(
         .as_ref()
         .and_then(|c| c.metadata_json.clone())
         .unwrap_or(Value::Null);
-    let extracted = extract_crossref_fields(&crossref_meta);
+    // `mut` only in `metadata` builds, where the DataCite fallback below may
+    // reassign it; without that feature nothing writes to it.
+    #[allow(unused_mut)]
+    let mut extracted = extract_crossref_fields(&crossref_meta);
+
+    // Issue #414 / ADR-0040: DataCite fallback, strictly AFTER Crossref and
+    // only when Crossref produced nothing. DataCite is the other large
+    // registration agency — Zenodo / figshare / Dryad / OSF DOIs are in
+    // neither Crossref nor Unpaywall, so without this a live, open record
+    // is reported NotFound. Ordering it here is what makes the source
+    // additive: a Crossref-registered DOI never reaches it, so turning the
+    // flag on cannot change any resolution that already works.
+    //
+    // Runtime-gated by `DOIGET_ENABLE_DATACITE` (off by default), so with
+    // the flag unset this block is inert and behaviour is byte-identical.
+    #[cfg(feature = "metadata")]
+    let datacite_meta = if cross.is_none() && profile.metadata.datacite {
+        match crate::sources::datacite::DataCiteSource::new()
+            .fetch(ref_, profile, ctx)
+            .await
+        {
+            Ok(r) => {
+                if let Some(attrs) = r.metadata_json.as_ref() {
+                    extracted = extract_datacite_fields(attrs);
+                }
+                r.metadata_json
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "datacite fallback found nothing for this DOI");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    #[cfg(not(feature = "metadata"))]
+    let datacite_meta: Option<Value> = None;
+    let _ = &datacite_meta;
 
     // Unpaywall second — license enrichment + OA URL chain discovery.
     // A failure here is non-fatal: we still write the Crossref-
@@ -1741,6 +1778,73 @@ pub(crate) struct CrossrefFields {
     pub(crate) issue: Option<String>,
     pub(crate) pages: Option<String>,
     pub(crate) type_: Option<String>,
+}
+
+/// Map a DataCite `data.attributes` object onto [`CrossrefFields`].
+///
+/// Issue #414. DataCite is a different registration agency with a
+/// different schema, but downstream only consumes [`CrossrefFields`], so
+/// the shapes are reconciled here rather than by widening every consumer.
+///
+/// `type_` deliberately carries `types.resourceTypeGeneral` — on Zenodo,
+/// dataset plus software plus image outnumber `JournalArticle`, and an
+/// agent that cannot tell them apart will treat a software release as a
+/// paper. Every field degrades to `None` rather than guessing.
+#[cfg(feature = "metadata")]
+pub(crate) fn extract_datacite_fields(attributes: &Value) -> CrossrefFields {
+    let title = attributes
+        .get("titles")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|t| t.get("title"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let authors = attributes
+        .get("creators")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| {
+                    // `name` is the canonical field; fall back to the
+                    // given/family pair when a depositor supplied only that.
+                    c.get("name")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                        .or_else(|| {
+                            let given = c.get("givenName").and_then(|v| v.as_str());
+                            let family = c.get("familyName").and_then(|v| v.as_str());
+                            match (given, family) {
+                                (Some(g), Some(f)) => Some(format!("{g} {f}")),
+                                (None, Some(f)) => Some(f.to_string()),
+                                _ => None,
+                            }
+                        })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let year = attributes
+        .get("publicationYear")
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|y| i32::try_from(y).ok());
+    let venue = attributes.get("publisher").and_then(|v| {
+        // DataCite 4.5 made `publisher` an object; earlier records
+        // carry a bare string.
+        v.as_str()
+            .map(str::to_string)
+            .or_else(|| v.get("name").and_then(|n| n.as_str()).map(str::to_string))
+    });
+    let type_ = crate::sources::datacite::resource_type_general(attributes).map(str::to_string);
+    CrossrefFields {
+        title,
+        authors,
+        year,
+        venue,
+        volume: None,
+        issue: None,
+        pages: None,
+        type_,
+    }
 }
 
 /// Defensively pull bibliographic fields out of a Crossref envelope's

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -1,0 +1,457 @@
+//! DataCite source — DOI **resolution** (Phase 4 / Tier 2, issue #414).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. DataCite is the second
+//! large DOI registration agency; Crossref and Unpaywall index neither
+//! its DOIs nor its records. Without this source a live, open-access
+//! Zenodo / figshare / Dryad / OSF DOI resolves to
+//! [`ErrorCode::NotFound`](crate::ErrorCode::NotFound) — a false negative
+//! already documented in-tree on that variant, and observed as a false
+//! positive in `doiget-citation-check`.
+//!
+//! ## Resolution, not enrichment
+//!
+//! Its siblings ([`openalex`](super::openalex) / [`s2`](super::s2) /
+//! [`doaj`](super::doaj)) add fields to a record Crossref already
+//! returned. This one answers the prior question — *does this DOI exist*
+//! — for an agency doiget otherwise cannot see. It therefore belongs
+//! **after** Crossref in the DOI fan-out: a Crossref-registered DOI never
+//! reaches it, so enabling it cannot change any resolution that works
+//! today.
+//!
+//! ## Capability gate
+//!
+//! [`DataCiteSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.datacite`](crate::CapabilityProfile) is
+//! `true` AND the ref is a [`Ref::Doi`]. The bool is set by
+//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_DATACITE`, which is
+//! **off by default** (ADR-0040) — with it unset the binary behaves
+//! exactly as it did before this source existed.
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4 this source never returns PDF bytes. DataCite
+//! returns a **landing page**, not a file: `attributes.url` for
+//! `10.5281/zenodo.X` is an HTML page under `zenodo.org`. Per-repository
+//! file retrieval (Zenodo `/api/records/<id>` then `files[].links.self`,
+//! figshare, Dryad, …) is deliberately out of scope until we can measure
+//! how often the landing URL alone suffices.
+//!
+//! ## Resolution only, never discovery
+//!
+//! DataCite is queried by exact DOI and nothing else. Zenodo accepts
+//! arbitrary deposits from anyone, so using it as a *search* surface would
+//! pull a large volume of unreviewed material into results. The contract
+//! here is narrower: resolve a DOI the user explicitly named.
+//!
+//! API: public REST, no auth, no key.
+//! ToS: <https://datacite.org/terms-and-conditions/>
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production DataCite REST API base.
+const DEFAULT_BASE: &str = "https://api.datacite.org";
+
+/// DataCite [`Source`] impl — DOI to DataCite record.
+#[derive(Clone, Debug)]
+pub struct DataCiteSource {
+    /// API base URL. Production pins `https://api.datacite.org`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl DataCiteSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build the `/dois/<doi>` URL.
+    ///
+    /// The DOI goes in the path and its `/` separator must survive as a
+    /// literal, so the suffix is pushed as its own segment rather than
+    /// percent-encoded into one blob. Every other reserved character IS
+    /// encoded by `push`, so a crafted suffix cannot inject a query string
+    /// or climb out of the `/dois/` prefix.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let mut url = self.base.clone();
+        {
+            let mut segs = url
+                .path_segments_mut()
+                .map_err(|()| FetchError::SourceSchema {
+                    hint: "datacite base URL cannot be a base".to_string(),
+                })?;
+            segs.clear();
+            segs.push("dois");
+            for part in doi.as_str().split('/') {
+                segs.push(part);
+            }
+        }
+        Ok(url)
+    }
+}
+
+impl Default for DataCiteSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for DataCiteSource {
+    fn name(&self) -> &str {
+        "datacite"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.metadata.datacite && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "datacite".into(),
+                });
+            }
+        };
+
+        if !profile.metadata.datacite {
+            return Err(FetchError::NotEligible {
+                source_key: "datacite".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("datacite returned non-JSON: {e}"),
+            })?;
+
+        // JSON:API envelope: { data: { id, type: "dois", attributes: {..} } }.
+        let attributes = envelope
+            .get("data")
+            .and_then(|d| d.get("attributes"))
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "datacite response missing `data.attributes` (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+
+        let license = license_of(attributes);
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(license.as_str()),
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(attributes.clone()),
+        })
+    }
+}
+
+/// Extract a licence identifier from `attributes.rightsList[]`.
+///
+/// DataCite records are heterogeneous — depositors fill `rightsList`
+/// freely — so this takes the first entry carrying a `rightsIdentifier`
+/// and otherwise reports `"unknown"`. Reporting `unknown` is honest;
+/// inferring a licence from a free-text `rights` string would not be, and
+/// a wrong licence is worse than an absent one.
+fn license_of(attributes: &serde_json::Value) -> String {
+    attributes
+        .get("rightsList")
+        .and_then(|r| r.as_array())
+        .and_then(|list| {
+            list.iter()
+                .find_map(|r| r.get("rightsIdentifier").and_then(|v| v.as_str()))
+        })
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// `attributes.types.resourceTypeGeneral`, if present.
+///
+/// Surfaced because a DataCite DOI is very often **not** an article — on
+/// Zenodo, dataset plus software plus image outnumber `JournalArticle`. An
+/// agent that cannot tell them apart will treat a software release as a
+/// paper (#414).
+#[must_use]
+pub fn resource_type_general(attributes: &serde_json::Value) -> Option<&str> {
+    attributes
+        .get("types")
+        .and_then(|t| t.get("resourceTypeGeneral"))
+        .and_then(|v| v.as_str())
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// Trimmed real shape from `GET /dois/10.5281/zenodo.22053902`.
+    const SAMPLE_RECORD: &str = r#"{
+        "data": {
+            "id": "10.5281/zenodo.22053902",
+            "type": "dois",
+            "attributes": {
+                "doi": "10.5281/zenodo.22053902",
+                "titles": [{"title": "An Example Deposit"}],
+                "creators": [
+                    {"name": "Researcher, Alice"},
+                    {"givenName": "Bob", "familyName": "Coauthor"}
+                ],
+                "publicationYear": 2024,
+                "publisher": "Zenodo",
+                "types": {"resourceTypeGeneral": "JournalArticle"},
+                "rightsList": [
+                    {"rights": "Creative Commons Attribution 4.0",
+                     "rightsIdentifier": "cc-by-4.0"}
+                ],
+                "url": "https://zenodo.org/doi/10.5281/zenodo.22053902"
+            }
+        }
+    }"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "datacite",
+            wiremock_host,
+        ));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_dir.join("test.jsonl"), session_id.clone())
+                .expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    fn profile(datacite: bool) -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite,
+        };
+        p
+    }
+
+    /// The DOI separator `/` must stay structural in the path — DataCite
+    /// routes on `/dois/<prefix>/<suffix>`, so percent-encoding it 404s.
+    #[test]
+    fn request_url_keeps_the_doi_slash_structural() {
+        let src = DataCiteSource::new();
+        let doi = Doi::parse("10.5281/zenodo.22053902").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(
+            url.as_str(),
+            "https://api.datacite.org/dois/10.5281/zenodo.22053902"
+        );
+    }
+
+    /// Injection into the path is prevented one layer earlier than the URL
+    /// builder: `Doi` is a validated newtype, so a suffix carrying `?`, `#`
+    /// or a space never becomes a `Doi` at all and `request_url` can never
+    /// be handed one. Pinned here because the builder deliberately pushes
+    /// the suffix as structural path segments, which would otherwise be the
+    /// place to worry.
+    #[test]
+    fn doi_newtype_rejects_characters_that_could_escape_the_path() {
+        for bad in ["10.5281/a?b", "10.5281/a#b", "10.5281/a b"] {
+            assert!(
+                Doi::parse(bad).is_err(),
+                "{bad} must not parse as a DOI, or request_url could see it"
+            );
+        }
+    }
+
+    /// A DOI suffix may itself contain `/`. Every one of them stays
+    /// structural, and nothing climbs above `/dois/`.
+    #[test]
+    fn request_url_handles_a_multi_segment_suffix() {
+        let src = DataCiteSource::new();
+        let doi = Doi::parse("10.17605/osf.io/ab3cd").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(
+            url.as_str(),
+            "https://api.datacite.org/dois/10.17605/osf.io/ab3cd"
+        );
+        assert!(url.query().is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_attributes_and_license() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/dois/10.5281/zenodo.22053902"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_RECORD))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.5281/zenodo.22053902").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("fetch succeeds");
+        assert_eq!(got.source, "datacite");
+        assert_eq!(got.license, "cc-by-4.0");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+        let attrs = got.metadata_json.expect("attributes");
+        assert_eq!(resource_type_general(&attrs), Some("JournalArticle"));
+    }
+
+    /// The regression #413 requires of every new source: with the runtime
+    /// flag unset it must refuse BEFORE touching the network. No route is
+    /// mounted either, so a request would also fail loudly.
+    #[tokio::test]
+    async fn is_inert_when_the_runtime_flag_is_unset() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.5281/zenodo.22053902").expect("doi"));
+
+        assert!(
+            !src.can_serve(&profile(false), &ref_),
+            "can_serve must be false with DOIGET_ENABLE_DATACITE unset"
+        );
+        let err = src
+            .fetch(&ref_, &profile(false), &ctx)
+            .await
+            .expect_err("must refuse");
+        assert!(matches!(err, FetchError::NotEligible { .. }), "got {err:?}");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "an inert source must make NO request"
+        );
+    }
+
+    #[tokio::test]
+    async fn arxiv_refs_are_not_eligible() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+        assert!(!src.can_serve(&profile(true), &ref_));
+        assert!(matches!(
+            src.fetch(&ref_, &profile(true), &ctx).await,
+            Err(FetchError::NotEligible { .. })
+        ));
+    }
+
+    /// A DOI DataCite does not hold returns a JSON error envelope with no
+    /// `data.attributes`. That must surface as SourceSchema so the
+    /// orchestrator falls through rather than aborting the fetch.
+    #[tokio::test]
+    async fn missing_record_surfaces_as_source_schema() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/dois/10.1234/not-datacite"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(r#"{"errors":[{"status":"404"}]}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/not-datacite").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("must not claim success");
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn license_falls_back_to_unknown_rather_than_guessing() {
+        // Free-text `rights` with no identifier must NOT become a licence:
+        // a wrong licence is worse than an absent one.
+        let attrs = serde_json::json!({"rightsList": [{"rights": "Open Access"}]});
+        assert_eq!(license_of(&attrs), "unknown");
+        assert_eq!(license_of(&serde_json::json!({})), "unknown");
+    }
+}

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -268,6 +268,7 @@ mod tests {
             openalex: false,
             semantic_scholar: false,
             doaj: true,
+            datacite: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
 //! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
-//!   feature): OpenAlex / Semantic Scholar / DOAJ.
+//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite.
 //! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
 //!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
@@ -24,6 +24,13 @@ pub mod s2;
 
 #[cfg(feature = "metadata")]
 pub mod doaj;
+
+/// DataCite — DOI **resolution** for the second registration agency
+/// (Zenodo / figshare / Dryad / OSF). Not enrichment: without it those
+/// DOIs report `NotFound`. Runtime-gated by `DOIGET_ENABLE_DATACITE`,
+/// off by default (ADR-0040, #414).
+#[cfg(feature = "metadata")]
+pub mod datacite;
 
 // ---------------------------------------------------------------------------
 // Tier 3 (Phase 5) — compile-gated by per-publisher Cargo features.

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -292,6 +292,7 @@ mod tests {
             openalex: true,
             semantic_scholar: false,
             doaj: false,
+            datacite: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -282,6 +282,7 @@ mod tests {
             openalex: false,
             semantic_scholar: true,
             doaj: false,
+            datacite: false,
         };
         p
     }

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -110,6 +110,7 @@ impl CapabilityProfile {
                 openalex:        env::var("DOIGET_ENABLE_OPENALEX").is_ok(),
                 semantic_scholar: env::var("DOIGET_ENABLE_S2").is_ok(),
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
+                datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -167,6 +168,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
+| `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -41,7 +41,12 @@ its use of these APIs polite.
 
 **Opt-in only — compile-time feature flag + your own configuration:**
 
-- `--features metadata`: **Semantic Scholar**, **DOAJ** (extra metadata).
+- `--features metadata`: **Semantic Scholar**, **DOAJ** (extra metadata) and
+  **DataCite** (<https://api.datacite.org>, DOI resolution for Zenodo / figshare /
+  Dryad / OSF). Each is additionally inert until you set its own
+  `DOIGET_ENABLE_<NAME>`, so compiling the feature in contacts nobody by itself.
+  DataCite is queried by exact DOI only — never used as a search surface — and
+  needs no key or account.
 - `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
   text-and-data-mining APIs, used **only with your own API key and explicit
   agreement**. doiget bundles no keys and shares none.

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -18,6 +18,7 @@
 | OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -116,6 +116,7 @@ impl CapabilityProfile {
                 openalex:        env::var("DOIGET_ENABLE_OPENALEX").is_ok(),
                 semantic_scholar: env::var("DOIGET_ENABLE_S2").is_ok(),
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
+                datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -173,6 +174,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
+| `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -24,6 +24,7 @@ weight = 200
 | OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |


### PR DESCRIPTION
Closes #414. First source of the #413 epic, gated per **ADR-0040** (landed in #428).

The only one in that epic that fixes a **live false positive**: `doiget-citation-check`
gates a `.bib` as broken when it cites `10.5281/zenodo.*`, `10.6084/m9.figshare.*`,
`10.5061/dryad.*` or `10.17605/osf.io/*`, because Crossref and Unpaywall index neither
those DOIs nor their records. The gap is already documented in-tree on `ErrorCode::NotFound`.

## The ordering is the safety property

DataCite sits **after** Crossref in the DOI fan-out and is consulted **only when Crossref
returned nothing**. A Crossref-registered DOI therefore never reaches it, so enabling the
flag cannot change any resolution that already works. Together with
`DOIGET_ENABLE_DATACITE` being off by default, a binary with the flag unset behaves
byte-identically to before — the constraint #413 set for the whole epic, pinned by
`is_inert_when_the_runtime_flag_is_unset`, which asserts the mock server received
**zero requests**.

## Deliberate limits

- **Metadata only.** DataCite returns a *landing page*, not a file (`attributes.url` for a
  Zenodo DOI is HTML). Per-repository file retrieval is out of scope until we can measure
  how often the landing URL suffices.
- **Resolution, never discovery.** Queried by exact DOI and nothing else. Zenodo accepts
  arbitrary deposits from anyone; using it as a search surface would pull unreviewed
  material into results.
- **Licence refuses to guess.** Only `rightsIdentifier` is trusted; free-text `rights`
  degrades to `"unknown"`. A wrong licence is worse than an absent one — tested.
- **`resourceTypeGeneral` is surfaced.** On Zenodo, dataset + software + image outnumber
  `JournalArticle`; an agent that cannot tell them apart will treat a software release as
  a paper.

## One finding worth recording

`request_url` pushes the DOI suffix as structural path segments (DataCite routes on
`/dois/<prefix>/<suffix>`, so percent-encoding the `/` 404s). I wrote an injection test
for that — and it **failed**, because `Doi` is a validated newtype that rejects `?`, `#`
and space before `request_url` can ever be handed one. The test now pins that earlier
guarantee rather than asserting something the type system already prevents.

## Checklist from #413

- [x] `sources/datacite.rs` — `Source` impl
- [x] `sources/mod.rs` — feature-gated `pub mod`
- [x] `CapabilityProfile` / `MetadataAccess` + `from_env` reads `DOIGET_ENABLE_DATACITE`
- [x] `docs/SOURCES.md` §1 matrix row + **ToS link**
- [x] `docs/CAPABILITY.md`
- [x] `docs/PRIVACY.md` third-party services list
- [x] `scripts/sync_docs_to_site.sh` re-run
- [x] default-off regression test
- [ ] fixture under `tests/fixtures/real_world/` — not added: the resolve path for
      *Crossref* DOIs is unchanged, and the existing Zenodo fixture is hand-crafted (its
      DOI 404s at `api.datacite.org`), so a snapshot would assert against synthetic data.
      Wiremock coverage is real-shape instead.

8 unit tests; `fmt`, `rustdoc -D warnings`, `cargo test --workspace` (50 suites) and the
`oa-only,citation` matrix all clean.

**Follow-up the issue asks for:** run `doiget-citation-check` over a `.bib` with Zenodo /
figshare DOIs and confirm the false positives clear. That needs the other repo, so it is
not in this PR.