### PR TITLE
feat(source): CORE cross-repository OA aggregation, opt-in (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.7] - 2026-08-23
+
+### Added
+- **[source]** **CORE** — cross-repository OA aggregation, opt-in via
+  `DOIGET_ENABLE_CORE` (#417). The broadest single OA index outside Unpaywall, so
+  it sits last in the optional chain. An **optional** free key in
+  `DOIGET_CORE_API_KEY` raises the rate limit; absent — or blank — it degrades to
+  the key-less limit rather than failing. No key is bundled and none is needed to
+  build. A rejected key surfaces as a transport error carrying the 401/403, which
+  is a different error *type* from the `NOT_FOUND` a genuine miss produces, so a
+  misconfigured key cannot be mistaken for an absent paper.
+
 ## [0.8.8-beta.6] - 2026-08-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.6"
+version = "0.8.8-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.6"
+version = "0.8.8-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.6"
+version = "0.8.8-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.6"
+version       = "0.8.8-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.6" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.6" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.6" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -450,6 +450,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -259,6 +259,8 @@ pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
         // endpoint on the same host is unstable (503s) and deliberately
         // unused; only the Graph path is called.
         SourceAllowlist::new("openaire", vec!["api.openaire.eu".to_string()]),
+        // CORE REST v3 (#417). Optional bearer key; same host either way.
+        SourceAllowlist::new("core", vec!["api.core.ac.uk".to_string()]),
     ]
 }
 
@@ -1427,6 +1429,7 @@ mod tests {
         let datacite = crate::sources::datacite::DataCiteSource::new();
         let hal = crate::sources::hal::HalSource::new();
         let openaire = crate::sources::openaire::OpenAireSource::new();
+        let core = crate::sources::core_oa::CoreSource::new();
         let names: Vec<&str> = vec![
             openalex.name(),
             s2.name(),
@@ -1434,6 +1437,7 @@ mod tests {
             datacite.name(),
             hal.name(),
             openaire.name(),
+            core.name(),
         ];
         let registered: Vec<String> = tier_2_allowlist()
             .iter()

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -936,6 +936,11 @@ pub struct MetadataAccess {
     /// OpenAIRE — European institutional / funder repository aggregation;
     /// enabled by `DOIGET_ENABLE_OPENAIRE` (ADR-0040, #416).
     pub openaire: bool,
+    /// CORE — cross-repository OA aggregation, the last fallback in the
+    /// optional chain; enabled by `DOIGET_ENABLE_CORE`. An optional free
+    /// key in `DOIGET_CORE_API_KEY` raises the rate limit but is not
+    /// required (ADR-0040, #417).
+    pub core: bool,
 }
 
 /// Process-wide rate limits. Hard-coded; not configurable.
@@ -1175,6 +1180,11 @@ impl CapabilityProfile {
             hal: resolve_metadata_flag("DOIGET_ENABLE_HAL", "metadata", cfg!(feature = "metadata")),
             openaire: resolve_metadata_flag(
                 "DOIGET_ENABLE_OPENAIRE",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+            core: resolve_metadata_flag(
+                "DOIGET_ENABLE_CORE",
                 "metadata",
                 cfg!(feature = "metadata"),
             ),

--- a/crates/doiget-core/src/sources/core_oa.rs
+++ b/crates/doiget-core/src/sources/core_oa.rs
@@ -1,0 +1,550 @@
+//! CORE source — cross-repository OA aggregation (Tier 2, #417).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. CORE aggregates OA full
+//! text across repositories worldwide and is the broadest single OA index
+//! outside Unpaywall, so it sits **last** in the optional chain: the
+//! fallback before giving up.
+//!
+//! The module is `core_oa` rather than `core` because `core` is a Rust
+//! built-in crate name, and shadowing it inside `sources::` would make
+//! every `core::` path in this module ambiguous.
+//!
+//! ## Capability gate
+//!
+//! [`CoreSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.core`](crate::CapabilityProfile) is `true`
+//! AND the ref is a [`Ref::Doi`]. The bool is set by
+//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_CORE`, which is
+//! **off by default** (ADR-0040) — unset, this source is inert.
+//!
+//! ## The API key is optional, and absence is not an error
+//!
+//! CORE works with no key at a low rate limit; a **free** key raises it.
+//! So the key is read from `DOIGET_CORE_API_KEY` when the user set one and
+//! simply omitted otherwise — an absent key degrades to the key-less rate
+//! limit rather than failing, which is what #417 requires. doiget bundles
+//! no key, and none is needed to build.
+//!
+//! The key is sent as a bearer header through
+//! [`HttpClient::fetch_bytes_with_headers`](crate::http::HttpClient::fetch_bytes_with_headers),
+//! whose contract is that header values reach the wire only and are never
+//! logged.
+//!
+//! ## A bad key must not look like a missing paper
+//!
+//! Two failures that are easy to conflate:
+//!
+//! - CORE holds nothing for this DOI — [`FetchError::NotFound`]
+//! - CORE rejected our credentials — [`FetchError::Http`], carrying the
+//!   401/403
+//!
+//! They are different error *types*, not two spellings of one hint, so a
+//! caller cannot accidentally read a misconfigured key as an absent
+//! record. When a key *was* sent and the answer is 401/403, the source
+//! additionally logs a warning naming the env var — that is the one case
+//! where the user has something to fix.
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4 this source never returns PDF bytes. CORE
+//! exposes `downloadUrl` on its works, but those point at repository
+//! hosts, reached through the `oa-publisher` key rather than this one.
+//!
+//! API: public REST v3.
+//! Terms: <https://core.ac.uk/terms>
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production CORE API base.
+const DEFAULT_BASE: &str = "https://api.core.ac.uk";
+
+/// Env var holding the user's own free CORE key. Never bundled.
+const API_KEY_ENV: &str = "DOIGET_CORE_API_KEY";
+
+/// CORE [`Source`] impl — DOI to aggregated OA work record.
+#[derive(Clone, Debug)]
+pub struct CoreSource {
+    /// API base URL. Production pins `https://api.core.ac.uk`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl CoreSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build `/v3/search/works?q=doi:"<doi>"&limit=1`.
+    ///
+    /// The DOI is quoted so the query engine treats it as a phrase rather
+    /// than tokenising on `.` and `/`, and the whole value is
+    /// percent-encoded by `query_pairs_mut`, so no query syntax can be
+    /// injected from the suffix.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let mut url = self
+            .base
+            .join("/v3/search/works")
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("core URL construction failed: {e}"),
+            })?;
+        url.query_pairs_mut()
+            .append_pair("q", &format!("doi:\"{}\"", doi.as_str()))
+            .append_pair("limit", "1");
+        Ok(url)
+    }
+}
+
+impl Default for CoreSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Read the optional user-supplied CORE key.
+///
+/// Returns `None` for unset **and** for whitespace-only, so an
+/// accidentally blank `DOIGET_CORE_API_KEY=` behaves as "no key" instead
+/// of sending an empty bearer token that CORE would answer with a 401 —
+/// which would then look like a *bad* key rather than no key.
+fn api_key_from_env() -> Option<String> {
+    std::env::var(API_KEY_ENV)
+        .ok()
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+}
+
+#[async_trait]
+impl Source for CoreSource {
+    fn name(&self) -> &str {
+        "core"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.metadata.core && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "core".into(),
+                });
+            }
+        };
+
+        if !profile.metadata.core {
+            return Err(FetchError::NotEligible {
+                source_key: "core".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let key = api_key_from_env();
+        let bearer = key.as_ref().map(|k| format!("Bearer {k}"));
+        let headers: Vec<(&str, &str)> = match bearer.as_deref() {
+            Some(v) => vec![("authorization", v)],
+            None => Vec::new(),
+        };
+
+        let (body, final_url) = match ctx
+            .http
+            .fetch_bytes_with_headers(self.name(), url, &headers)
+            .await
+        {
+            Ok(ok) => ok,
+            Err(e) => {
+                // A rejected key is the one failure here the user can act
+                // on, so say so — but only when a key was actually sent,
+                // since a key-less 401 means something else entirely.
+                if key.is_some() && matches!(status_of(&e), Some(401 | 403)) {
+                    tracing::warn!(
+                        env = API_KEY_ENV,
+                        "core rejected the configured API key; it is wrong or \
+                         revoked (unset the variable to fall back to the \
+                         key-less rate limit)"
+                    );
+                }
+                return Err(e.into());
+            }
+        };
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("core returned non-JSON: {e}"),
+            })?;
+
+        let results = envelope
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "core response missing `results` array (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+        // Deliberately NotFound, not SourceSchema: "CORE holds nothing for
+        // this DOI" is a clean miss, and must stay type-distinct from the
+        // credential failure handled above.
+        let work = results.first().ok_or_else(|| FetchError::NotFound {
+            hint: format!("core has no work for {}", doi.as_str()),
+        })?;
+
+        let license = license_of(work);
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(license.as_str()),
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(work.clone()),
+        })
+    }
+}
+
+/// HTTP status carried by an [`crate::http::HttpError`], when it has one.
+fn status_of(e: &crate::http::HttpError) -> Option<u16> {
+    match e {
+        crate::http::HttpError::HttpStatus { status, .. } => Some(*status),
+        _ => None,
+    }
+}
+
+/// Licence from the CORE work, else `"unknown"`.
+///
+/// Free text from the aggregated repository rather than an SPDX id, so it
+/// is passed through verbatim — normalising would mean guessing, and a
+/// wrong licence is worse than an absent one.
+fn license_of(work: &serde_json::Value) -> String {
+    work.get("license")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    const SAMPLE_HIT: &str = r#"{
+        "totalHits": 1,
+        "results": [
+            {
+                "id": 12345,
+                "title": "An Aggregated Open Access Work",
+                "doi": "10.1234/example",
+                "license": "https://creativecommons.org/licenses/by/4.0/",
+                "downloadUrl": "https://core.ac.uk/download/12345.pdf"
+            }
+        ]
+    }"#;
+
+    const SAMPLE_EMPTY: &str = r#"{"totalHits": 0, "results": []}"#;
+
+    /// RAII env guard — these tests mutate `DOIGET_CORE_API_KEY`, which is
+    /// process-global, so they are serialised.
+    struct KeyGuard(Option<String>);
+    impl KeyGuard {
+        fn set(v: Option<&str>) -> Self {
+            let prev = std::env::var(API_KEY_ENV).ok();
+            match v {
+                Some(k) => std::env::set_var(API_KEY_ENV, k),
+                None => std::env::remove_var(API_KEY_ENV),
+            }
+            Self(prev)
+        }
+    }
+    impl Drop for KeyGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(v) => std::env::set_var(API_KEY_ENV, v),
+                None => std::env::remove_var(API_KEY_ENV),
+            }
+        }
+    }
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http("core", wiremock_host));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_dir.join("test.jsonl"), session_id.clone())
+                .expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    fn profile(core: bool) -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite: false,
+            hal: false,
+            openaire: false,
+            core,
+        };
+        p
+    }
+
+    #[test]
+    fn request_url_quotes_the_doi_as_a_phrase() {
+        let src = CoreSource::new();
+        let doi = Doi::parse("10.1234/example").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(url.path(), "/v3/search/works");
+        let q = url
+            .query_pairs()
+            .find(|(k, _)| k == "q")
+            .expect("q param")
+            .1
+            .into_owned();
+        assert_eq!(q, "doi:\"10.1234/example\"");
+    }
+
+    /// #417: an absent key must degrade to the key-less rate limit, NOT
+    /// fail, and must not send an empty `authorization` header.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn works_without_a_key_and_sends_no_auth_header() {
+        let _g = KeyGuard::set(None);
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_HIT))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("key-less fetch must succeed");
+        assert_eq!(got.source, "core");
+        assert_eq!(got.license, "https://creativecommons.org/licenses/by/4.0/");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+
+        let reqs = server.received_requests().await.expect("recorded");
+        assert!(
+            reqs[0].headers.get("authorization").is_none(),
+            "no key configured means no authorization header"
+        );
+    }
+
+    /// A configured key must actually reach the wire as a bearer header.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn sends_the_configured_key_as_a_bearer_header() {
+        let _g = KeyGuard::set(Some("secret-key-value"));
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_HIT))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+        src.fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("keyed fetch must succeed");
+
+        let reqs = server.received_requests().await.expect("recorded");
+        let auth = reqs[0]
+            .headers
+            .get("authorization")
+            .expect("authorization header")
+            .to_str()
+            .expect("ascii");
+        assert_eq!(auth, "Bearer secret-key-value");
+    }
+
+    /// A blank `DOIGET_CORE_API_KEY=` is "no key", not an empty key.
+    /// Sending an empty bearer would earn a 401 that looks like a *bad* key.
+    #[test]
+    #[serial_test::serial]
+    fn blank_key_is_treated_as_absent() {
+        {
+            let _g = KeyGuard::set(Some("   "));
+            assert_eq!(api_key_from_env(), None);
+        }
+        {
+            let _g = KeyGuard::set(Some("k"));
+            assert_eq!(api_key_from_env(), Some("k".to_string()));
+        }
+    }
+
+    /// #417: a rejected key must be reported distinctly from "not found".
+    /// These are different error TYPES, so a caller cannot conflate them.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejected_key_and_missing_work_are_different_error_types() {
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+
+        // 401 with a key configured -> Http, carrying the status.
+        let _g = KeyGuard::set(Some("bad-key"));
+        let unauthorized = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&unauthorized)
+            .await;
+        let (_td1, ctx1) = build_test_context(&unauthorized.address().to_string());
+        let src1 = CoreSource::with_base(Url::parse(&unauthorized.uri()).expect("base"));
+        let auth_err = src1
+            .fetch(&ref_, &profile(true), &ctx1)
+            .await
+            .expect_err("401 must be an error");
+        assert!(
+            matches!(auth_err, FetchError::Http(_)),
+            "a rejected key must surface as Http, got {auth_err:?}"
+        );
+
+        // Empty results -> NotFound.
+        let empty = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_EMPTY))
+            .mount(&empty)
+            .await;
+        let (_td2, ctx2) = build_test_context(&empty.address().to_string());
+        let src2 = CoreSource::with_base(Url::parse(&empty.uri()).expect("base"));
+        let miss = src2
+            .fetch(&ref_, &profile(true), &ctx2)
+            .await
+            .expect_err("no results must be an error");
+        assert!(
+            matches!(miss, FetchError::NotFound { .. }),
+            "a clean miss must surface as NotFound, got {miss:?}"
+        );
+    }
+
+    /// The regression #413 requires of every new source.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn is_inert_when_the_runtime_flag_is_unset() {
+        let _g = KeyGuard::set(None);
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+
+        assert!(!src.can_serve(&profile(false), &ref_));
+        let err = src
+            .fetch(&ref_, &profile(false), &ctx)
+            .await
+            .expect_err("must refuse");
+        assert!(matches!(err, FetchError::NotEligible { .. }), "got {err:?}");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "an inert source must make NO request"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn arxiv_refs_are_not_eligible() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+        assert!(!src.can_serve(&profile(true), &ref_));
+        assert!(matches!(
+            src.fetch(&ref_, &profile(true), &ctx).await,
+            Err(FetchError::NotEligible { .. })
+        ));
+    }
+
+    #[test]
+    fn license_falls_back_to_unknown() {
+        assert_eq!(license_of(&serde_json::json!({})), "unknown");
+        assert_eq!(license_of(&serde_json::json!({"license": "  "})), "unknown");
+        assert_eq!(
+            license_of(&serde_json::json!({"license": "cc-by"})),
+            "cc-by"
+        );
+    }
+}

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -308,6 +308,7 @@ mod tests {
             datacite,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -271,6 +271,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -329,6 +329,7 @@ mod tests {
             datacite: false,
             hal,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
 //! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
-//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL / OpenAIRE.
+//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL / OpenAIRE / CORE.
 //! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
 //!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
@@ -44,6 +44,15 @@ pub mod hal;
 /// Runtime-gated by `DOIGET_ENABLE_OPENAIRE`, off by default (#416).
 #[cfg(feature = "metadata")]
 pub mod openaire;
+
+/// CORE — cross-repository OA aggregation, the broadest single OA index
+/// outside Unpaywall and therefore the LAST fallback in the chain. Takes
+/// an optional free key from `DOIGET_CORE_API_KEY`; absent, it degrades
+/// to the key-less rate limit. Runtime-gated by `DOIGET_ENABLE_CORE`,
+/// off by default (#417). Named `core_oa` because `core` is a built-in
+/// crate name.
+#[cfg(feature = "metadata")]
+pub mod core_oa;
 
 // ---------------------------------------------------------------------------
 // Tier 3 (Phase 5) — compile-gated by per-publisher Cargo features.

--- a/crates/doiget-core/src/sources/openaire.rs
+++ b/crates/doiget-core/src/sources/openaire.rs
@@ -351,6 +351,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -295,6 +295,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -285,6 +285,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -113,6 +113,7 @@ impl CapabilityProfile {
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
                 openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
+                core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -173,6 +174,8 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
+| `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
+| `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -53,6 +53,10 @@ its use of these APIs polite.
 - `--features metadata`: **OpenAIRE** (<https://api.openaire.eu>, European repository
   aggregation). Inert until `DOIGET_ENABLE_OPENAIRE` is set; queried by exact DOI
   through the Graph API v1 `pid` parameter only. No key or account.
+- `--features metadata`: **CORE** (<https://api.core.ac.uk>, cross-repository OA
+  aggregation). Inert until `DOIGET_ENABLE_CORE` is set. Works with no account; if
+  you supply your own free key in `DOIGET_CORE_API_KEY` it is sent as a bearer
+  header to CORE and to nowhere else, and is never written to the provenance log.
 - `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
   text-and-data-mining APIs, used **only with your own API key and explicit
   agreement**. doiget bundles no keys and shares none.

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -21,6 +21,7 @@
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
+| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -119,6 +119,7 @@ impl CapabilityProfile {
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
                 openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
+                core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -179,6 +180,8 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
+| `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
+| `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -27,6 +27,7 @@ weight = 200
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
+| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |


### PR DESCRIPTION
Closes #417. Fourth source of the #413 epic — **only #415 Europe PMC left**.

CORE is the broadest single OA index outside Unpaywall, so it sits **last** in the optional
chain: the fallback before giving up.

## First optional source with a credential path

Both of #417's requirements are about not punishing a user for a key they were never
required to have.

**The key is optional and absence is not an error.** No key means the key-less rate limit,
not a failure. A **blank** `DOIGET_CORE_API_KEY=` is also treated as absent — sending an
empty bearer earns a 401, which would then look like a *bad* key rather than *no* key.
Both cases are tested.

**A rejected key must not look like a missing paper.** These are different error **types**,
not two spellings of one hint:

| situation | error |
|---|---|
| CORE holds nothing for this DOI | `FetchError::NotFound` |
| CORE rejected our credentials | `FetchError::Http` carrying the 401/403 |

`rejected_key_and_missing_work_are_different_error_types` asserts both arms against two
mock servers, so a caller cannot conflate them. When a key *was* sent and the answer is
401/403, the source additionally warns naming the env var — the one case the user can act
on. A key-less 401 does **not** warn, because it means something else entirely.

doiget bundles no key and none is needed to build. The key reaches the wire as a bearer
header through `fetch_bytes_with_headers`, whose contract is that header values are never
logged. One test pins the exact header value; another pins that **no** `authorization`
header is sent when no key is configured.

## Naming

The module is `core_oa`, not `core` — `core` is a Rust built-in crate name, and shadowing
it inside `sources::` makes every `core::` path in the module ambiguous. The struct is
still `CoreSource` and the source key is still `"core"`.

## Checklist (#413)

`sources/core_oa.rs` · `mod.rs` · `CapabilityProfile` + `DOIGET_ENABLE_CORE` · transport
allowlist entry (+ the registry guard extended) · `SOURCES.md` row with the key column and
ToS · `CAPABILITY.md` (both env vars) · `PRIVACY.md` (states the key goes to CORE and
nowhere else, and never to the provenance log) · site sync · default-off regression test
asserting **zero requests**.

8 tests, serialised with `serial_test` because they mutate a process-global env var.
`fmt`, clippy on both feature sets, `rustdoc -D warnings`, `cargo test --workspace`
(50 suites) all clean.