### PR TITLE
release: promote 0.8.8 to main

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration.
+#
+# Mirrors the `[advisories] ignore` list in `deny.toml`. The two tools do not
+# share config: `cargo deny` reads `deny.toml`, `cargo audit` reads this file,
+# and neither reads the other's. Keeping only `deny.toml` meant `cargo audit`
+# re-reported an advisory the project had already assessed and accepted.
+#
+# It surfaced asymmetrically: `rustsec/audit-check` treats an informational
+# warning as fatal on a `push` event but not on `pull_request`, so every PR was
+# green and `main` went red the moment the 0.8.7 promotion landed.
+#
+# Any entry added here MUST also be in `deny.toml`, with the same rationale.
+
+[advisories]
+ignore = [
+    # paste — RUSTSEC-2024-0436: UNMAINTAINED (not a vulnerability). Pulled
+    # transitively by `biblatex` (the ADR-0030 D2 `.bib` parser, #258), a
+    # maintained, load-bearing dependency with no drop-in replacement.
+    # `paste` is a compile-time-only proc-macro (no runtime / network
+    # surface), so an unmaintained advisory carries no security exposure
+    # here. Revisit if biblatex drops it or adopts a maintained fork.
+    "RUSTSEC-2024-0436",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,8 @@ jobs:
       - env:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --no-deps --no-default-features --features oa-only
+      # The `citation` surface was never doc-built, so two broken intra-doc
+      # links sat latent on `main` and the five 0.8.8 sources could add more
+      # without CI noticing. Release binaries ship `oa-only,citation`, so the
+      # docs for that surface have to build too.
+      - run: cargo doc --workspace --no-deps --no-default-features --features oa-only,citation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.8] - 2026-08-23
+
+### Added
+- **[source]** **Europe PMC** — biomedical OA full text that Unpaywall does not
+  index, opt-in via `DOIGET_ENABLE_EUROPE_PMC` (#415). Completes the #413 epic.
+  Gated on `isOpenAccess`, deliberately **not** `inEPMC`: a record can be present
+  in the archive while its full text is subscription-only, and gating on presence
+  would return records doiget cannot retrieve. A non-OA hit is an explicit refusal
+  naming both flags, not a retry. `resultType=core` is requested because the
+  default `lite` response omits `fullTextUrlList`, which is the point of consulting
+  the source. The OA PDF location is surfaced from `fullTextUrlList`; the download
+  itself goes through the existing `oa-publisher` leg, where a blocked fetch
+  already surfaces with an ADR-0023 `denial_context` naming the host and allowlist.
+
 ## [0.8.8-beta.7] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.3] - 2026-08-22
+
+### Added
+- **[cli]** `doiget config init` writes a fully commented `config.toml` template to
+  the resolved config path. A fresh install has no config file, nothing created
+  one, and three of the four settings that decide a session's outcome — store
+  location and the two allowlist flags — fail silently when it is absent. Every
+  line in the template is commented out, so it documents the choices without
+  changing behaviour; each comment says what the default actually is, not just
+  what the key is called. `--force` overwrites, and without it `init` refuses
+  rather than replace a file that may hold a hand-written allowlist (#408).
+
 ## [0.8.8-beta.2] - 2026-08-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.2] - 2026-08-22
+
+### Changed
+- **[network]** `doaj.org` / `*.doaj.org` are on the **default** `oa-publisher`
+  allowlist (ADR-0037). They were already trusted under the `doaj` *metadata*
+  source key, which the CLI wires in only under `#[cfg(feature = "citation")]`, so
+  the two keys disagreed about a host the project had already accepted and a stock
+  build could not reach it at all. Promoted on the ADR-0027 precedent that made
+  `*.aps.org` unconditional. A gold-OA article routed through DOAJ now works with
+  no configuration (#405).
+- **[network]** DOAJ is removed from the `trust_oa_registries` curated set — it no
+  longer needs a flag. The remaining five (SciELO, Zenodo, OSF, HAL, CORE) appear
+  nowhere in `http.rs`, so for them the flag is genuinely new trust and stays
+  opt-in (#405).
+- **[docs]** `metadata` is redefined in `SOURCES.md` §3 and `CAPABILITY.md` as the
+  optional non-Tier-1 source surface as a whole — enrichment, resolution and
+  retrieval — with the runtime `DOIGET_ENABLE_<NAME>` flags, not the Cargo feature,
+  as the boundary that keeps sources inert (ADR-0040, #413).
+
+### Added
+- **[docs]** ADR-0037 (DOAJ on `oa-publisher`), ADR-0038 (store root stays
+  cwd-relative; 0036 reaffirmed against #406), ADR-0039 (IEEE / ACM / SIAM / AMS
+  stay off the allowlist; TDM credentials are the route, #407), ADR-0040 (source
+  expansion gated by `metadata`, #413).
+
 ## [0.8.8-beta.1] - 2026-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [0.8.8] - 2026-08-23
 
+### Fixed
+- **[source]** The five optional sources are now **actually reached**. DataCite was
+  wired into the DOI fan-out; Europe PMC, OpenAIRE, HAL and CORE were not called by
+  anything, so setting `DOIGET_ENABLE_HAL` (and the other three) was a silent no-op.
+  Every source unit test passed because each drove its own `Source` impl directly —
+  nothing asserted that the production path reached them (#413).
+- **[source]** Optional sources honour `DOIGET_<NAME>_BASE` overrides, mirroring
+  `DOIGET_CROSSREF_BASE`. Without this the chain could only ever talk to production,
+  which is *why* it shipped unreachable: no test could point it anywhere, so no test
+  could prove reachability.
+
+### Added
+- **[core]** A resolution trace. Every optional source records a `SourceAttempt`
+  — including the ones **not** consulted — distinguishing "not consulted (set
+  `DOIGET_ENABLE_X` to enable)", "not consulted (an earlier source answered)", "not
+  consulted (cannot serve this ref kind)", "consulted: no record", "consulted: found,
+  not open access", and "consulted: failed". A DOI that resolves nowhere now reports
+  which of those happened, per source, instead of returning the bare Crossref error.
+  "We asked and it had nothing" and "we never asked" are different problems with
+  different fixes, and were previously the same observable (#413).
+
 Five opt-in OA sources, a config-file generator, and four architecture decisions.
 The optional source surface roughly doubles — DataCite, Europe PMC, OpenAIRE, CORE
 and HAL — while the default binary is byte-identical to 0.8.7: every source is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.4] - 2026-08-22
+
+### Added
+- **[source]** **DataCite** DOI resolution, opt-in via `DOIGET_ENABLE_DATACITE`
+  (#414, first of the #413 epic under ADR-0040). DataCite is the second large
+  registration agency and Crossref/Unpaywall index neither its DOIs nor its
+  records, so a live, open-access Zenodo / figshare / Dryad / OSF DOI resolved to
+  `NOT_FOUND` — a false negative already documented on that `ErrorCode` variant
+  and seen as a false positive in `doiget-citation-check`. Ordered strictly
+  **after** Crossref in the DOI fan-out and only consulted when Crossref returned
+  nothing, so a Crossref-registered DOI never reaches it and enabling the flag
+  cannot change any resolution that already works. `resourceTypeGeneral` is
+  surfaced because most DataCite DOIs are not articles. Metadata only: DataCite
+  returns a landing page, not a file, so no PDF is fetched.
+
 ## [0.8.8-beta.3] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   anything, so setting `DOIGET_ENABLE_HAL` (and the other three) was a silent no-op.
   Every source unit test passed because each drove its own `Source` impl directly —
   nothing asserted that the production path reached them (#413).
+- **[ci]** `rustdoc` now builds the `oa-only,citation` surface too, not just
+  `oa-only`. Release binaries ship `citation`, but its docs were never built — so
+  two broken intra-doc links had been sitting latent on `main`, and the five new
+  sources could have added more without CI noticing. Both latent links fixed.
 - **[source]** Optional sources honour `DOIGET_<NAME>_BASE` overrides, mirroring
   `DOIGET_CROSSREF_BASE`. Without this the chain could only ever talk to production,
   which is *why* it shipped unreachable: no test could point it anywhere, so no test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.7] - 2026-08-23
+
+### Added
+- **[source]** **CORE** — cross-repository OA aggregation, opt-in via
+  `DOIGET_ENABLE_CORE` (#417). The broadest single OA index outside Unpaywall, so
+  it sits last in the optional chain. An **optional** free key in
+  `DOIGET_CORE_API_KEY` raises the rate limit; absent — or blank — it degrades to
+  the key-less limit rather than failing. No key is bundled and none is needed to
+  build. A rejected key surfaces as a transport error carrying the 401/403, which
+  is a different error *type* from the `NOT_FOUND` a genuine miss produces, so a
+  misconfigured key cannot be mistaken for an absent paper.
+
 ## [0.8.8-beta.6] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.1] - 2026-08-22
+
+### Fixed
+- **[ci]** Add `.cargo/audit.toml` mirroring the `[advisories] ignore` list in
+  `deny.toml`. The two tools do not share configuration — `cargo deny` reads
+  `deny.toml`, `cargo audit` reads `.cargo/audit.toml` — so the already-assessed
+  `paste` unmaintained advisory (RUSTSEC-2024-0436) was suppressed for one and
+  re-reported by the other. It stayed invisible because `rustsec/audit-check`
+  treats an informational warning as fatal on `push` but not on `pull_request`:
+  every PR was green while `main` had been red since 2026-08-10.
+
 ## [0.8.7] - 2026-08-22
 
 Security, allowlist visibility, and a network doctor. The two config keys that decide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.6] - 2026-08-23
+
+### Added
+- **[source]** **OpenAIRE** — European institutional / funder repository
+  aggregation, opt-in via `DOIGET_ENABLE_OPENAIRE` (#416). Uses the **Graph API
+  v1**; the legacy `/search/publications` endpoint is unstable (503s were measured
+  in #416) and is deliberately not wired. Unlike the pure-OA sources, OpenAIRE
+  aggregates records with **mixed access rights**, so a hit is not evidence of
+  availability: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted, judged
+  on the code rather than the human-readable label, and an absent field counts as
+  not open.
+
 ## [0.8.8-beta.5] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.8-beta.5] - 2026-08-23
+
+### Added
+- **[source]** **HAL** — the French national OA repository, opt-in via
+  `DOIGET_ENABLE_HAL` (#418). Holds author deposits in maths / physics / CS that
+  Crossref-centric indexes miss. OA deposits only: a record whose
+  `openAccess_bool` is not `true` is rejected rather than returned, because an
+  entry resolving to no reachable text looks like a hit but is not one.
+  Metadata-only; the `hal.science` content host is reached through
+  `oa-publisher`, not this source key.
+
+### Fixed
+- **[source]** Register `datacite` in `tier_2_allowlist`. **DataCite shipped in
+  0.8.8-beta.4 with no transport allowlist entry, so a production fetch would have
+  failed `UnknownSource`.** Every unit test passed because they build their client
+  with `new_for_tests_allow_http("datacite", ..)`, which registers the key itself —
+  the tests could not see the gap. A new
+  `every_tier_2_source_has_a_transport_allowlist_entry` enumerates the Tier-2
+  sources against the allowlist so this cannot recur; removing an entry now fails
+  `cargo test`.
+
 ## [0.8.8-beta.4] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
-## [0.8.8-beta.8] - 2026-08-23
+## [0.8.8] - 2026-08-23
+
+Five opt-in OA sources, a config-file generator, and four architecture decisions.
+The optional source surface roughly doubles — DataCite, Europe PMC, OpenAIRE, CORE
+and HAL — while the default binary is byte-identical to 0.8.7: every source is
+compiled in but inert until its own `DOIGET_ENABLE_<NAME>` is set.
 
 ### Added
 - **[source]** **Europe PMC** — biomedical OA full text that Unpaywall does not
@@ -23,10 +28,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   the source. The OA PDF location is surfaced from `fullTextUrlList`; the download
   itself goes through the existing `oa-publisher` leg, where a blocked fetch
   already surfaces with an ADR-0023 `denial_context` naming the host and allowlist.
-
-## [0.8.8-beta.7] - 2026-08-23
-
-### Added
 - **[source]** **CORE** — cross-repository OA aggregation, opt-in via
   `DOIGET_ENABLE_CORE` (#417). The broadest single OA index outside Unpaywall, so
   it sits last in the optional chain. An **optional** free key in
@@ -35,10 +36,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   build. A rejected key surfaces as a transport error carrying the 401/403, which
   is a different error *type* from the `NOT_FOUND` a genuine miss produces, so a
   misconfigured key cannot be mistaken for an absent paper.
-
-## [0.8.8-beta.6] - 2026-08-23
-
-### Added
 - **[source]** **OpenAIRE** — European institutional / funder repository
   aggregation, opt-in via `DOIGET_ENABLE_OPENAIRE` (#416). Uses the **Graph API
   v1**; the legacy `/search/publications` endpoint is unstable (503s were measured
@@ -47,10 +44,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   availability: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted, judged
   on the code rather than the human-readable label, and an absent field counts as
   not open.
-
-## [0.8.8-beta.5] - 2026-08-23
-
-### Added
 - **[source]** **HAL** — the French national OA repository, opt-in via
   `DOIGET_ENABLE_HAL` (#418). Holds author deposits in maths / physics / CS that
   Crossref-centric indexes miss. OA deposits only: a record whose
@@ -58,20 +51,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   entry resolving to no reachable text looks like a hit but is not one.
   Metadata-only; the `hal.science` content host is reached through
   `oa-publisher`, not this source key.
-
-### Fixed
-- **[source]** Register `datacite` in `tier_2_allowlist`. **DataCite shipped in
-  0.8.8-beta.4 with no transport allowlist entry, so a production fetch would have
-  failed `UnknownSource`.** Every unit test passed because they build their client
-  with `new_for_tests_allow_http("datacite", ..)`, which registers the key itself —
-  the tests could not see the gap. A new
-  `every_tier_2_source_has_a_transport_allowlist_entry` enumerates the Tier-2
-  sources against the allowlist so this cannot recur; removing an entry now fails
-  `cargo test`.
-
-## [0.8.8-beta.4] - 2026-08-22
-
-### Added
 - **[source]** **DataCite** DOI resolution, opt-in via `DOIGET_ENABLE_DATACITE`
   (#414, first of the #413 epic under ADR-0040). DataCite is the second large
   registration agency and Crossref/Unpaywall index neither its DOIs nor its
@@ -83,10 +62,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   cannot change any resolution that already works. `resourceTypeGeneral` is
   surfaced because most DataCite DOIs are not articles. Metadata only: DataCite
   returns a landing page, not a file, so no PDF is fetched.
-
-## [0.8.8-beta.3] - 2026-08-22
-
-### Added
 - **[cli]** `doiget config init` writes a fully commented `config.toml` template to
   the resolved config path. A fresh install has no config file, nothing created
   one, and three of the four settings that decide a session's outcome — store
@@ -95,8 +70,10 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   changing behaviour; each comment says what the default actually is, not just
   what the key is called. `--force` overwrites, and without it `init` refuses
   rather than replace a file that may hold a hand-written allowlist (#408).
-
-## [0.8.8-beta.2] - 2026-08-22
+- **[docs]** ADR-0037 (DOAJ on `oa-publisher`), ADR-0038 (store root stays
+  cwd-relative; 0036 reaffirmed against #406), ADR-0039 (IEEE / ACM / SIAM / AMS
+  stay off the allowlist; TDM credentials are the route, #407), ADR-0040 (source
+  expansion gated by `metadata`, #413).
 
 ### Changed
 - **[network]** `doaj.org` / `*.doaj.org` are on the **default** `oa-publisher`
@@ -115,15 +92,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   retrieval — with the runtime `DOIGET_ENABLE_<NAME>` flags, not the Cargo feature,
   as the boundary that keeps sources inert (ADR-0040, #413).
 
-### Added
-- **[docs]** ADR-0037 (DOAJ on `oa-publisher`), ADR-0038 (store root stays
-  cwd-relative; 0036 reaffirmed against #406), ADR-0039 (IEEE / ACM / SIAM / AMS
-  stay off the allowlist; TDM credentials are the route, #407), ADR-0040 (source
-  expansion gated by `metadata`, #413).
-
-## [0.8.8-beta.1] - 2026-08-22
-
 ### Fixed
+- **[source]** Register `datacite` in `tier_2_allowlist`. **DataCite shipped in
+  0.8.8-beta.4 with no transport allowlist entry, so a production fetch would have
+  failed `UnknownSource`.** Every unit test passed because they build their client
+  with `new_for_tests_allow_http("datacite", ..)`, which registers the key itself —
+  the tests could not see the gap. A new
+  `every_tier_2_source_has_a_transport_allowlist_entry` enumerates the Tier-2
+  sources against the allowlist so this cannot recur; removing an entry now fails
+  `cargo test`.
 - **[ci]** Add `.cargo/audit.toml` mirroring the `[advisories] ignore` list in
   `deny.toml`. The two tools do not share configuration — `cargo deny` reads
   `deny.toml`, `cargo audit` reads `.cargo/audit.toml` — so the already-assessed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.6"
+version = "0.8.8-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.6"
+version = "0.8.8-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.6"
+version = "0.8.8-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.8"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.8"
+version = "0.8.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.8"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.5"
+version = "0.8.8-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.5"
+version = "0.8.8-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.5"
+version = "0.8.8-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.4"
+version = "0.8.8-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.4"
+version = "0.8.8-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.4"
+version = "0.8.8-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.7"
+version = "0.8.8-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.7"
+version = "0.8.8-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.7"
+version = "0.8.8-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.7"
+version = "0.8.8-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.7"
+version = "0.8.8-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.7"
+version = "0.8.8-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.3"
+version = "0.8.8-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.3"
+version = "0.8.8-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.3"
+version = "0.8.8-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.1"
+version = "0.8.8-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.1"
+version = "0.8.8-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.1"
+version = "0.8.8-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8-beta.2"
+version = "0.8.8-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8-beta.2"
+version = "0.8.8-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8-beta.2"
+version = "0.8.8-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.6"
+version       = "0.8.8-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.6" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.6" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.6" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.1"
+version       = "0.8.8-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.4"
+version       = "0.8.8-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.3"
+version       = "0.8.8-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.2"
+version       = "0.8.8-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.7"
+version       = "0.8.8-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.8"
+version       = "0.8.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.7"
+version       = "0.8.8-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8-beta.5"
+version       = "0.8.8-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.8-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -11,7 +11,7 @@
 //! never invoked from inside an MCP session (`doiget serve` runs a
 //! different code path), so the lint is locally relaxed below.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 
 use super::fetch::CliExit;
@@ -129,7 +129,12 @@ impl ResolvedConfig {
 // belong on stderr by design (stdout stays clean for `| jq` style pipes
 // when we add `--json` later).
 #[allow(clippy::print_stdout, clippy::print_stderr)]
-pub async fn run(action: String, mode: super::output::OutputMode, network: bool) -> Result<()> {
+pub async fn run(
+    action: String,
+    mode: super::output::OutputMode,
+    network: bool,
+    force: bool,
+) -> Result<()> {
     // `mode` honors ADR-0017: `Quiet` suppresses the TOML dump (`show`)
     // and the path println! (`path`); `doctor` is unaffected because its
     // per-check output is on stderr and only the failure/success exit
@@ -138,6 +143,10 @@ pub async fn run(action: String, mode: super::output::OutputMode, network: bool)
     let cfg = ResolvedConfig::from_env()?;
     if network && action != "doctor" {
         eprintln_err("error: --network applies to `config doctor` only");
+        return Err(anyhow::Error::new(CliExit(2)));
+    }
+    if force && action != "init" {
+        eprintln_err("error: --force applies to `config init` only");
         return Err(anyhow::Error::new(CliExit(2)));
     }
     match action.as_str() {
@@ -155,6 +164,7 @@ pub async fn run(action: String, mode: super::output::OutputMode, network: bool)
                 print!("{s}");
             }
         },
+        "init" => init_config(&cfg, force, mode)?,
         "path" => match mode {
             super::output::OutputMode::Quiet => {}
             super::output::OutputMode::Json => {
@@ -304,7 +314,7 @@ pub async fn run(action: String, mode: super::output::OutputMode, network: bool)
             // misuse → `docs/ERRORS.md` §4 exit 2, not the generic exit 1
             // a bare `bail!` produced.
             eprintln_err(&format!(
-                "error: unknown config action: {other}; expected `show` / `path` / `doctor`"
+                "error: unknown config action: {other}; expected `init` / `show` / `path` / `doctor`"
             ));
             return Err(anyhow::Error::new(CliExit(2)));
         }
@@ -327,6 +337,135 @@ fn eprintln_err(msg: &str) {
 /// When `ok` is `false` and `tip` is `Some`, a remediation tip is printed
 /// on the next line, indented so it is visually attached to the failed
 /// check (issue #322).
+/// The commented `config.toml` template written by `doiget config init`.
+///
+/// Issue #408: on a fresh install `~/.config/doiget/config.toml` does not
+/// exist, nothing creates it, and four of the settings that decide the
+/// outcome of a session live in it. Three of those four fail *silently*.
+/// Every commented line here doubles as documentation at the place the user
+/// is already looking.
+///
+/// Pure and `pub(crate)` so the tests can assert the template actually
+/// mentions each load-bearing key — a template that silently loses one is
+/// the failure mode worth guarding against.
+pub(crate) fn config_template() -> &'static str {
+    // NOTE: every key below is commented out on purpose. Writing live values
+    // would change behaviour just by running `init`; the file's job is to be
+    // a discoverable, annotated menu, not a new set of defaults.
+    r#"# ~/.config/doiget/config.toml — written by `doiget config init`.
+#
+# Every field is optional and every line below is commented out: this file
+# documents the choices, it does not change behaviour until you uncomment
+# something. Re-run `doiget config init --force` to restore this template.
+#
+# See docs/CONFIG.md for the full schema, and run `doiget config doctor`
+# (add --network for outbound checks) to see what is actually in effect.
+
+[store]
+# Where fetched papers are written.
+#
+# DEFAULT: `./papers` — relative to the CURRENT WORKING DIRECTORY, so it
+# moves with you (ADR-0036). That is deliberate: artifacts land where the
+# work is, instead of somewhere you have to go looking for. The cost is that
+# fetching from many directories leaves several small stores. Set this for a
+# single central library.
+# root = "/home/you/papers"
+
+[network]
+# Contact address for the polite pool. STRONGLY RECOMMENDED.
+#
+# Without it doiget still queries Unpaywall, but as `doiget@localhost`, from
+# the non-polite pool — where you may be throttled or refused. Since the
+# automatic arXiv-preprint fallback fires on what Unpaywall reports, a
+# throttled response quietly costs you that fallback too.
+# unpaywall_email = "you@institution.edu"
+
+# Allow the curated academic-repository suffixes, i.e. where institutions
+# host their own Green OA:
+#   *.ac.uk  *.ac.jp  *.jst.go.jp  *.edu.au  *.edu.cn  *.ac.cn  *.edu.pl
+#   *.ac.nz  *.ac.za  *.ac.in  *.edu.br  *.edu.tw  *.edu.tr  *.edu.ar
+#   *.edu.mx
+#
+# Without this, an OA PDF on e.g. `strathprints.strath.ac.uk` is denied with
+# `error[CAPABILITY_DENIED] ... redirect_not_in_allowlist`.
+# trust_academic_repos = false
+
+# Allow the curated cross-publisher OA registries and repositories:
+#   scielo.org  zenodo.org  osf.io  hal.science  core.ac.uk  (+ subdomains)
+#
+# Separate from the flag above because the trust argument differs: one is
+# "this institution publishes its own work here", the other is "this registry
+# indexes open content across publishers". DOAJ needs no flag — it is on the
+# default allowlist (ADR-0037).
+# trust_oa_registries = false
+
+# Anything outside both curated sets. Each entry is a literal FQDN or a
+# single-suffix wildcard (`*.example.edu`); multi-segment globs are rejected
+# at load time, as are unknown keys in this table.
+# [[network.additional_hosts]]
+# host = "repository.example.edu"
+# note = "free-text, optional"
+
+# Request timeouts, in seconds.
+# connect_timeout_sec = 10
+# read_timeout_sec = 60
+# total_timeout_sec = 300
+
+[output]
+# mode = "human"     # human | json | quiet | mcp
+# color = "auto"     # auto | always | never
+# progress = false
+# emoji = false
+"#
+}
+
+/// `doiget config init` — write [`config_template`] to the resolved config
+/// path (issue #408).
+///
+/// Refuses to overwrite an existing file unless `force`. That refusal is the
+/// whole safety property: the file may hold a user's hand-written allowlist,
+/// and silently replacing it with a fully commented-out template would
+/// disable every host they had added.
+#[allow(clippy::print_stdout, clippy::print_stderr)]
+fn init_config(cfg: &ResolvedConfig, force: bool, mode: super::output::OutputMode) -> Result<()> {
+    let path = &cfg.config_path;
+    let existed = path.exists();
+    if existed && !force {
+        eprintln_err(&format!(
+            "error: {path} already exists; pass --force to overwrite it"
+        ));
+        return Err(anyhow::Error::new(CliExit(2)));
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent.as_std_path())
+            .with_context(|| format!("creating config directory {parent}"))?;
+    }
+    std::fs::write(path.as_std_path(), config_template())
+        .with_context(|| format!("writing {path}"))?;
+
+    match mode {
+        super::output::OutputMode::Quiet => {}
+        super::output::OutputMode::Json => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "ok": true,
+                    "config_path": path.as_str(),
+                    "overwritten": existed,
+                })
+            );
+        }
+        _ => {
+            let verb = if existed { "overwrote" } else { "wrote" };
+            println!("{verb} {path}");
+            eprintln_err(
+                "  = note: every field is commented out; nothing changed until you edit it",
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Classification of a single publisher probe (issue #407).
 ///
 /// The point of the enum is the `BotChallenge` arm. A publisher WAF answers
@@ -672,6 +811,68 @@ mod tests {
         );
     }
 
+    // ── #408: `config init` ──────────────────────────────────────────────
+
+    /// The template's job is to document the keys that fail *silently* on a
+    /// default install. If one is ever dropped from it, the file stops being
+    /// the answer to #408 while still looking fine.
+    #[test]
+    fn template_documents_every_silently_defaulting_key() {
+        let t = config_template();
+        for key in [
+            "[store]",
+            "root =",
+            "unpaywall_email",
+            "trust_academic_repos",
+            "trust_oa_registries",
+            "[[network.additional_hosts]]",
+        ] {
+            assert!(t.contains(key), "template must mention {key}");
+        }
+        // ADR-0036 / ADR-0037 are the two non-obvious defaults; the template
+        // must say what they are, not merely name the keys.
+        assert!(
+            t.contains("CURRENT WORKING DIRECTORY"),
+            "store root default"
+        );
+        assert!(
+            t.contains("doiget@localhost"),
+            "non-polite pool consequence"
+        );
+        assert!(t.contains("DOAJ needs no flag"), "post-ADR-0037 accuracy");
+    }
+
+    /// Every line must be inert: writing live values would mean `init`
+    /// silently changed behaviour just by being run.
+    #[test]
+    fn template_is_entirely_commented_out() {
+        for line in config_template().lines() {
+            let t = line.trim();
+            if t.is_empty() || t.starts_with('#') {
+                continue;
+            }
+            assert!(
+                t.starts_with('[') && t.ends_with(']') && !t.starts_with("[["),
+                "only bare section headers may be live; found: {line:?}"
+            );
+        }
+    }
+
+    /// The template must round-trip as TOML — a malformed one would be
+    /// written happily and only fail on the user's next command.
+    #[test]
+    fn template_parses_as_toml() {
+        let v: toml::Value = toml::from_str(config_template()).expect("template is valid TOML");
+        // With everything commented out it must carry no live keys beyond the
+        // empty section tables.
+        for (name, tbl) in v.as_table().expect("table") {
+            assert!(
+                tbl.as_table().expect("section").is_empty(),
+                "section [{name}] must be empty in the template"
+            );
+        }
+    }
+
     // ── #407: probe classification ───────────────────────────────────────
 
     /// The load-bearing case. A publisher WAF answers a scripted client
@@ -758,6 +959,7 @@ mod tests {
             "doctor".into(),
             crate::commands::output::OutputMode::Human,
             false,
+            false,
         )
         .await
         .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
@@ -780,6 +982,7 @@ mod tests {
         run(
             "doctor".into(),
             crate::commands::output::OutputMode::Human,
+            false,
             false,
         )
         .await
@@ -833,6 +1036,7 @@ mod tests {
             "doctor".into(),
             crate::commands::output::OutputMode::Human,
             false,
+            false,
         )
         .await
         .expect_err("doctor should fail when user-extension config is malformed");
@@ -872,6 +1076,7 @@ mod tests {
         let err = run(
             "bogus".into(),
             crate::commands::output::OutputMode::Human,
+            false,
             false,
         )
         .await

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1373,13 +1373,16 @@ host = "*.uj.edu.pl"
             .source_allowlist("oa-publisher")
             .expect("oa-publisher source registered");
 
+        // ADR-0037: DOAJ is a DEFAULT allowlist entry now, so it is not
+        // evidence that the flag worked. Assert on a host only the flag can
+        // provide.
         assert!(
-            oa.matches("doaj.org"),
-            "the apex that denied 10.1109/access.2024.3495502 MUST match; got {:?}",
+            oa.matches("zenodo.org"),
+            "the zenodo apex must match with the flag set; got {:?}",
             oa.redirect_hosts
         );
-        assert!(oa.matches("www.doaj.org"), "wildcard covers subdomains");
-        assert!(oa.matches("zenodo.org"), "zenodo apex must match");
+        assert!(oa.matches("data.zenodo.org"), "wildcard covers subdomains");
+        assert!(oa.matches("hal.science"), "hal apex must match");
         assert!(
             oa.redirect_hosts.iter().any(|p| p == "*.aps.org"),
             "the curated allowlist MUST survive the merge"

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -125,7 +125,7 @@ enum ProvenanceAction {
                   \x20 list-recent  List the most recently fetched entries\n\
                   \x20 audit-log    Inspect or verify the provenance log\n\
                   \x20 provenance   Provenance-log lifecycle ops (migrate v1 -> v2)\n\
-                  \x20 config       Show or doctor the resolved configuration\n\
+                  \x20 config       init / show / path / doctor the configuration\n\
                   \x20 serve        Run as an MCP server over stdio\n\
                   \x20 graph        Expand a DOI's citation neighborhood via OpenAlex\n\
                   \x20              (requires --features citation + DOIGET_ENABLE_OPENALEX)\n\
@@ -565,8 +565,13 @@ enum Command {
     Capabilities,
     /// Show or doctor the resolved configuration.
     Config {
-        /// `show` / `path` / `doctor`
+        /// `init` / `show` / `path` / `doctor`
         action: String,
+        /// `init` only: overwrite an existing config.toml. Without this,
+        /// `init` refuses rather than replace a file that may hold a
+        /// hand-written allowlist (issue #408).
+        #[arg(long)]
+        force: bool,
         /// `doctor` only: also run the outbound network report — proxy
         /// configuration, Unpaywall pool, allowlist coverage, and one
         /// GET per well-known publisher to show which will talk to a
@@ -760,9 +765,11 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
                 doiget_cli::commands::provenance::migrate(dry_run, mode)
             }
         },
-        Some(Command::Config { action, network }) => {
-            doiget_cli::commands::config::run(action, mode, network).await
-        }
+        Some(Command::Config {
+            action,
+            network,
+            force,
+        }) => doiget_cli::commands::config::run(action, mode, network, force).await,
         Some(Command::Info { ref_ }) => {
             doiget_cli::commands::info::run(ref_, mode, out.quiet_was_explicit)
         }

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -447,6 +447,7 @@ mod tests {
             openalex: true,
             semantic_scholar: false,
             doaj: false,
+            datacite: false,
         };
         p
     }

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -450,6 +450,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -451,6 +451,7 @@ mod tests {
             hal: false,
             openaire: false,
             core: false,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -449,6 +449,7 @@ mod tests {
             doaj: false,
             datacite: false,
             hal: false,
+            openaire: false,
         };
         p
     }

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -1,6 +1,6 @@
 //! Citation graph BFS expansion (Phase 4 / ADR-0010).
 //!
-//! Spec: [`docs/DECISIONS/0010-citation-graph-hard-cap.md`].
+//! Spec: `docs/DECISIONS/0010-citation-graph-hard-cap.md`.
 //!
 //! ## Binding contract
 //!

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -448,6 +448,7 @@ mod tests {
             semantic_scholar: false,
             doaj: false,
             datacite: false,
+            hal: false,
         };
         p
     }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -259,6 +259,8 @@ pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
         // endpoint on the same host is unstable (503s) and deliberately
         // unused; only the Graph path is called.
         SourceAllowlist::new("openaire", vec!["api.openaire.eu".to_string()]),
+        // CORE REST v3 (#417). Optional bearer key; same host either way.
+        SourceAllowlist::new("core", vec!["api.core.ac.uk".to_string()]),
     ]
 }
 
@@ -1427,6 +1429,7 @@ mod tests {
         let datacite = crate::sources::datacite::DataCiteSource::new();
         let hal = crate::sources::hal::HalSource::new();
         let openaire = crate::sources::openaire::OpenAireSource::new();
+        let core = crate::sources::core_oa::CoreSource::new();
         let names: Vec<&str> = vec![
             openalex.name(),
             s2.name(),
@@ -1434,6 +1437,7 @@ mod tests {
             datacite.name(),
             hal.name(),
             openaire.name(),
+            core.name(),
         ];
         let registered: Vec<String> = tier_2_allowlist()
             .iter()

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -432,6 +432,20 @@ pub fn oa_publisher_allowlist() -> Vec<SourceAllowlist> {
             "*.scipost.org".to_string(),
             // IOP Publishing — iopscience.iop.org (New J. Phys. etc.).
             "*.iop.org".to_string(),
+            // DOAJ — the canonical redirect host for gold-OA journal
+            // content. ADR-0037: this domain was ALREADY trusted in this
+            // file under the `"doaj"` metadata key (`tier_2_allowlist`),
+            // which the CLI wires in only under
+            // `#[cfg(feature = "citation")]` — so the two keys disagreed
+            // about a host the project had already accepted, and a stock
+            // build could not reach it at all. Promoted here on the
+            // ADR-0027 precedent that made `*.aps.org` unconditional
+            // rather than feature-gated. The apex is listed separately
+            // because a single-suffix wildcard does not match it and the
+            // observed redirect (10.1109/access.2024.3495502, #405)
+            // targeted the bare apex.
+            "doaj.org".to_string(),
+            "*.doaj.org".to_string(),
             // arXiv — already on the `arxiv` tier-1 allowlist, but the
             // Unpaywall-driven path uses the `oa-publisher` source key,
             // so we mirror the host list here too. See REDIRECT_ALLOWLIST.md
@@ -1376,6 +1390,52 @@ fn build_client(allowlist: SourceAllowlist, ua: &str) -> Result<Client, reqwest:
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// ADR-0037: `doaj.org` must be reachable on the `oa-publisher` key with
+    /// NO config file and NO feature flags — that is the whole point of
+    /// promoting it. Pinned on the apex specifically: a single-suffix
+    /// wildcard does not match an apex, and the redirect that motivated
+    /// #405 (10.1109/access.2024.3495502, IEEE Access gold OA) targeted the
+    /// bare apex.
+    #[test]
+    fn doaj_is_on_the_default_oa_publisher_allowlist() {
+        let lists = oa_publisher_allowlist();
+        let oa = lists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .expect("oa-publisher entry");
+        assert!(
+            oa.matches("doaj.org"),
+            "apex must match: {:?}",
+            oa.redirect_hosts
+        );
+        assert!(oa.matches("www.doaj.org"), "subdomains must match");
+        assert!(
+            !oa.matches("doaj.org.evil.test"),
+            "suffix confusion must not match"
+        );
+    }
+
+    /// The `"doaj"` metadata key and the `"oa-publisher"` PDF-redirect key
+    /// must now agree about DOAJ. Their disagreement was the defect ADR-0037
+    /// fixed; this pins that they cannot silently drift apart again.
+    #[test]
+    fn doaj_metadata_and_oa_publisher_keys_agree() {
+        let meta = tier_2_allowlist();
+        let doaj = meta.iter().find(|a| a.source == "doaj").expect("doaj key");
+        let lists = oa_publisher_allowlist();
+        let oa = lists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .expect("oa key");
+        for pat in &doaj.redirect_hosts {
+            let sample = pat.strip_prefix("*.").unwrap_or(pat);
+            assert!(
+                oa.matches(sample),
+                "{pat} is trusted on the doaj key but not on oa-publisher"
+            );
+        }
+    }
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -245,6 +245,16 @@ pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
             "doaj",
             vec!["doaj.org".to_string(), "*.doaj.org".to_string()],
         ),
+        // DataCite REST — DOI resolution for the second registration
+        // agency (#414). Distinct from `doaj.org`: that host serves
+        // article records, this one is the DOI registry API.
+        SourceAllowlist::new("datacite", vec!["api.datacite.org".to_string()]),
+        // HAL — French national OA repository, Solr-style search API
+        // (#418). `api.archives-ouvertes.fr` is the API host; the
+        // deposit landing pages live on `hal.science`, which is reached
+        // through the `oa-publisher` key (via `trust_oa_registries`),
+        // not this one.
+        SourceAllowlist::new("hal", vec!["api.archives-ouvertes.fr".to_string()]),
     ]
 }
 
@@ -1390,6 +1400,46 @@ fn build_client(allowlist: SourceAllowlist, ua: &str) -> Result<Client, reqwest:
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// Every Tier-2 `Source` MUST have a transport allowlist entry under
+    /// its own `name()`, or `HttpClient::fetch_bytes` rejects it with
+    /// `UnknownSource` in production.
+    ///
+    /// This was not hypothetical: #414 shipped `DataCiteSource` with no
+    /// `tier_2_allowlist` entry. Every unit test passed because they build
+    /// their client with `new_for_tests_allow_http("datacite", ..)`, which
+    /// registers the key itself — so the tests could not see the gap, and
+    /// only a real fetch would have. Enumerating the names here means
+    /// adding a source without its allowlist entry fails at `cargo test`.
+    #[test]
+    #[cfg(feature = "metadata")]
+    fn every_tier_2_source_has_a_transport_allowlist_entry() {
+        use crate::source::Source as _;
+        // Bind first: `name()` borrows from the source, so the values must
+        // outlive the collection.
+        let openalex = crate::sources::openalex::OpenalexSource::new(String::new());
+        let s2 = crate::sources::s2::S2Source::new(None);
+        let doaj = crate::sources::doaj::DoajSource::new();
+        let datacite = crate::sources::datacite::DataCiteSource::new();
+        let hal = crate::sources::hal::HalSource::new();
+        let names: Vec<&str> = vec![
+            openalex.name(),
+            s2.name(),
+            doaj.name(),
+            datacite.name(),
+            hal.name(),
+        ];
+        let registered: Vec<String> = tier_2_allowlist()
+            .iter()
+            .map(|a| a.source.clone())
+            .collect();
+        for n in names {
+            assert!(
+                registered.iter().any(|r| r == n),
+                "source `{n}` has no tier_2_allowlist entry; a production fetch                  would fail UnknownSource. registered: {registered:?}"
+            );
+        }
+    }
 
     /// ADR-0037: `doaj.org` must be reachable on the `oa-publisher` key with
     /// NO config file and NO feature flags — that is the whole point of

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -255,6 +255,10 @@ pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
         // through the `oa-publisher` key (via `trust_oa_registries`),
         // not this one.
         SourceAllowlist::new("hal", vec!["api.archives-ouvertes.fr".to_string()]),
+        // OpenAIRE Graph API v1 (#416). The legacy `/search/publications`
+        // endpoint on the same host is unstable (503s) and deliberately
+        // unused; only the Graph path is called.
+        SourceAllowlist::new("openaire", vec!["api.openaire.eu".to_string()]),
     ]
 }
 
@@ -1422,12 +1426,14 @@ mod tests {
         let doaj = crate::sources::doaj::DoajSource::new();
         let datacite = crate::sources::datacite::DataCiteSource::new();
         let hal = crate::sources::hal::HalSource::new();
+        let openaire = crate::sources::openaire::OpenAireSource::new();
         let names: Vec<&str> = vec![
             openalex.name(),
             s2.name(),
             doaj.name(),
             datacite.name(),
             hal.name(),
+            openaire.name(),
         ];
         let registered: Vec<String> = tier_2_allowlist()
             .iter()

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -261,6 +261,10 @@ pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
         SourceAllowlist::new("openaire", vec!["api.openaire.eu".to_string()]),
         // CORE REST v3 (#417). Optional bearer key; same host either way.
         SourceAllowlist::new("core", vec!["api.core.ac.uk".to_string()]),
+        // Europe PMC REST (#415). This is the EBI API host; the OA PDF it
+        // points at lives on `europepmc.org`, which is already on the
+        // `oa-publisher` key and is where the download actually happens.
+        SourceAllowlist::new("europe-pmc", vec!["www.ebi.ac.uk".to_string()]),
     ]
 }
 
@@ -1430,6 +1434,7 @@ mod tests {
         let hal = crate::sources::hal::HalSource::new();
         let openaire = crate::sources::openaire::OpenAireSource::new();
         let core = crate::sources::core_oa::CoreSource::new();
+        let epmc = crate::sources::europepmc::EuropePmcSource::new();
         let names: Vec<&str> = vec![
             openalex.name(),
             s2.name(),
@@ -1438,6 +1443,7 @@ mod tests {
             hal.name(),
             openaire.name(),
             core.name(),
+            epmc.name(),
         ];
         let registered: Vec<String> = tier_2_allowlist()
             .iter()

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -933,6 +933,9 @@ pub struct MetadataAccess {
     /// CS deposits that Crossref-centric indexes miss; enabled by
     /// `DOIGET_ENABLE_HAL` (ADR-0040, #418).
     pub hal: bool,
+    /// OpenAIRE — European institutional / funder repository aggregation;
+    /// enabled by `DOIGET_ENABLE_OPENAIRE` (ADR-0040, #416).
+    pub openaire: bool,
 }
 
 /// Process-wide rate limits. Hard-coded; not configurable.
@@ -1170,6 +1173,11 @@ impl CapabilityProfile {
                 cfg!(feature = "metadata"),
             ),
             hal: resolve_metadata_flag("DOIGET_ENABLE_HAL", "metadata", cfg!(feature = "metadata")),
+            openaire: resolve_metadata_flag(
+                "DOIGET_ENABLE_OPENAIRE",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
         };
 
         // -- Tier 3 TDM grants ----------------------------------------------

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -936,6 +936,11 @@ pub struct MetadataAccess {
     /// OpenAIRE — European institutional / funder repository aggregation;
     /// enabled by `DOIGET_ENABLE_OPENAIRE` (ADR-0040, #416).
     pub openaire: bool,
+    /// CORE — cross-repository OA aggregation, the last fallback in the
+    /// optional chain; enabled by `DOIGET_ENABLE_CORE`. An optional free
+    /// key in `DOIGET_CORE_API_KEY` raises the rate limit but is not
+    /// required (ADR-0040, #417).
+    pub core: bool,
 }
 
 /// Process-wide rate limits. Hard-coded; not configurable.
@@ -1175,6 +1180,11 @@ impl CapabilityProfile {
             hal: resolve_metadata_flag("DOIGET_ENABLE_HAL", "metadata", cfg!(feature = "metadata")),
             openaire: resolve_metadata_flag(
                 "DOIGET_ENABLE_OPENAIRE",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+            core: resolve_metadata_flag(
+                "DOIGET_ENABLE_CORE",
                 "metadata",
                 cfg!(feature = "metadata"),
             ),

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -929,6 +929,10 @@ pub struct MetadataAccess {
     /// simply do not index these DOIs, so without it a live, open record is
     /// reported [`ErrorCode::NotFound`] (ADR-0040, #414).
     pub datacite: bool,
+    /// HAL — the French national OA repository, holding maths / physics /
+    /// CS deposits that Crossref-centric indexes miss; enabled by
+    /// `DOIGET_ENABLE_HAL` (ADR-0040, #418).
+    pub hal: bool,
 }
 
 /// Process-wide rate limits. Hard-coded; not configurable.
@@ -1165,6 +1169,7 @@ impl CapabilityProfile {
                 "metadata",
                 cfg!(feature = "metadata"),
             ),
+            hal: resolve_metadata_flag("DOIGET_ENABLE_HAL", "metadata", cfg!(feature = "metadata")),
         };
 
         // -- Tier 3 TDM grants ----------------------------------------------

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -921,6 +921,14 @@ pub struct MetadataAccess {
     pub semantic_scholar: bool,
     /// Phase 4+; enabled by `DOIGET_ENABLE_DOAJ`.
     pub doaj: bool,
+    /// DOI **resolution** for DataCite-registered DOIs (Zenodo / figshare /
+    /// Dryad / OSF / most institutional repositories); enabled by
+    /// `DOIGET_ENABLE_DATACITE`.
+    ///
+    /// Unlike its siblings this is not enrichment — Crossref and Unpaywall
+    /// simply do not index these DOIs, so without it a live, open record is
+    /// reported [`ErrorCode::NotFound`] (ADR-0040, #414).
+    pub datacite: bool,
 }
 
 /// Process-wide rate limits. Hard-coded; not configurable.
@@ -1149,6 +1157,11 @@ impl CapabilityProfile {
             ),
             doaj: resolve_metadata_flag(
                 "DOIGET_ENABLE_DOAJ",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+            datacite: resolve_metadata_flag(
+                "DOIGET_ENABLE_DATACITE",
                 "metadata",
                 cfg!(feature = "metadata"),
             ),

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -941,6 +941,9 @@ pub struct MetadataAccess {
     /// key in `DOIGET_CORE_API_KEY` raises the rate limit but is not
     /// required (ADR-0040, #417).
     pub core: bool,
+    /// Europe PMC — biomedical OA full text that Unpaywall does not index;
+    /// enabled by `DOIGET_ENABLE_EUROPE_PMC` (ADR-0040, #415).
+    pub europe_pmc: bool,
 }
 
 /// Process-wide rate limits. Hard-coded; not configurable.
@@ -1185,6 +1188,11 @@ impl CapabilityProfile {
             ),
             core: resolve_metadata_flag(
                 "DOIGET_ENABLE_CORE",
+                "metadata",
+                cfg!(feature = "metadata"),
+            ),
+            europe_pmc: resolve_metadata_flag(
+                "DOIGET_ENABLE_EUROPE_PMC",
                 "metadata",
                 cfg!(feature = "metadata"),
             ),

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1119,39 +1119,33 @@ async fn fetch_paper_doi(
     #[allow(unused_mut)]
     let mut extracted = extract_crossref_fields(&crossref_meta);
 
-    // Issue #414 / ADR-0040: DataCite fallback, strictly AFTER Crossref and
-    // only when Crossref produced nothing. DataCite is the other large
-    // registration agency — Zenodo / figshare / Dryad / OSF DOIs are in
-    // neither Crossref nor Unpaywall, so without this a live, open record
-    // is reported NotFound. Ordering it here is what makes the source
-    // additive: a Crossref-registered DOI never reaches it, so turning the
-    // flag on cannot change any resolution that already works.
+    // #413 / ADR-0040: the optional resolution chain, strictly AFTER
+    // Crossref and consulted only when Crossref produced nothing. That
+    // ordering is what makes every source additive — a Crossref-registered
+    // DOI never reaches them, so enabling a flag cannot change a
+    // resolution that already works.
     //
-    // Runtime-gated by `DOIGET_ENABLE_DATACITE` (off by default), so with
-    // the flag unset this block is inert and behaviour is byte-identical.
+    // Every source records a `SourceAttempt`, including the ones that were
+    // NOT consulted. That is the point: before this, a failed DOI fetch
+    // returned the Crossref error and said nothing about the rest of the
+    // chain, so "HAL was asked and had nothing" and "HAL was never asked
+    // because the flag is unset" were the same observable. They are
+    // different problems with different fixes.
+    #[allow(unused_mut)]
+    let mut attempts: Vec<SourceAttempt> = Vec::new();
     #[cfg(feature = "metadata")]
-    let datacite_meta = if cross.is_none() && profile.metadata.datacite {
-        match crate::sources::datacite::DataCiteSource::new()
-            .fetch(ref_, profile, ctx)
-            .await
-        {
-            Ok(r) => {
-                if let Some(attrs) = r.metadata_json.as_ref() {
-                    extracted = extract_datacite_fields(attrs);
-                }
-                r.metadata_json
-            }
-            Err(e) => {
-                tracing::debug!(error = %e, "datacite fallback found nothing for this DOI");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let optional_meta = resolve_optional_chain(
+        ref_,
+        profile,
+        ctx,
+        cross.is_some(),
+        &mut extracted,
+        &mut attempts,
+    )
+    .await;
     #[cfg(not(feature = "metadata"))]
-    let datacite_meta: Option<Value> = None;
-    let _ = &datacite_meta;
+    let optional_meta: Option<Value> = None;
+    let _ = &optional_meta;
 
     // Unpaywall second — license enrichment + OA URL chain discovery.
     // A failure here is non-fatal: we still write the Crossref-
@@ -1321,6 +1315,26 @@ async fn fetch_paper_doi(
     // Surface the Crossref error so the caller reports a real reason.
     if let Some(e) = crossref_err {
         if pdf_bytes.is_none() {
+            // #413: attach the resolution trace. Returning the bare
+            // Crossref error was the whole problem — it said nothing about
+            // whether the optional chain had been consulted and come up
+            // empty, or had never run because its flags are unset. Those
+            // need different fixes, so the message has to tell them apart.
+            if !attempts.is_empty() {
+                let trace = render_attempts(&attempts);
+                let lead = if nothing_was_consulted(&attempts) {
+                    "no optional source was consulted for this DOI"
+                } else {
+                    "the optional sources were consulted and did not resolve it"
+                };
+                return Err(FetchError::NotFound {
+                    hint: format!(
+                        "{e}
+  = note: {lead}:
+{trace}"
+                    ),
+                });
+            }
             return Err(e);
         }
     }
@@ -1769,6 +1783,7 @@ async fn try_fetch_oa_pdf(
 }
 
 /// Subset of Crossref `message` fields populated into the on-disk metadata.
+#[derive(Default)]
 pub(crate) struct CrossrefFields {
     pub(crate) title: Option<String>,
     pub(crate) authors: Vec<String>,
@@ -3216,5 +3231,645 @@ mod tests {
         // nothing parseable -> empty (still a valid TOML)
         assert!(extract_metadata_authors(&json!({"x": 1})).is_empty());
         assert!(extract_metadata_authors(&json!({"authors": []})).is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Source-attempt trace (#413 follow-up)
+// ---------------------------------------------------------------------------
+
+/// Why a given optional source did or did not contribute.
+///
+/// The distinction this type exists to make: **"we asked and it had
+/// nothing" is not the same failure as "we never asked".** Before this,
+/// both looked identical from outside — a DOI fetch that failed returned
+/// the Crossref error and said nothing about the rest of the chain, so a
+/// user could not tell whether HAL had been consulted and come up empty,
+/// or whether `DOIGET_ENABLE_HAL` was simply unset. One means the paper is
+/// not there; the other means you have not turned the source on. They need
+/// completely different actions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AttemptOutcome {
+    /// Runtime flag unset — **not consulted**. Carries the env var so the
+    /// message can name the exact thing the user has to change.
+    Disabled {
+        /// e.g. `"DOIGET_ENABLE_HAL"`.
+        env: &'static str,
+    },
+    /// This source cannot serve this kind of ref at all (e.g. an arXiv id
+    /// handed to a DOI-only resolver). Not a misconfiguration.
+    NotApplicable,
+    /// An earlier source in the chain already answered, so this one was
+    /// deliberately skipped. Not a failure.
+    NotNeeded,
+    /// **Consulted.** The source has no record for this ref.
+    NoRecord,
+    /// **Consulted.** A record exists but is not open access — the source
+    /// knows the paper and still cannot give it to us.
+    NotOpenAccess {
+        /// Source-specific detail, e.g. the access-rights code observed.
+        detail: String,
+    },
+    /// **Consulted.** The request itself failed (transport, auth, schema).
+    Failed {
+        /// Rendered error.
+        detail: String,
+    },
+    /// **Consulted**, and it answered.
+    Resolved,
+}
+
+impl AttemptOutcome {
+    /// Whether a request actually went out for this source.
+    ///
+    /// This is the predicate the reachability tests assert on: a source
+    /// reporting `was_consulted() == false` is one the production path
+    /// never reached, which is exactly the condition that used to be
+    /// invisible.
+    #[must_use]
+    pub fn was_consulted(&self) -> bool {
+        matches!(
+            self,
+            Self::NoRecord | Self::NotOpenAccess { .. } | Self::Failed { .. } | Self::Resolved
+        )
+    }
+
+    /// One-line rendering, phrased so consulted and not-consulted cannot
+    /// be misread for one another.
+    #[must_use]
+    pub fn render(&self) -> String {
+        match self {
+            Self::Disabled { env } => format!("not consulted (set {env} to enable)"),
+            Self::NotApplicable => "not consulted (cannot serve this ref kind)".to_string(),
+            Self::NotNeeded => "not consulted (an earlier source answered)".to_string(),
+            Self::NoRecord => "consulted: no record".to_string(),
+            Self::NotOpenAccess { detail } => {
+                format!("consulted: found, not open access ({detail})")
+            }
+            Self::Failed { detail } => format!("consulted: failed ({detail})"),
+            Self::Resolved => "consulted: resolved".to_string(),
+        }
+    }
+}
+
+/// One row of the resolution trace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SourceAttempt {
+    /// Source key, matching [`Source::name`](crate::source::Source::name).
+    pub source: &'static str,
+    /// What happened.
+    pub outcome: AttemptOutcome,
+}
+
+impl SourceAttempt {
+    /// Construct a row.
+    #[must_use]
+    pub fn new(source: &'static str, outcome: AttemptOutcome) -> Self {
+        Self { source, outcome }
+    }
+}
+
+/// Render a whole trace as an `= note:`-style block.
+///
+/// Ordered as the chain ran, so reading top to bottom tells you how far
+/// resolution actually got.
+#[must_use]
+pub fn render_attempts(attempts: &[SourceAttempt]) -> String {
+    attempts
+        .iter()
+        .map(|a| format!("  {:<12} {}", a.source, a.outcome.render()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// True when no source in the trace was actually reached.
+///
+/// Distinguishes "this DOI is genuinely not findable" from "nothing was
+/// even switched on" — a data problem versus a configuration problem.
+#[must_use]
+pub fn nothing_was_consulted(attempts: &[SourceAttempt]) -> bool {
+    !attempts.is_empty() && attempts.iter().all(|a| !a.outcome.was_consulted())
+}
+
+/// Map a source's terminal error onto an [`AttemptOutcome`].
+///
+/// Keeps the classification in one place so every source in the chain
+/// reports the same way: a clean miss must not be recorded as a failure,
+/// and an access refusal must not be recorded as a miss.
+#[cfg(feature = "metadata")]
+fn classify_attempt(e: &FetchError) -> AttemptOutcome {
+    match e {
+        FetchError::NotFound { .. } => AttemptOutcome::NoRecord,
+        // Sources signal "found it, cannot give it to you" through
+        // SourceSchema with an explicit hint (OpenAIRE access rights,
+        // Europe PMC isOpenAccess, HAL openAccess_bool). The hint is
+        // carried verbatim so the reason survives into the message.
+        FetchError::SourceSchema { hint } if is_access_refusal(hint) => {
+            AttemptOutcome::NotOpenAccess {
+                detail: hint.clone(),
+            }
+        }
+        other => AttemptOutcome::Failed {
+            detail: other.to_string(),
+        },
+    }
+}
+
+/// Whether a `SourceSchema` hint describes an access refusal rather than a
+/// malformed response.
+#[cfg(feature = "metadata")]
+fn is_access_refusal(hint: &str) -> bool {
+    hint.contains("not open access") || hint.contains("openAccess")
+}
+
+/// Run the optional resolution chain and record one [`SourceAttempt`] per
+/// source, consulted or not.
+///
+/// Order is #413's priority order: DataCite (resolution for the second
+/// registration agency) first, then the OA aggregators, then CORE as the
+/// broadest and therefore last fallback. Each is skipped — with a recorded
+/// reason — once something has answered, so the common case costs at most
+/// one extra request.
+///
+/// `extracted` is overwritten by the first source that answers, so the
+/// caller sees the bibliographic fields of whichever source resolved.
+#[cfg(feature = "metadata")]
+async fn resolve_optional_chain(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    crossref_answered: bool,
+    extracted: &mut CrossrefFields,
+    attempts: &mut Vec<SourceAttempt>,
+) -> Option<Value> {
+    // Built eagerly so the trace lists every source in a fixed order even
+    // when none is consulted — an empty trace would be indistinguishable
+    // from "no chain exists", which is the confusion this whole mechanism
+    // is here to remove.
+    // Base URLs come from the env, mirroring `crossref_source_from_env`
+    // and friends. Without this the chain could only ever talk to
+    // production, which is how it shipped unreachable in the first place:
+    // no test could point it anywhere, so no test could prove it was
+    // reached.
+    let datacite = optional_base("DOIGET_DATACITE_BASE").map_or_else(
+        crate::sources::datacite::DataCiteSource::new,
+        crate::sources::datacite::DataCiteSource::with_base,
+    );
+    let epmc = optional_base("DOIGET_EUROPE_PMC_BASE").map_or_else(
+        crate::sources::europepmc::EuropePmcSource::new,
+        crate::sources::europepmc::EuropePmcSource::with_base,
+    );
+    let openaire = optional_base("DOIGET_OPENAIRE_BASE").map_or_else(
+        crate::sources::openaire::OpenAireSource::new,
+        crate::sources::openaire::OpenAireSource::with_base,
+    );
+    let hal = optional_base("DOIGET_HAL_BASE").map_or_else(
+        crate::sources::hal::HalSource::new,
+        crate::sources::hal::HalSource::with_base,
+    );
+    let core = optional_base("DOIGET_CORE_BASE").map_or_else(
+        crate::sources::core_oa::CoreSource::new,
+        crate::sources::core_oa::CoreSource::with_base,
+    );
+
+    // The name is carried explicitly rather than read from `src.name()`:
+    // that borrows the source, while a `SourceAttempt` holds a `'static`
+    // key so the trace can outlive the chain. A test asserts the two agree,
+    // so this cannot drift into a lie.
+    let chain: Vec<(&'static str, &'static str, &dyn crate::source::Source)> = vec![
+        ("datacite", "DOIGET_ENABLE_DATACITE", &datacite),
+        ("europe-pmc", "DOIGET_ENABLE_EUROPE_PMC", &epmc),
+        ("openaire", "DOIGET_ENABLE_OPENAIRE", &openaire),
+        ("hal", "DOIGET_ENABLE_HAL", &hal),
+        ("core", "DOIGET_ENABLE_CORE", &core),
+    ];
+
+    let mut resolved: Option<Value> = None;
+
+    for (name, env, src) in chain {
+        debug_assert_eq!(name, src.name(), "chain name must match Source::name");
+
+        // Crossref already answered: nothing in this chain is needed.
+        if crossref_answered || resolved.is_some() {
+            attempts.push(SourceAttempt::new(name, AttemptOutcome::NotNeeded));
+            continue;
+        }
+        // `can_serve` folds two very different reasons together, so split
+        // them: a disabled flag is a configuration problem the user can
+        // fix; an inapplicable ref kind is not.
+        if !src.can_serve(profile, ref_) {
+            let outcome = if matches!(ref_, Ref::Doi(_)) {
+                AttemptOutcome::Disabled { env }
+            } else {
+                AttemptOutcome::NotApplicable
+            };
+            attempts.push(SourceAttempt::new(name, outcome));
+            continue;
+        }
+
+        match src.fetch(ref_, profile, ctx).await {
+            Ok(r) => {
+                if let Some(meta) = r.metadata_json.as_ref() {
+                    *extracted = extract_optional_fields(name, meta);
+                }
+                attempts.push(SourceAttempt::new(name, AttemptOutcome::Resolved));
+                resolved = r.metadata_json;
+            }
+            Err(e) => {
+                tracing::debug!(source = name, error = %e, "optional source did not resolve");
+                attempts.push(SourceAttempt::new(name, classify_attempt(&e)));
+            }
+        }
+    }
+    resolved
+}
+
+/// Read a `DOIGET_*_BASE` override, warning rather than failing on a
+/// malformed value — a bad override must not take the source offline.
+#[cfg(feature = "metadata")]
+fn optional_base(env: &str) -> Option<url::Url> {
+    let raw = std::env::var(env).ok()?;
+    match url::Url::parse(&raw) {
+        Ok(u) => Some(u),
+        Err(e) => {
+            tracing::warn!(value = %raw, error = %e, env, "base override is not a valid URL; using the default");
+            None
+        }
+    }
+}
+
+/// Map an optional source's payload onto [`CrossrefFields`].
+///
+/// Only DataCite has a documented field mapping today
+/// ([`extract_datacite_fields`]); the OA aggregators return
+/// source-specific shapes whose bibliographic mapping is separate work.
+/// Rather than guess, those keep whatever Crossref produced and contribute
+/// their payload as `metadata_json` only — an empty title is a visible
+/// gap, a wrong title is a silent corruption.
+#[cfg(feature = "metadata")]
+fn extract_optional_fields(source: &str, meta: &Value) -> CrossrefFields {
+    match source {
+        "datacite" => extract_datacite_fields(meta),
+        _ => CrossrefFields::default(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #413: chain reachability + "never asked" vs "asked and empty"
+// ---------------------------------------------------------------------------
+//
+// These tests exist because four of the five sources added in 0.8.8 were
+// initially unreachable: implemented, capability-gated, allowlisted — and
+// never called by anything. Every unit test passed, because each one drove
+// its own `Source` impl directly. Nothing asserted that the PRODUCTION
+// path reaches them.
+//
+// So the assertions here are deliberately about reach, not behaviour:
+// `server.received_requests()` is the only evidence that a source was
+// actually consulted, and the attempt trace is the only way an operator
+// can tell "consulted and empty" from "never consulted".
+
+#[cfg(all(test, feature = "metadata"))]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod chain_tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// A context whose HTTP client points EVERY optional source key at the
+    /// same mock server, so "was this source reached?" is answerable by
+    /// asking the server what it received.
+    /// Point every optional source at the mock. Restored on drop; these
+    /// tests are serialised because the vars are process-global.
+    struct BaseGuard(Vec<(&'static str, Option<String>)>);
+    impl BaseGuard {
+        fn to(uri: &str) -> Self {
+            const VARS: &[&str] = &[
+                "DOIGET_DATACITE_BASE",
+                "DOIGET_EUROPE_PMC_BASE",
+                "DOIGET_OPENAIRE_BASE",
+                "DOIGET_HAL_BASE",
+                "DOIGET_CORE_BASE",
+            ];
+            Self(
+                VARS.iter()
+                    .map(|v| {
+                        let old = std::env::var(v).ok();
+                        std::env::set_var(v, uri);
+                        (*v, old)
+                    })
+                    .collect(),
+            )
+        }
+    }
+    impl Drop for BaseGuard {
+        fn drop(&mut self) {
+            for (v, old) in &self.0 {
+                match old {
+                    Some(o) => std::env::set_var(v, o),
+                    None => std::env::remove_var(v),
+                }
+            }
+        }
+    }
+
+    fn ctx_for(host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let dir = Utf8PathBuf::try_from(td.path().to_path_buf()).expect("utf-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http_multi(&[
+            ("datacite", host),
+            ("europe-pmc", host),
+            ("openaire", host),
+            ("hal", host),
+            ("core", host),
+        ]));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(dir.join("t.jsonl"), session_id.clone()).expect("log opens"),
+        );
+        (
+            td,
+            FetchContext {
+                http,
+                rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+                log,
+                session_id,
+                cache_root: None,
+            },
+        )
+    }
+
+    fn all_off() -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite: false,
+            hal: false,
+            openaire: false,
+            core: false,
+            europe_pmc: false,
+        };
+        p
+    }
+
+    fn all_on() -> CapabilityProfile {
+        let mut p = all_off();
+        p.metadata.datacite = true;
+        p.metadata.hal = true;
+        p.metadata.openaire = true;
+        p.metadata.core = true;
+        p.metadata.europe_pmc = true;
+        p
+    }
+
+    fn outcome<'a>(attempts: &'a [SourceAttempt], name: &str) -> &'a AttemptOutcome {
+        &attempts
+            .iter()
+            .find(|a| a.source == name)
+            .unwrap_or_else(|| panic!("no attempt recorded for {name}; got {attempts:?}"))
+            .outcome
+    }
+
+    /// THE regression for the bug this whole change exists to fix.
+    ///
+    /// With every flag on and Crossref having produced nothing, all five
+    /// sources must actually be REACHED — proven by the mock server having
+    /// received five requests, not by any assertion about return values.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn every_optional_source_is_actually_reached_by_the_production_chain() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        // Every source gets a syntactically valid but empty answer, so the
+        // chain runs to the end instead of stopping at the first hit.
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"results":[],"response":{"docs":[]},"resultList":{"result":[]}}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+        let mut fields = CrossrefFields::default();
+        let mut attempts = Vec::new();
+
+        resolve_optional_chain(&ref_, &all_on(), &ctx, false, &mut fields, &mut attempts).await;
+
+        let names: Vec<&str> = attempts.iter().map(|a| a.source).collect();
+        assert_eq!(
+            names,
+            vec!["datacite", "europe-pmc", "openaire", "hal", "core"],
+            "the trace must list every source, in chain order"
+        );
+        for a in &attempts {
+            assert!(
+                a.outcome.was_consulted(),
+                "{} was NOT reached by the production chain: {:?}",
+                a.source,
+                a.outcome
+            );
+        }
+        assert_eq!(
+            server.received_requests().await.expect("recorded").len(),
+            5,
+            "each enabled source must issue exactly one request"
+        );
+    }
+
+    /// The distinction the trace exists for: flags off means **no request
+    /// is made at all**, and the trace says so in a way that cannot be
+    /// confused with an empty result.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn flags_off_means_never_consulted_and_says_which_var_to_set() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+        let mut fields = CrossrefFields::default();
+        let mut attempts = Vec::new();
+
+        resolve_optional_chain(&ref_, &all_off(), &ctx, false, &mut fields, &mut attempts).await;
+
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "a disabled chain must make NO request"
+        );
+        assert!(
+            nothing_was_consulted(&attempts),
+            "the trace must report that nothing was reached"
+        );
+        assert_eq!(
+            outcome(&attempts, "hal"),
+            &AttemptOutcome::Disabled {
+                env: "DOIGET_ENABLE_HAL"
+            },
+            "a disabled source must name the variable that enables it"
+        );
+        let rendered = render_attempts(&attempts);
+        assert!(
+            rendered.contains("not consulted (set DOIGET_ENABLE_HAL to enable)"),
+            "rendered trace must be actionable; got:\n{rendered}"
+        );
+    }
+
+    /// The two states that used to be indistinguishable, side by side.
+    /// If this ever passes with both rendering the same string, the whole
+    /// mechanism is worthless.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn never_consulted_and_consulted_but_empty_render_differently() {
+        // (a) consulted, empty.
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"results":[]}"#))
+            .mount(&server)
+            .await;
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+        let mut f1 = CrossrefFields::default();
+        let mut consulted = Vec::new();
+        let mut on = all_off();
+        on.metadata.datacite = true;
+        resolve_optional_chain(&ref_, &on, &ctx, false, &mut f1, &mut consulted).await;
+
+        // (b) never consulted.
+        let mut f2 = CrossrefFields::default();
+        let mut skipped = Vec::new();
+        resolve_optional_chain(&ref_, &all_off(), &ctx, false, &mut f2, &mut skipped).await;
+
+        let a = outcome(&consulted, "datacite");
+        let b = outcome(&skipped, "datacite");
+        assert!(a.was_consulted(), "(a) must be consulted, got {a:?}");
+        assert!(!b.was_consulted(), "(b) must NOT be consulted, got {b:?}");
+        assert_ne!(
+            a.render(),
+            b.render(),
+            "the two states MUST NOT render identically"
+        );
+        assert!(a.render().starts_with("consulted:"), "{}", a.render());
+        assert!(b.render().starts_with("not consulted"), "{}", b.render());
+    }
+
+    /// When Crossref already answered, the chain must not fire at all —
+    /// and must say why, rather than looking like everything was disabled.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_crossref_hit_skips_the_chain_without_pretending_it_was_disabled() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+        let mut fields = CrossrefFields::default();
+        let mut attempts = Vec::new();
+
+        resolve_optional_chain(&ref_, &all_on(), &ctx, true, &mut fields, &mut attempts).await;
+
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "a Crossref hit must cost no extra requests"
+        );
+        for a in &attempts {
+            assert_eq!(
+                a.outcome,
+                AttemptOutcome::NotNeeded,
+                "{} must be NotNeeded, not Disabled — the flags ARE on",
+                a.source
+            );
+        }
+    }
+
+    /// An access refusal is not a miss. OpenAIRE / Europe PMC / HAL all
+    /// report "found it, cannot give it to you" — that must not be recorded
+    /// as `NoRecord`, or the operator concludes the paper does not exist.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn an_access_refusal_is_recorded_distinctly_from_a_miss() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"resultList":{"result":[{"doi":"10.1234/x","isOpenAccess":"N","inEPMC":"Y"}]}}"#,
+            ))
+            .mount(&server)
+            .await;
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Doi(Doi::parse("10.1234/x").expect("doi"));
+        let mut fields = CrossrefFields::default();
+        let mut attempts = Vec::new();
+        let mut on = all_off();
+        on.metadata.europe_pmc = true;
+
+        resolve_optional_chain(&ref_, &on, &ctx, false, &mut fields, &mut attempts).await;
+
+        let o = outcome(&attempts, "europe-pmc");
+        assert!(
+            matches!(o, AttemptOutcome::NotOpenAccess { .. }),
+            "a closed record must be NotOpenAccess, not NoRecord/Failed; got {o:?}"
+        );
+        assert!(o.was_consulted(), "it WAS reached");
+        assert!(
+            o.render().contains("not open access"),
+            "the reason must survive into the message; got {}",
+            o.render()
+        );
+    }
+
+    /// A source that cannot serve the ref kind is not a misconfiguration,
+    /// so it must not tell the user to set an env var that would not help.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn an_arxiv_ref_is_not_applicable_rather_than_disabled() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv"));
+        let mut fields = CrossrefFields::default();
+        let mut attempts = Vec::new();
+
+        resolve_optional_chain(&ref_, &all_on(), &ctx, false, &mut fields, &mut attempts).await;
+
+        for a in &attempts {
+            assert_eq!(
+                a.outcome,
+                AttemptOutcome::NotApplicable,
+                "{} must be NotApplicable for an arXiv ref",
+                a.source
+            );
+            assert!(
+                !a.outcome.render().contains("set DOIGET_"),
+                "must not suggest a variable that would not help: {}",
+                a.outcome.render()
+            );
+        }
+        assert!(server
+            .received_requests()
+            .await
+            .expect("recorded")
+            .is_empty());
     }
 }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -3317,7 +3317,7 @@ impl AttemptOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct SourceAttempt {
-    /// Source key, matching [`Source::name`](crate::source::Source::name).
+    /// Source key, matching [`crate::source::Source::name`].
     pub source: &'static str,
     /// What happened.
     pub outcome: AttemptOutcome,

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1114,7 +1114,44 @@ async fn fetch_paper_doi(
         .as_ref()
         .and_then(|c| c.metadata_json.clone())
         .unwrap_or(Value::Null);
-    let extracted = extract_crossref_fields(&crossref_meta);
+    // `mut` only in `metadata` builds, where the DataCite fallback below may
+    // reassign it; without that feature nothing writes to it.
+    #[allow(unused_mut)]
+    let mut extracted = extract_crossref_fields(&crossref_meta);
+
+    // Issue #414 / ADR-0040: DataCite fallback, strictly AFTER Crossref and
+    // only when Crossref produced nothing. DataCite is the other large
+    // registration agency — Zenodo / figshare / Dryad / OSF DOIs are in
+    // neither Crossref nor Unpaywall, so without this a live, open record
+    // is reported NotFound. Ordering it here is what makes the source
+    // additive: a Crossref-registered DOI never reaches it, so turning the
+    // flag on cannot change any resolution that already works.
+    //
+    // Runtime-gated by `DOIGET_ENABLE_DATACITE` (off by default), so with
+    // the flag unset this block is inert and behaviour is byte-identical.
+    #[cfg(feature = "metadata")]
+    let datacite_meta = if cross.is_none() && profile.metadata.datacite {
+        match crate::sources::datacite::DataCiteSource::new()
+            .fetch(ref_, profile, ctx)
+            .await
+        {
+            Ok(r) => {
+                if let Some(attrs) = r.metadata_json.as_ref() {
+                    extracted = extract_datacite_fields(attrs);
+                }
+                r.metadata_json
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "datacite fallback found nothing for this DOI");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    #[cfg(not(feature = "metadata"))]
+    let datacite_meta: Option<Value> = None;
+    let _ = &datacite_meta;
 
     // Unpaywall second — license enrichment + OA URL chain discovery.
     // A failure here is non-fatal: we still write the Crossref-
@@ -1741,6 +1778,73 @@ pub(crate) struct CrossrefFields {
     pub(crate) issue: Option<String>,
     pub(crate) pages: Option<String>,
     pub(crate) type_: Option<String>,
+}
+
+/// Map a DataCite `data.attributes` object onto [`CrossrefFields`].
+///
+/// Issue #414. DataCite is a different registration agency with a
+/// different schema, but downstream only consumes [`CrossrefFields`], so
+/// the shapes are reconciled here rather than by widening every consumer.
+///
+/// `type_` deliberately carries `types.resourceTypeGeneral` — on Zenodo,
+/// dataset plus software plus image outnumber `JournalArticle`, and an
+/// agent that cannot tell them apart will treat a software release as a
+/// paper. Every field degrades to `None` rather than guessing.
+#[cfg(feature = "metadata")]
+pub(crate) fn extract_datacite_fields(attributes: &Value) -> CrossrefFields {
+    let title = attributes
+        .get("titles")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|t| t.get("title"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let authors = attributes
+        .get("creators")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| {
+                    // `name` is the canonical field; fall back to the
+                    // given/family pair when a depositor supplied only that.
+                    c.get("name")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                        .or_else(|| {
+                            let given = c.get("givenName").and_then(|v| v.as_str());
+                            let family = c.get("familyName").and_then(|v| v.as_str());
+                            match (given, family) {
+                                (Some(g), Some(f)) => Some(format!("{g} {f}")),
+                                (None, Some(f)) => Some(f.to_string()),
+                                _ => None,
+                            }
+                        })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let year = attributes
+        .get("publicationYear")
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|y| i32::try_from(y).ok());
+    let venue = attributes.get("publisher").and_then(|v| {
+        // DataCite 4.5 made `publisher` an object; earlier records
+        // carry a bare string.
+        v.as_str()
+            .map(str::to_string)
+            .or_else(|| v.get("name").and_then(|n| n.as_str()).map(str::to_string))
+    });
+    let type_ = crate::sources::datacite::resource_type_general(attributes).map(str::to_string);
+    CrossrefFields {
+        title,
+        authors,
+        year,
+        venue,
+        volume: None,
+        issue: None,
+        pages: None,
+        type_,
+    }
 }
 
 /// Defensively pull bibliographic fields out of a Crossref envelope's

--- a/crates/doiget-core/src/sources/core_oa.rs
+++ b/crates/doiget-core/src/sources/core_oa.rs
@@ -11,10 +11,10 @@
 //!
 //! ## Capability gate
 //!
-//! [`CoreSource::can_serve`] returns `true` only when
+//! `CoreSource::can_serve` returns `true` only when
 //! [`CapabilityProfile.metadata.core`](crate::CapabilityProfile) is `true`
-//! AND the ref is a [`Ref::Doi`]. The bool is set by
-//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_CORE`, which is
+//! AND the ref is a `Ref::Doi`. The bool is set by
+//! `CapabilityProfile::from_env` from `DOIGET_ENABLE_CORE`, which is
 //! **off by default** (ADR-0040) — unset, this source is inert.
 //!
 //! ## The API key is optional, and absence is not an error
@@ -34,8 +34,8 @@
 //!
 //! Two failures that are easy to conflate:
 //!
-//! - CORE holds nothing for this DOI — [`FetchError::NotFound`]
-//! - CORE rejected our credentials — [`FetchError::Http`], carrying the
+//! - CORE holds nothing for this DOI — `FetchError::NotFound`
+//! - CORE rejected our credentials — `FetchError::Http`, carrying the
 //!   401/403
 //!
 //! They are different error *types*, not two spellings of one hint, so a

--- a/crates/doiget-core/src/sources/core_oa.rs
+++ b/crates/doiget-core/src/sources/core_oa.rs
@@ -357,6 +357,7 @@ mod tests {
             hal: false,
             openaire: false,
             core,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/core_oa.rs
+++ b/crates/doiget-core/src/sources/core_oa.rs
@@ -1,0 +1,550 @@
+//! CORE source — cross-repository OA aggregation (Tier 2, #417).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. CORE aggregates OA full
+//! text across repositories worldwide and is the broadest single OA index
+//! outside Unpaywall, so it sits **last** in the optional chain: the
+//! fallback before giving up.
+//!
+//! The module is `core_oa` rather than `core` because `core` is a Rust
+//! built-in crate name, and shadowing it inside `sources::` would make
+//! every `core::` path in this module ambiguous.
+//!
+//! ## Capability gate
+//!
+//! [`CoreSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.core`](crate::CapabilityProfile) is `true`
+//! AND the ref is a [`Ref::Doi`]. The bool is set by
+//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_CORE`, which is
+//! **off by default** (ADR-0040) — unset, this source is inert.
+//!
+//! ## The API key is optional, and absence is not an error
+//!
+//! CORE works with no key at a low rate limit; a **free** key raises it.
+//! So the key is read from `DOIGET_CORE_API_KEY` when the user set one and
+//! simply omitted otherwise — an absent key degrades to the key-less rate
+//! limit rather than failing, which is what #417 requires. doiget bundles
+//! no key, and none is needed to build.
+//!
+//! The key is sent as a bearer header through
+//! [`HttpClient::fetch_bytes_with_headers`](crate::http::HttpClient::fetch_bytes_with_headers),
+//! whose contract is that header values reach the wire only and are never
+//! logged.
+//!
+//! ## A bad key must not look like a missing paper
+//!
+//! Two failures that are easy to conflate:
+//!
+//! - CORE holds nothing for this DOI — [`FetchError::NotFound`]
+//! - CORE rejected our credentials — [`FetchError::Http`], carrying the
+//!   401/403
+//!
+//! They are different error *types*, not two spellings of one hint, so a
+//! caller cannot accidentally read a misconfigured key as an absent
+//! record. When a key *was* sent and the answer is 401/403, the source
+//! additionally logs a warning naming the env var — that is the one case
+//! where the user has something to fix.
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4 this source never returns PDF bytes. CORE
+//! exposes `downloadUrl` on its works, but those point at repository
+//! hosts, reached through the `oa-publisher` key rather than this one.
+//!
+//! API: public REST v3.
+//! Terms: <https://core.ac.uk/terms>
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production CORE API base.
+const DEFAULT_BASE: &str = "https://api.core.ac.uk";
+
+/// Env var holding the user's own free CORE key. Never bundled.
+const API_KEY_ENV: &str = "DOIGET_CORE_API_KEY";
+
+/// CORE [`Source`] impl — DOI to aggregated OA work record.
+#[derive(Clone, Debug)]
+pub struct CoreSource {
+    /// API base URL. Production pins `https://api.core.ac.uk`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl CoreSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build `/v3/search/works?q=doi:"<doi>"&limit=1`.
+    ///
+    /// The DOI is quoted so the query engine treats it as a phrase rather
+    /// than tokenising on `.` and `/`, and the whole value is
+    /// percent-encoded by `query_pairs_mut`, so no query syntax can be
+    /// injected from the suffix.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let mut url = self
+            .base
+            .join("/v3/search/works")
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("core URL construction failed: {e}"),
+            })?;
+        url.query_pairs_mut()
+            .append_pair("q", &format!("doi:\"{}\"", doi.as_str()))
+            .append_pair("limit", "1");
+        Ok(url)
+    }
+}
+
+impl Default for CoreSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Read the optional user-supplied CORE key.
+///
+/// Returns `None` for unset **and** for whitespace-only, so an
+/// accidentally blank `DOIGET_CORE_API_KEY=` behaves as "no key" instead
+/// of sending an empty bearer token that CORE would answer with a 401 —
+/// which would then look like a *bad* key rather than no key.
+fn api_key_from_env() -> Option<String> {
+    std::env::var(API_KEY_ENV)
+        .ok()
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+}
+
+#[async_trait]
+impl Source for CoreSource {
+    fn name(&self) -> &str {
+        "core"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.metadata.core && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "core".into(),
+                });
+            }
+        };
+
+        if !profile.metadata.core {
+            return Err(FetchError::NotEligible {
+                source_key: "core".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let key = api_key_from_env();
+        let bearer = key.as_ref().map(|k| format!("Bearer {k}"));
+        let headers: Vec<(&str, &str)> = match bearer.as_deref() {
+            Some(v) => vec![("authorization", v)],
+            None => Vec::new(),
+        };
+
+        let (body, final_url) = match ctx
+            .http
+            .fetch_bytes_with_headers(self.name(), url, &headers)
+            .await
+        {
+            Ok(ok) => ok,
+            Err(e) => {
+                // A rejected key is the one failure here the user can act
+                // on, so say so — but only when a key was actually sent,
+                // since a key-less 401 means something else entirely.
+                if key.is_some() && matches!(status_of(&e), Some(401 | 403)) {
+                    tracing::warn!(
+                        env = API_KEY_ENV,
+                        "core rejected the configured API key; it is wrong or \
+                         revoked (unset the variable to fall back to the \
+                         key-less rate limit)"
+                    );
+                }
+                return Err(e.into());
+            }
+        };
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("core returned non-JSON: {e}"),
+            })?;
+
+        let results = envelope
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "core response missing `results` array (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+        // Deliberately NotFound, not SourceSchema: "CORE holds nothing for
+        // this DOI" is a clean miss, and must stay type-distinct from the
+        // credential failure handled above.
+        let work = results.first().ok_or_else(|| FetchError::NotFound {
+            hint: format!("core has no work for {}", doi.as_str()),
+        })?;
+
+        let license = license_of(work);
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(license.as_str()),
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(work.clone()),
+        })
+    }
+}
+
+/// HTTP status carried by an [`crate::http::HttpError`], when it has one.
+fn status_of(e: &crate::http::HttpError) -> Option<u16> {
+    match e {
+        crate::http::HttpError::HttpStatus { status, .. } => Some(*status),
+        _ => None,
+    }
+}
+
+/// Licence from the CORE work, else `"unknown"`.
+///
+/// Free text from the aggregated repository rather than an SPDX id, so it
+/// is passed through verbatim — normalising would mean guessing, and a
+/// wrong licence is worse than an absent one.
+fn license_of(work: &serde_json::Value) -> String {
+    work.get("license")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    const SAMPLE_HIT: &str = r#"{
+        "totalHits": 1,
+        "results": [
+            {
+                "id": 12345,
+                "title": "An Aggregated Open Access Work",
+                "doi": "10.1234/example",
+                "license": "https://creativecommons.org/licenses/by/4.0/",
+                "downloadUrl": "https://core.ac.uk/download/12345.pdf"
+            }
+        ]
+    }"#;
+
+    const SAMPLE_EMPTY: &str = r#"{"totalHits": 0, "results": []}"#;
+
+    /// RAII env guard — these tests mutate `DOIGET_CORE_API_KEY`, which is
+    /// process-global, so they are serialised.
+    struct KeyGuard(Option<String>);
+    impl KeyGuard {
+        fn set(v: Option<&str>) -> Self {
+            let prev = std::env::var(API_KEY_ENV).ok();
+            match v {
+                Some(k) => std::env::set_var(API_KEY_ENV, k),
+                None => std::env::remove_var(API_KEY_ENV),
+            }
+            Self(prev)
+        }
+    }
+    impl Drop for KeyGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(v) => std::env::set_var(API_KEY_ENV, v),
+                None => std::env::remove_var(API_KEY_ENV),
+            }
+        }
+    }
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http("core", wiremock_host));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_dir.join("test.jsonl"), session_id.clone())
+                .expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    fn profile(core: bool) -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite: false,
+            hal: false,
+            openaire: false,
+            core,
+        };
+        p
+    }
+
+    #[test]
+    fn request_url_quotes_the_doi_as_a_phrase() {
+        let src = CoreSource::new();
+        let doi = Doi::parse("10.1234/example").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(url.path(), "/v3/search/works");
+        let q = url
+            .query_pairs()
+            .find(|(k, _)| k == "q")
+            .expect("q param")
+            .1
+            .into_owned();
+        assert_eq!(q, "doi:\"10.1234/example\"");
+    }
+
+    /// #417: an absent key must degrade to the key-less rate limit, NOT
+    /// fail, and must not send an empty `authorization` header.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn works_without_a_key_and_sends_no_auth_header() {
+        let _g = KeyGuard::set(None);
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_HIT))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("key-less fetch must succeed");
+        assert_eq!(got.source, "core");
+        assert_eq!(got.license, "https://creativecommons.org/licenses/by/4.0/");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+
+        let reqs = server.received_requests().await.expect("recorded");
+        assert!(
+            reqs[0].headers.get("authorization").is_none(),
+            "no key configured means no authorization header"
+        );
+    }
+
+    /// A configured key must actually reach the wire as a bearer header.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn sends_the_configured_key_as_a_bearer_header() {
+        let _g = KeyGuard::set(Some("secret-key-value"));
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_HIT))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+        src.fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("keyed fetch must succeed");
+
+        let reqs = server.received_requests().await.expect("recorded");
+        let auth = reqs[0]
+            .headers
+            .get("authorization")
+            .expect("authorization header")
+            .to_str()
+            .expect("ascii");
+        assert_eq!(auth, "Bearer secret-key-value");
+    }
+
+    /// A blank `DOIGET_CORE_API_KEY=` is "no key", not an empty key.
+    /// Sending an empty bearer would earn a 401 that looks like a *bad* key.
+    #[test]
+    #[serial_test::serial]
+    fn blank_key_is_treated_as_absent() {
+        {
+            let _g = KeyGuard::set(Some("   "));
+            assert_eq!(api_key_from_env(), None);
+        }
+        {
+            let _g = KeyGuard::set(Some("k"));
+            assert_eq!(api_key_from_env(), Some("k".to_string()));
+        }
+    }
+
+    /// #417: a rejected key must be reported distinctly from "not found".
+    /// These are different error TYPES, so a caller cannot conflate them.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejected_key_and_missing_work_are_different_error_types() {
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+
+        // 401 with a key configured -> Http, carrying the status.
+        let _g = KeyGuard::set(Some("bad-key"));
+        let unauthorized = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&unauthorized)
+            .await;
+        let (_td1, ctx1) = build_test_context(&unauthorized.address().to_string());
+        let src1 = CoreSource::with_base(Url::parse(&unauthorized.uri()).expect("base"));
+        let auth_err = src1
+            .fetch(&ref_, &profile(true), &ctx1)
+            .await
+            .expect_err("401 must be an error");
+        assert!(
+            matches!(auth_err, FetchError::Http(_)),
+            "a rejected key must surface as Http, got {auth_err:?}"
+        );
+
+        // Empty results -> NotFound.
+        let empty = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v3/search/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_EMPTY))
+            .mount(&empty)
+            .await;
+        let (_td2, ctx2) = build_test_context(&empty.address().to_string());
+        let src2 = CoreSource::with_base(Url::parse(&empty.uri()).expect("base"));
+        let miss = src2
+            .fetch(&ref_, &profile(true), &ctx2)
+            .await
+            .expect_err("no results must be an error");
+        assert!(
+            matches!(miss, FetchError::NotFound { .. }),
+            "a clean miss must surface as NotFound, got {miss:?}"
+        );
+    }
+
+    /// The regression #413 requires of every new source.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn is_inert_when_the_runtime_flag_is_unset() {
+        let _g = KeyGuard::set(None);
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("doi"));
+
+        assert!(!src.can_serve(&profile(false), &ref_));
+        let err = src
+            .fetch(&ref_, &profile(false), &ctx)
+            .await
+            .expect_err("must refuse");
+        assert!(matches!(err, FetchError::NotEligible { .. }), "got {err:?}");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "an inert source must make NO request"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn arxiv_refs_are_not_eligible() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = CoreSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+        assert!(!src.can_serve(&profile(true), &ref_));
+        assert!(matches!(
+            src.fetch(&ref_, &profile(true), &ctx).await,
+            Err(FetchError::NotEligible { .. })
+        ));
+    }
+
+    #[test]
+    fn license_falls_back_to_unknown() {
+        assert_eq!(license_of(&serde_json::json!({})), "unknown");
+        assert_eq!(license_of(&serde_json::json!({"license": "  "})), "unknown");
+        assert_eq!(
+            license_of(&serde_json::json!({"license": "cc-by"})),
+            "cc-by"
+        );
+    }
+}

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -307,6 +307,7 @@ mod tests {
             doaj: false,
             datacite,
             hal: false,
+            openaire: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -309,6 +309,7 @@ mod tests {
             hal: false,
             openaire: false,
             core: false,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -308,6 +308,7 @@ mod tests {
             datacite,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -1,0 +1,457 @@
+//! DataCite source — DOI **resolution** (Phase 4 / Tier 2, issue #414).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. DataCite is the second
+//! large DOI registration agency; Crossref and Unpaywall index neither
+//! its DOIs nor its records. Without this source a live, open-access
+//! Zenodo / figshare / Dryad / OSF DOI resolves to
+//! [`ErrorCode::NotFound`](crate::ErrorCode::NotFound) — a false negative
+//! already documented in-tree on that variant, and observed as a false
+//! positive in `doiget-citation-check`.
+//!
+//! ## Resolution, not enrichment
+//!
+//! Its siblings ([`openalex`](super::openalex) / [`s2`](super::s2) /
+//! [`doaj`](super::doaj)) add fields to a record Crossref already
+//! returned. This one answers the prior question — *does this DOI exist*
+//! — for an agency doiget otherwise cannot see. It therefore belongs
+//! **after** Crossref in the DOI fan-out: a Crossref-registered DOI never
+//! reaches it, so enabling it cannot change any resolution that works
+//! today.
+//!
+//! ## Capability gate
+//!
+//! [`DataCiteSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.datacite`](crate::CapabilityProfile) is
+//! `true` AND the ref is a [`Ref::Doi`]. The bool is set by
+//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_DATACITE`, which is
+//! **off by default** (ADR-0040) — with it unset the binary behaves
+//! exactly as it did before this source existed.
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4 this source never returns PDF bytes. DataCite
+//! returns a **landing page**, not a file: `attributes.url` for
+//! `10.5281/zenodo.X` is an HTML page under `zenodo.org`. Per-repository
+//! file retrieval (Zenodo `/api/records/<id>` then `files[].links.self`,
+//! figshare, Dryad, …) is deliberately out of scope until we can measure
+//! how often the landing URL alone suffices.
+//!
+//! ## Resolution only, never discovery
+//!
+//! DataCite is queried by exact DOI and nothing else. Zenodo accepts
+//! arbitrary deposits from anyone, so using it as a *search* surface would
+//! pull a large volume of unreviewed material into results. The contract
+//! here is narrower: resolve a DOI the user explicitly named.
+//!
+//! API: public REST, no auth, no key.
+//! ToS: <https://datacite.org/terms-and-conditions/>
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production DataCite REST API base.
+const DEFAULT_BASE: &str = "https://api.datacite.org";
+
+/// DataCite [`Source`] impl — DOI to DataCite record.
+#[derive(Clone, Debug)]
+pub struct DataCiteSource {
+    /// API base URL. Production pins `https://api.datacite.org`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl DataCiteSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build the `/dois/<doi>` URL.
+    ///
+    /// The DOI goes in the path and its `/` separator must survive as a
+    /// literal, so the suffix is pushed as its own segment rather than
+    /// percent-encoded into one blob. Every other reserved character IS
+    /// encoded by `push`, so a crafted suffix cannot inject a query string
+    /// or climb out of the `/dois/` prefix.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let mut url = self.base.clone();
+        {
+            let mut segs = url
+                .path_segments_mut()
+                .map_err(|()| FetchError::SourceSchema {
+                    hint: "datacite base URL cannot be a base".to_string(),
+                })?;
+            segs.clear();
+            segs.push("dois");
+            for part in doi.as_str().split('/') {
+                segs.push(part);
+            }
+        }
+        Ok(url)
+    }
+}
+
+impl Default for DataCiteSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for DataCiteSource {
+    fn name(&self) -> &str {
+        "datacite"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.metadata.datacite && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "datacite".into(),
+                });
+            }
+        };
+
+        if !profile.metadata.datacite {
+            return Err(FetchError::NotEligible {
+                source_key: "datacite".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("datacite returned non-JSON: {e}"),
+            })?;
+
+        // JSON:API envelope: { data: { id, type: "dois", attributes: {..} } }.
+        let attributes = envelope
+            .get("data")
+            .and_then(|d| d.get("attributes"))
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "datacite response missing `data.attributes` (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+
+        let license = license_of(attributes);
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(license.as_str()),
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(attributes.clone()),
+        })
+    }
+}
+
+/// Extract a licence identifier from `attributes.rightsList[]`.
+///
+/// DataCite records are heterogeneous — depositors fill `rightsList`
+/// freely — so this takes the first entry carrying a `rightsIdentifier`
+/// and otherwise reports `"unknown"`. Reporting `unknown` is honest;
+/// inferring a licence from a free-text `rights` string would not be, and
+/// a wrong licence is worse than an absent one.
+fn license_of(attributes: &serde_json::Value) -> String {
+    attributes
+        .get("rightsList")
+        .and_then(|r| r.as_array())
+        .and_then(|list| {
+            list.iter()
+                .find_map(|r| r.get("rightsIdentifier").and_then(|v| v.as_str()))
+        })
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// `attributes.types.resourceTypeGeneral`, if present.
+///
+/// Surfaced because a DataCite DOI is very often **not** an article — on
+/// Zenodo, dataset plus software plus image outnumber `JournalArticle`. An
+/// agent that cannot tell them apart will treat a software release as a
+/// paper (#414).
+#[must_use]
+pub fn resource_type_general(attributes: &serde_json::Value) -> Option<&str> {
+    attributes
+        .get("types")
+        .and_then(|t| t.get("resourceTypeGeneral"))
+        .and_then(|v| v.as_str())
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// Trimmed real shape from `GET /dois/10.5281/zenodo.22053902`.
+    const SAMPLE_RECORD: &str = r#"{
+        "data": {
+            "id": "10.5281/zenodo.22053902",
+            "type": "dois",
+            "attributes": {
+                "doi": "10.5281/zenodo.22053902",
+                "titles": [{"title": "An Example Deposit"}],
+                "creators": [
+                    {"name": "Researcher, Alice"},
+                    {"givenName": "Bob", "familyName": "Coauthor"}
+                ],
+                "publicationYear": 2024,
+                "publisher": "Zenodo",
+                "types": {"resourceTypeGeneral": "JournalArticle"},
+                "rightsList": [
+                    {"rights": "Creative Commons Attribution 4.0",
+                     "rightsIdentifier": "cc-by-4.0"}
+                ],
+                "url": "https://zenodo.org/doi/10.5281/zenodo.22053902"
+            }
+        }
+    }"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "datacite",
+            wiremock_host,
+        ));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_dir.join("test.jsonl"), session_id.clone())
+                .expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    fn profile(datacite: bool) -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite,
+        };
+        p
+    }
+
+    /// The DOI separator `/` must stay structural in the path — DataCite
+    /// routes on `/dois/<prefix>/<suffix>`, so percent-encoding it 404s.
+    #[test]
+    fn request_url_keeps_the_doi_slash_structural() {
+        let src = DataCiteSource::new();
+        let doi = Doi::parse("10.5281/zenodo.22053902").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(
+            url.as_str(),
+            "https://api.datacite.org/dois/10.5281/zenodo.22053902"
+        );
+    }
+
+    /// Injection into the path is prevented one layer earlier than the URL
+    /// builder: `Doi` is a validated newtype, so a suffix carrying `?`, `#`
+    /// or a space never becomes a `Doi` at all and `request_url` can never
+    /// be handed one. Pinned here because the builder deliberately pushes
+    /// the suffix as structural path segments, which would otherwise be the
+    /// place to worry.
+    #[test]
+    fn doi_newtype_rejects_characters_that_could_escape_the_path() {
+        for bad in ["10.5281/a?b", "10.5281/a#b", "10.5281/a b"] {
+            assert!(
+                Doi::parse(bad).is_err(),
+                "{bad} must not parse as a DOI, or request_url could see it"
+            );
+        }
+    }
+
+    /// A DOI suffix may itself contain `/`. Every one of them stays
+    /// structural, and nothing climbs above `/dois/`.
+    #[test]
+    fn request_url_handles_a_multi_segment_suffix() {
+        let src = DataCiteSource::new();
+        let doi = Doi::parse("10.17605/osf.io/ab3cd").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(
+            url.as_str(),
+            "https://api.datacite.org/dois/10.17605/osf.io/ab3cd"
+        );
+        assert!(url.query().is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_attributes_and_license() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/dois/10.5281/zenodo.22053902"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_RECORD))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.5281/zenodo.22053902").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("fetch succeeds");
+        assert_eq!(got.source, "datacite");
+        assert_eq!(got.license, "cc-by-4.0");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+        let attrs = got.metadata_json.expect("attributes");
+        assert_eq!(resource_type_general(&attrs), Some("JournalArticle"));
+    }
+
+    /// The regression #413 requires of every new source: with the runtime
+    /// flag unset it must refuse BEFORE touching the network. No route is
+    /// mounted either, so a request would also fail loudly.
+    #[tokio::test]
+    async fn is_inert_when_the_runtime_flag_is_unset() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.5281/zenodo.22053902").expect("doi"));
+
+        assert!(
+            !src.can_serve(&profile(false), &ref_),
+            "can_serve must be false with DOIGET_ENABLE_DATACITE unset"
+        );
+        let err = src
+            .fetch(&ref_, &profile(false), &ctx)
+            .await
+            .expect_err("must refuse");
+        assert!(matches!(err, FetchError::NotEligible { .. }), "got {err:?}");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "an inert source must make NO request"
+        );
+    }
+
+    #[tokio::test]
+    async fn arxiv_refs_are_not_eligible() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+        assert!(!src.can_serve(&profile(true), &ref_));
+        assert!(matches!(
+            src.fetch(&ref_, &profile(true), &ctx).await,
+            Err(FetchError::NotEligible { .. })
+        ));
+    }
+
+    /// A DOI DataCite does not hold returns a JSON error envelope with no
+    /// `data.attributes`. That must surface as SourceSchema so the
+    /// orchestrator falls through rather than aborting the fetch.
+    #[tokio::test]
+    async fn missing_record_surfaces_as_source_schema() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/dois/10.1234/not-datacite"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(r#"{"errors":[{"status":"404"}]}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = DataCiteSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/not-datacite").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("must not claim success");
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn license_falls_back_to_unknown_rather_than_guessing() {
+        // Free-text `rights` with no identifier must NOT become a licence:
+        // a wrong licence is worse than an absent one.
+        let attrs = serde_json::json!({"rightsList": [{"rights": "Open Access"}]});
+        assert_eq!(license_of(&attrs), "unknown");
+        assert_eq!(license_of(&serde_json::json!({})), "unknown");
+    }
+}

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -10,8 +10,8 @@
 //!
 //! ## Resolution, not enrichment
 //!
-//! Its siblings ([`openalex`](super::openalex) / [`s2`](super::s2) /
-//! [`doaj`](super::doaj)) add fields to a record Crossref already
+//! Its siblings (`openalex` / `s2` /
+//! `doaj`) add fields to a record Crossref already
 //! returned. This one answers the prior question — *does this DOI exist*
 //! — for an agency doiget otherwise cannot see. It therefore belongs
 //! **after** Crossref in the DOI fan-out: a Crossref-registered DOI never
@@ -20,10 +20,10 @@
 //!
 //! ## Capability gate
 //!
-//! [`DataCiteSource::can_serve`] returns `true` only when
+//! `DataCiteSource::can_serve` returns `true` only when
 //! [`CapabilityProfile.metadata.datacite`](crate::CapabilityProfile) is
-//! `true` AND the ref is a [`Ref::Doi`]. The bool is set by
-//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_DATACITE`, which is
+//! `true` AND the ref is a `Ref::Doi`. The bool is set by
+//! `CapabilityProfile::from_env` from `DOIGET_ENABLE_DATACITE`, which is
 //! **off by default** (ADR-0040) — with it unset the binary behaves
 //! exactly as it did before this source existed.
 //!

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -306,6 +306,7 @@ mod tests {
             semantic_scholar: false,
             doaj: false,
             datacite,
+            hal: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -269,6 +269,7 @@ mod tests {
             semantic_scholar: false,
             doaj: true,
             datacite: false,
+            hal: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -270,6 +270,7 @@ mod tests {
             doaj: true,
             datacite: false,
             hal: false,
+            openaire: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -272,6 +272,7 @@ mod tests {
             hal: false,
             openaire: false,
             core: false,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -268,6 +268,7 @@ mod tests {
             openalex: false,
             semantic_scholar: false,
             doaj: true,
+            datacite: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -271,6 +271,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/europepmc.rs
+++ b/crates/doiget-core/src/sources/europepmc.rs
@@ -1,0 +1,533 @@
+//! Europe PMC source — biomedical OA full text (Tier 2, #415).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. Europe PMC holds OA full
+//! text (the PMC mirror plus Europe-specific deposits) that Unpaywall's
+//! `best_oa_location` frequently misses, or for which Unpaywall returns a
+//! landing page rather than a `url_for_pdf`.
+//!
+//! ## Capability gate
+//!
+//! [`EuropePmcSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.europe_pmc`](crate::CapabilityProfile) is
+//! `true` AND the ref is a [`Ref::Doi`]. The bool is set by
+//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_EUROPE_PMC`, which
+//! is **off by default** (ADR-0040).
+//!
+//! ## OA subset only
+//!
+//! Europe PMC indexes far more than it can give you: a record can be
+//! `inEPMC = "Y"` — present in the archive — while `isOpenAccess = "N"`,
+//! meaning the full text sits behind the publisher subscription. Only
+//! `isOpenAccess = "Y"` is accepted, and anything else is an explicit
+//! refusal rather than a hit, exactly as #415 requires. `inEPMC` is
+//! deliberately **not** the gate; it answers a different question.
+//!
+//! ## Retrieval goes through the existing OA chain, not this source
+//!
+//! Per `docs/SOURCES.md` §4 this source returns no PDF bytes. It surfaces
+//! the OA PDF location from `fullTextUrlList` via
+//! [`open_access_pdf_url`], and the fetch itself is performed by the
+//! existing `oa-publisher` leg — `europepmc.org` is already on that
+//! allowlist.
+//!
+//! That is a deliberate choice about where a failure surfaces. #415 asks
+//! for a distinct error when a proxy blocks the download; routing through
+//! `oa-publisher` gives that for free, and gives it *better*, because the
+//! existing denial machinery already carries an ADR-0023 `denial_context`
+//! naming the attempted host and the allowlist that rejected it. A bespoke
+//! `ErrorCode` would carry strictly less information and would widen the
+//! closed set in `docs/ERRORS.md` §3 for no gain.
+//!
+//! API: public REST, no auth, no key.
+//! About / terms: <https://europepmc.org/About>
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production Europe PMC REST base.
+const DEFAULT_BASE: &str = "https://www.ebi.ac.uk";
+
+/// Europe PMC [`Source`] impl — DOI to indexed record.
+#[derive(Clone, Debug)]
+pub struct EuropePmcSource {
+    /// API base URL. Production pins `https://www.ebi.ac.uk`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl EuropePmcSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build the search URL for one DOI.
+    ///
+    /// `resultType=core` is required: the default `lite` response omits
+    /// `fullTextUrlList`, which is the whole reason to consult this
+    /// source. The DOI is quoted so the query parser treats it as a phrase
+    /// rather than tokenising on `.` and `/`, and `query_pairs_mut`
+    /// percent-encodes the value so no query syntax escapes from the
+    /// suffix.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let mut url = self
+            .base
+            .join("/europepmc/webservices/rest/search")
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("europepmc URL construction failed: {e}"),
+            })?;
+        url.query_pairs_mut()
+            .append_pair("query", &format!("DOI:\"{}\"", doi.as_str()))
+            .append_pair("format", "json")
+            .append_pair("resultType", "core")
+            .append_pair("pageSize", "1");
+        Ok(url)
+    }
+}
+
+impl Default for EuropePmcSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for EuropePmcSource {
+    fn name(&self) -> &str {
+        "europe-pmc"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.metadata.europe_pmc && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "europe-pmc".into(),
+                });
+            }
+        };
+
+        if !profile.metadata.europe_pmc {
+            return Err(FetchError::NotEligible {
+                source_key: "europe-pmc".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("europepmc returned non-JSON: {e}"),
+            })?;
+
+        // Envelope: { hitCount, resultList: { result: [ .. ] } }.
+        let results = envelope
+            .get("resultList")
+            .and_then(|r| r.get("result"))
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "europepmc response missing `resultList.result` (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+        let record = results.first().ok_or_else(|| FetchError::NotFound {
+            hint: format!("europepmc has no record for {}", doi.as_str()),
+        })?;
+
+        // #415: OA subset only, as an explicit refusal rather than a retry.
+        if !is_open_access(record) {
+            return Err(FetchError::SourceSchema {
+                hint: format!(
+                    "europepmc record is indexed but not open access \
+                     (isOpenAccess = {}, inEPMC = {})",
+                    flag(record, "isOpenAccess").unwrap_or("absent"),
+                    flag(record, "inEPMC").unwrap_or("absent"),
+                ),
+            });
+        }
+
+        let license = record
+            .get("license")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(license.as_str()),
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(record.clone()),
+        })
+    }
+}
+
+/// Read one of the Europe PMC `"Y"` / `"N"` string flags.
+fn flag<'a>(record: &'a serde_json::Value, name: &str) -> Option<&'a str> {
+    record.get(name).and_then(|v| v.as_str())
+}
+
+/// True only for `isOpenAccess == "Y"`.
+///
+/// Deliberately **not** `inEPMC`: a record can be in the archive while its
+/// full text is subscription-only, so gating on presence rather than
+/// openness would return records doiget cannot retrieve. Absent counts as
+/// not open.
+#[must_use]
+pub fn is_open_access(record: &serde_json::Value) -> bool {
+    flag(record, "isOpenAccess") == Some("Y")
+}
+
+/// The OA PDF URL from `fullTextUrlList`, if the record advertises one.
+///
+/// Prefers a `documentStyle == "pdf"` entry whose availability code is
+/// free/open (`F` or `OA`), and returns `None` rather than a landing page
+/// — a landing page is precisely what Unpaywall already gives, and what
+/// makes this source worth consulting when it does not.
+///
+/// The URL is handed to the existing `oa-publisher` fetch leg rather than
+/// downloaded here; see the module docs for why that is also the right
+/// place for a proxy-blocked download to surface.
+#[must_use]
+pub fn open_access_pdf_url(record: &serde_json::Value) -> Option<&str> {
+    record
+        .get("fullTextUrlList")
+        .and_then(|l| l.get("fullTextUrl"))
+        .and_then(|l| l.as_array())
+        .and_then(|entries| {
+            entries.iter().find_map(|e| {
+                let style = e.get("documentStyle").and_then(|v| v.as_str())?;
+                let code = e.get("availabilityCode").and_then(|v| v.as_str())?;
+                let url = e.get("url").and_then(|v| v.as_str())?;
+                (style.eq_ignore_ascii_case("pdf") && matches!(code, "F" | "OA")).then_some(url)
+            })
+        })
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// An OA record with a free PDF entry listed AFTER a subscription DOI
+    /// entry — the ordering is deliberate, so the extractor has to pick on
+    /// the fields rather than take the first URL.
+    const SAMPLE_OA: &str = r#"{
+        "hitCount": 1,
+        "resultList": {"result": [
+            {
+                "id": "PMC1234567",
+                "source": "PMC",
+                "doi": "10.1234/open",
+                "title": "An Open Access Article",
+                "pubYear": "2024",
+                "isOpenAccess": "Y",
+                "inEPMC": "Y",
+                "license": "cc by",
+                "fullTextUrlList": {"fullTextUrl": [
+                    {"availability": "Subscription required", "availabilityCode": "S",
+                     "documentStyle": "doi", "site": "DOI",
+                     "url": "https://doi.org/10.1234/open"},
+                    {"availability": "Free", "availabilityCode": "F",
+                     "documentStyle": "pdf", "site": "Europe_PMC",
+                     "url": "https://europepmc.org/articles/PMC1234567?pdf=render"}
+                ]}
+            }
+        ]}
+    }"#;
+
+    /// Real trap, observed live on 10.1038/nature12373: the record IS in
+    /// the archive (`inEPMC = Y`) but is NOT open access.
+    const SAMPLE_IN_EPMC_BUT_CLOSED: &str = r#"{
+        "hitCount": 1,
+        "resultList": {"result": [
+            {
+                "id": "23903748",
+                "source": "MED",
+                "doi": "10.1038/nature12373",
+                "title": "Nanometre-scale thermometry in a living cell.",
+                "pubYear": "2013",
+                "isOpenAccess": "N",
+                "inEPMC": "Y",
+                "inPMC": "Y"
+            }
+        ]}
+    }"#;
+
+    const SAMPLE_EMPTY: &str = r#"{"hitCount": 0, "resultList": {"result": []}}"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "europe-pmc",
+            wiremock_host,
+        ));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_dir.join("test.jsonl"), session_id.clone())
+                .expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    fn profile(europe_pmc: bool) -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite: false,
+            hal: false,
+            openaire: false,
+            core: false,
+            europe_pmc,
+        };
+        p
+    }
+
+    /// `resultType=core` is not cosmetic: the default `lite` response omits
+    /// `fullTextUrlList`, which is the only reason to consult this source.
+    #[test]
+    fn request_url_asks_for_the_core_result_type() {
+        let src = EuropePmcSource::new();
+        let doi = Doi::parse("10.1234/open").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(url.path(), "/europepmc/webservices/rest/search");
+        let pairs: Vec<(String, String)> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        assert!(pairs.contains(&("resultType".into(), "core".into())));
+        assert!(pairs.contains(&("format".into(), "json".into())));
+        assert!(pairs.contains(&("query".into(), "DOI:\"10.1234/open\"".into())));
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_an_open_access_record() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/europepmc/webservices/rest/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_OA))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = EuropePmcSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/open").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("fetch succeeds");
+        assert_eq!(got.source, "europe-pmc");
+        assert_eq!(got.license, "cc by");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+        let rec = got.metadata_json.expect("record");
+        assert_eq!(
+            open_access_pdf_url(&rec),
+            Some("https://europepmc.org/articles/PMC1234567?pdf=render"),
+            "must pick the free PDF entry, not the first URL in the list"
+        );
+    }
+
+    /// The trap this gate exists for. `inEPMC = Y` means the record is in
+    /// the archive; it says nothing about whether the full text is
+    /// readable. Gating on presence instead of openness would hand back
+    /// records doiget cannot retrieve.
+    #[tokio::test]
+    async fn in_epmc_but_not_open_access_is_refused() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/europepmc/webservices/rest/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_IN_EPMC_BUT_CLOSED))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = EuropePmcSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1038/nature12373").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("a non-OA record must be refused, not returned");
+        let msg = err.to_string();
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+        assert!(
+            msg.contains("isOpenAccess = N") && msg.contains("inEPMC = Y"),
+            "the refusal must say WHY, naming both flags; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn open_access_is_judged_on_isopenaccess_not_inepmc() {
+        assert!(is_open_access(&serde_json::json!({"isOpenAccess": "Y"})));
+        assert!(!is_open_access(
+            &serde_json::json!({"isOpenAccess": "N", "inEPMC": "Y"})
+        ));
+        assert!(
+            !is_open_access(&serde_json::json!({"inEPMC": "Y"})),
+            "presence in the archive is not openness"
+        );
+        assert!(
+            !is_open_access(&serde_json::json!({})),
+            "absent is not open"
+        );
+    }
+
+    /// A landing page is what Unpaywall already gives; returning one here
+    /// would defeat the point of consulting this source.
+    #[test]
+    fn pdf_url_extraction_skips_landing_pages_and_subscription_entries() {
+        let only_landing = serde_json::json!({"fullTextUrlList": {"fullTextUrl": [
+            {"documentStyle": "html", "availabilityCode": "F", "url": "https://x/landing"}
+        ]}});
+        assert_eq!(open_access_pdf_url(&only_landing), None);
+
+        let paywalled_pdf = serde_json::json!({"fullTextUrlList": {"fullTextUrl": [
+            {"documentStyle": "pdf", "availabilityCode": "S", "url": "https://x/paid.pdf"}
+        ]}});
+        assert_eq!(
+            open_access_pdf_url(&paywalled_pdf),
+            None,
+            "a subscription PDF is not an OA PDF"
+        );
+
+        assert_eq!(open_access_pdf_url(&serde_json::json!({})), None);
+    }
+
+    #[tokio::test]
+    async fn no_record_surfaces_as_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/europepmc/webservices/rest/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_EMPTY))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = EuropePmcSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/absent").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("must not claim success");
+        assert!(matches!(err, FetchError::NotFound { .. }), "got {err:?}");
+    }
+
+    /// The regression #413 requires of every new source.
+    #[tokio::test]
+    async fn is_inert_when_the_runtime_flag_is_unset() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = EuropePmcSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/open").expect("doi"));
+
+        assert!(!src.can_serve(&profile(false), &ref_));
+        let err = src
+            .fetch(&ref_, &profile(false), &ctx)
+            .await
+            .expect_err("must refuse");
+        assert!(matches!(err, FetchError::NotEligible { .. }), "got {err:?}");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "an inert source must make NO request"
+        );
+    }
+
+    #[tokio::test]
+    async fn arxiv_refs_are_not_eligible() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = EuropePmcSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+        assert!(!src.can_serve(&profile(true), &ref_));
+        assert!(matches!(
+            src.fetch(&ref_, &profile(true), &ctx).await,
+            Err(FetchError::NotEligible { .. })
+        ));
+    }
+}

--- a/crates/doiget-core/src/sources/europepmc.rs
+++ b/crates/doiget-core/src/sources/europepmc.rs
@@ -7,10 +7,10 @@
 //!
 //! ## Capability gate
 //!
-//! [`EuropePmcSource::can_serve`] returns `true` only when
+//! `EuropePmcSource::can_serve` returns `true` only when
 //! [`CapabilityProfile.metadata.europe_pmc`](crate::CapabilityProfile) is
-//! `true` AND the ref is a [`Ref::Doi`]. The bool is set by
-//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_EUROPE_PMC`, which
+//! `true` AND the ref is a `Ref::Doi`. The bool is set by
+//! `CapabilityProfile::from_env` from `DOIGET_ENABLE_EUROPE_PMC`, which
 //! is **off by default** (ADR-0040).
 //!
 //! ## OA subset only
@@ -26,7 +26,7 @@
 //!
 //! Per `docs/SOURCES.md` §4 this source returns no PDF bytes. It surfaces
 //! the OA PDF location from `fullTextUrlList` via
-//! [`open_access_pdf_url`], and the fetch itself is performed by the
+//! `open_access_pdf_url`, and the fetch itself is performed by the
 //! existing `oa-publisher` leg — `europepmc.org` is already on that
 //! allowlist.
 //!

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -328,6 +328,7 @@ mod tests {
             doaj: false,
             datacite: false,
             hal,
+            openaire: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -330,6 +330,7 @@ mod tests {
             hal,
             openaire: false,
             core: false,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -329,6 +329,7 @@ mod tests {
             datacite: false,
             hal,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -1,0 +1,486 @@
+//! HAL source — French national OA repository (Phase 4 / Tier 2, #418).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. HAL (Hyper Articles en
+//! Ligne) is the French national open repository. It holds author
+//! deposits — notably in mathematics, physics and CS — that are absent
+//! from Crossref-centric indexes, so Unpaywall misses them.
+//!
+//! ## Capability gate
+//!
+//! [`HalSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.hal`](crate::CapabilityProfile) is `true`
+//! AND the ref is a [`Ref::Doi`]. The bool is set by
+//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_HAL`, which is
+//! **off by default** (ADR-0040) — with it unset this source is inert and
+//! the binary behaves exactly as before.
+//!
+//! ## OA deposits only
+//!
+//! A HAL record can exist for a paper whose full text was never deposited,
+//! or was deposited under embargo. `openAccess_bool` is the repository
+//! saying so itself, and a record without it set is rejected rather than
+//! returned — an entry resolving to no reachable text is worse than a
+//! clean miss, because it looks like a hit.
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4 this source never returns PDF bytes. HAL does
+//! expose a `fileMain_s` URL on `hal.science`, but that host is reached
+//! through the `oa-publisher` source key (via `trust_oa_registries`), not
+//! this one — the API host and the content host are deliberately separate
+//! allowlist entries.
+//!
+//! ## Resolution only, never discovery
+//!
+//! Queried by exact DOI through the `doiId_s` field and nothing else. The
+//! Solr endpoint would happily serve free-text search; using it that way
+//! would turn a resolver into a discovery surface, which `docs/SCOPE.md`
+//! keeps out.
+//!
+//! API: public Solr-style REST, no auth, no key.
+//! Terms: <https://api.archives-ouvertes.fr/docs>
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production HAL API base.
+const DEFAULT_BASE: &str = "https://api.archives-ouvertes.fr";
+
+/// Fields requested from the Solr endpoint.
+///
+/// Explicit rather than `*` so the response stays small and the parser has
+/// a fixed contract: an unexpected extra field cannot change behaviour,
+/// and a removed one fails visibly rather than silently widening the
+/// payload.
+const FIELDS: &str = "docid,title_s,authFullName_s,producedDateY_i,doiId_s,uri_s,\
+                      openAccess_bool,fileMain_s,licence_s,docType_s";
+
+/// HAL [`Source`] impl — DOI to HAL deposit record.
+#[derive(Clone, Debug)]
+pub struct HalSource {
+    /// API base URL. Production pins `https://api.archives-ouvertes.fr`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl HalSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build `/search/?q=doiId_s:"<doi>"&fl=<fields>&rows=1&wt=json`.
+    ///
+    /// The DOI is wrapped in double quotes so Solr treats it as a phrase:
+    /// unquoted, its `.` and `/` are tokenised and the query degrades into
+    /// a fuzzy match that can return the wrong record. `query_pairs_mut`
+    /// percent-encodes the whole value, so the quotes and the DOI travel
+    /// as data and no Solr syntax can be injected from the suffix.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let mut url = self
+            .base
+            .join("/search/")
+            .map_err(|e| FetchError::SourceSchema {
+                hint: format!("hal URL construction failed: {e}"),
+            })?;
+        url.query_pairs_mut()
+            .append_pair("q", &format!("doiId_s:\"{}\"", doi.as_str()))
+            .append_pair("fl", FIELDS)
+            .append_pair("rows", "1")
+            .append_pair("wt", "json");
+        Ok(url)
+    }
+}
+
+impl Default for HalSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for HalSource {
+    fn name(&self) -> &str {
+        "hal"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.metadata.hal && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "hal".into(),
+                });
+            }
+        };
+
+        if !profile.metadata.hal {
+            return Err(FetchError::NotEligible {
+                source_key: "hal".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("hal returned non-JSON: {e}"),
+            })?;
+
+        // Solr envelope: { responseHeader: {..}, response: { numFound, docs: [..] } }.
+        let docs = envelope
+            .get("response")
+            .and_then(|r| r.get("docs"))
+            .and_then(|d| d.as_array())
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "hal response missing `response.docs` (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+        let doc = docs.first().ok_or_else(|| FetchError::SourceSchema {
+            hint: "hal has no deposit for this DOI".to_string(),
+        })?;
+
+        // OA gate. An absent `openAccess_bool` is treated as NOT open: HAL
+        // omits the field on some record types, and defaulting an unknown
+        // to "open" would hand back a record whose text nobody can read.
+        if doc
+            .get("openAccess_bool")
+            .and_then(serde_json::Value::as_bool)
+            != Some(true)
+        {
+            return Err(FetchError::SourceSchema {
+                hint: "hal deposit is not open access (openAccess_bool != true)".to_string(),
+            });
+        }
+
+        let license = license_of(doc);
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(license.as_str()),
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(doc.clone()),
+        })
+    }
+}
+
+/// Licence from `licence_s`, else `"unknown"`.
+///
+/// HAL returns a licence URL (a `creativecommons.org/licenses/...` link)
+/// rather than an SPDX identifier, and only when the depositor set one. It
+/// is passed through verbatim: normalising a URL into an SPDX id means
+/// guessing, and a wrong licence is worse than an absent one.
+fn license_of(doc: &serde_json::Value) -> String {
+    first_str(doc, "licence_s")
+        .map(str::to_string)
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// First value of a Solr field that may be a bare string or an array.
+///
+/// `title_s` is multi-valued in HAL even when there is exactly one title,
+/// so a naive `as_str()` returns `None` for the common case.
+#[must_use]
+pub fn first_str<'a>(doc: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+    let v = doc.get(field)?;
+    v.as_str().or_else(|| {
+        v.as_array()
+            .and_then(|a| a.first())
+            .and_then(|f| f.as_str())
+    })
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// Real shape, captured 2026-08-22 from
+    /// `GET /search/?q=doiId_s:"10.1103/PhysRevB.92.125119"`.
+    /// Note `title_s` and `authFullName_s` are arrays even for one value,
+    /// and this record carries no `licence_s` — both are the common case.
+    const SAMPLE_HIT: &str = r#"{
+        "response": {
+            "numFound": 1,
+            "docs": [
+                {
+                    "docid": "1204546",
+                    "openAccess_bool": true,
+                    "title_s": ["Minimally entangled typical thermal states"],
+                    "authFullName_s": ["Moritz Binder", "Thomas Barthel"],
+                    "uri_s": "https://hal.science/hal-01204546v1",
+                    "doiId_s": "10.1103/PhysRevB.92.125119",
+                    "producedDateY_i": 2015
+                }
+            ]
+        }
+    }"#;
+
+    const SAMPLE_EMPTY: &str = r#"{"response": {"numFound": 0, "docs": []}}"#;
+
+    const SAMPLE_CLOSED: &str = r#"{
+        "response": {
+            "numFound": 1,
+            "docs": [
+                {
+                    "docid": "999",
+                    "openAccess_bool": false,
+                    "title_s": ["An Embargoed Deposit"],
+                    "doiId_s": "10.1234/closed"
+                }
+            ]
+        }
+    }"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http("hal", wiremock_host));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_dir.join("test.jsonl"), session_id.clone())
+                .expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    fn profile(hal: bool) -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite: false,
+            hal,
+        };
+        p
+    }
+
+    /// The DOI must be quoted so Solr treats it as a phrase — unquoted, the
+    /// `.` and `/` tokenise and the query can match a different record.
+    #[test]
+    fn request_url_quotes_the_doi_as_a_solr_phrase() {
+        let src = HalSource::new();
+        let doi = Doi::parse("10.1103/PhysRevB.92.125119").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        let q = url
+            .query_pairs()
+            .find(|(k, _)| k == "q")
+            .expect("q param")
+            .1
+            .into_owned();
+        assert_eq!(q, "doiId_s:\"10.1103/PhysRevB.92.125119\"");
+        assert_eq!(url.path(), "/search/");
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_the_first_open_deposit() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_HIT))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = HalSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevB.92.125119").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("fetch succeeds");
+        assert_eq!(got.source, "hal");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+        // No `licence_s` on this record: must report unknown, not invent one.
+        assert_eq!(got.license, "unknown");
+        let doc = got.metadata_json.expect("doc");
+        assert_eq!(
+            first_str(&doc, "title_s"),
+            Some("Minimally entangled typical thermal states"),
+            "multi-valued Solr fields must be unwrapped"
+        );
+    }
+
+    /// A record whose full text was never deposited, or is embargoed, must
+    /// NOT come back as a hit — it would look like a success and resolve to
+    /// nothing readable.
+    #[tokio::test]
+    async fn closed_access_deposits_are_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_CLOSED))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = HalSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/closed").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("closed deposits must not be returned");
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// An absent `openAccess_bool` is treated as closed. Defaulting an
+    /// unknown to open would hand back an unreadable record.
+    #[test]
+    fn missing_open_access_flag_is_not_treated_as_open() {
+        let doc = serde_json::json!({"docid": "1", "title_s": ["x"]});
+        assert_ne!(
+            doc.get("openAccess_bool")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[tokio::test]
+    async fn no_deposit_surfaces_as_source_schema() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_EMPTY))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = HalSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/absent").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("must not claim success");
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// The regression #413 requires of every new source: with the runtime
+    /// flag unset it must refuse BEFORE touching the network.
+    #[tokio::test]
+    async fn is_inert_when_the_runtime_flag_is_unset() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = HalSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevB.92.125119").expect("doi"));
+
+        assert!(!src.can_serve(&profile(false), &ref_));
+        let err = src
+            .fetch(&ref_, &profile(false), &ctx)
+            .await
+            .expect_err("must refuse");
+        assert!(matches!(err, FetchError::NotEligible { .. }), "got {err:?}");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "an inert source must make NO request"
+        );
+    }
+
+    #[tokio::test]
+    async fn arxiv_refs_are_not_eligible() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = HalSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+        assert!(!src.can_serve(&profile(true), &ref_));
+        assert!(matches!(
+            src.fetch(&ref_, &profile(true), &ctx).await,
+            Err(FetchError::NotEligible { .. })
+        ));
+    }
+
+    #[test]
+    fn first_str_handles_bare_and_array_fields() {
+        let doc = serde_json::json!({"a": "bare", "b": ["first", "second"], "c": []});
+        assert_eq!(first_str(&doc, "a"), Some("bare"));
+        assert_eq!(first_str(&doc, "b"), Some("first"));
+        assert_eq!(first_str(&doc, "c"), None);
+        assert_eq!(first_str(&doc, "missing"), None);
+    }
+}

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -7,10 +7,10 @@
 //!
 //! ## Capability gate
 //!
-//! [`HalSource::can_serve`] returns `true` only when
+//! `HalSource::can_serve` returns `true` only when
 //! [`CapabilityProfile.metadata.hal`](crate::CapabilityProfile) is `true`
-//! AND the ref is a [`Ref::Doi`]. The bool is set by
-//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_HAL`, which is
+//! AND the ref is a `Ref::Doi`. The bool is set by
+//! `CapabilityProfile::from_env` from `DOIGET_ENABLE_HAL`, which is
 //! **off by default** (ADR-0040) — with it unset this source is inert and
 //! the binary behaves exactly as before.
 //!

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
 //! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
-//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL / OpenAIRE.
+//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL / OpenAIRE / CORE.
 //! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
 //!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
@@ -44,6 +44,15 @@ pub mod hal;
 /// Runtime-gated by `DOIGET_ENABLE_OPENAIRE`, off by default (#416).
 #[cfg(feature = "metadata")]
 pub mod openaire;
+
+/// CORE — cross-repository OA aggregation, the broadest single OA index
+/// outside Unpaywall and therefore the LAST fallback in the chain. Takes
+/// an optional free key from `DOIGET_CORE_API_KEY`; absent, it degrades
+/// to the key-less rate limit. Runtime-gated by `DOIGET_ENABLE_CORE`,
+/// off by default (#417). Named `core_oa` because `core` is a built-in
+/// crate name.
+#[cfg(feature = "metadata")]
+pub mod core_oa;
 
 // ---------------------------------------------------------------------------
 // Tier 3 (Phase 5) — compile-gated by per-publisher Cargo features.

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
 //! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
-//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL.
+//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL / OpenAIRE.
 //! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
 //!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
@@ -37,6 +37,13 @@ pub mod datacite;
 /// `DOIGET_ENABLE_HAL`, off by default (ADR-0040, #418).
 #[cfg(feature = "metadata")]
 pub mod hal;
+
+/// OpenAIRE — European institutional / funder repository aggregation via
+/// the Graph API v1 (the legacy search endpoint is unstable and unused).
+/// Mixed access rights, so only COAR OPEN records are returned.
+/// Runtime-gated by `DOIGET_ENABLE_OPENAIRE`, off by default (#416).
+#[cfg(feature = "metadata")]
+pub mod openaire;
 
 // ---------------------------------------------------------------------------
 // Tier 3 (Phase 5) — compile-gated by per-publisher Cargo features.

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
 //! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
-//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite.
+//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL.
 //! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
 //!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
@@ -31,6 +31,12 @@ pub mod doaj;
 /// off by default (ADR-0040, #414).
 #[cfg(feature = "metadata")]
 pub mod datacite;
+
+/// HAL — the French national OA repository. Author deposits in maths /
+/// physics / CS that Crossref-centric indexes miss. Runtime-gated by
+/// `DOIGET_ENABLE_HAL`, off by default (ADR-0040, #418).
+#[cfg(feature = "metadata")]
+pub mod hal;
 
 // ---------------------------------------------------------------------------
 // Tier 3 (Phase 5) — compile-gated by per-publisher Cargo features.

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
 //! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
-//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL / OpenAIRE / CORE.
+//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite / HAL / OpenAIRE / CORE / Europe PMC.
 //! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
 //!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
@@ -53,6 +53,13 @@ pub mod openaire;
 /// crate name.
 #[cfg(feature = "metadata")]
 pub mod core_oa;
+
+/// Europe PMC — biomedical OA full text the Crossref-centric Unpaywall
+/// index misses. OA subset only (`isOpenAccess`, not `inEPMC`); the PDF
+/// it points at is fetched by the existing `oa-publisher` leg, not here.
+/// Runtime-gated by `DOIGET_ENABLE_EUROPE_PMC`, off by default (#415).
+#[cfg(feature = "metadata")]
+pub mod europepmc;
 
 // ---------------------------------------------------------------------------
 // Tier 3 (Phase 5) — compile-gated by per-publisher Cargo features.

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - Tier 1 (Open Access, always compiled in): Crossref / Unpaywall / arXiv.
 //! - Tier 2 (metadata enrichment, Phase 4, behind the `metadata` Cargo
-//!   feature): OpenAlex / Semantic Scholar / DOAJ.
+//!   feature): OpenAlex / Semantic Scholar / DOAJ / DataCite.
 //! - Tier 3 (TDM, Phase 5, behind per-publisher Cargo features):
 //!   Springer Nature OA / APS Harvest / Elsevier ScienceDirect.
 
@@ -24,6 +24,13 @@ pub mod s2;
 
 #[cfg(feature = "metadata")]
 pub mod doaj;
+
+/// DataCite — DOI **resolution** for the second registration agency
+/// (Zenodo / figshare / Dryad / OSF). Not enrichment: without it those
+/// DOIs report `NotFound`. Runtime-gated by `DOIGET_ENABLE_DATACITE`,
+/// off by default (ADR-0040, #414).
+#[cfg(feature = "metadata")]
+pub mod datacite;
 
 // ---------------------------------------------------------------------------
 // Tier 3 (Phase 5) — compile-gated by per-publisher Cargo features.

--- a/crates/doiget-core/src/sources/openaire.rs
+++ b/crates/doiget-core/src/sources/openaire.rs
@@ -1,0 +1,520 @@
+//! OpenAIRE source — European repository aggregation (Tier 2, #416).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 2 row + §4. OpenAIRE aggregates
+//! European institutional and funder repositories, covering OA deposits
+//! that never reach Crossref and therefore never reach Unpaywall.
+//!
+//! ## Graph API v1, not the legacy search endpoint
+//!
+//! #416 measured both on 2026-08-22:
+//!
+//! ```text
+//! GET /graph/v1/researchProducts?pid=<doi>   -> 200
+//! GET /search/publications?doi=<doi>         -> 503
+//! ```
+//!
+//! The legacy `/search/publications` endpoint is unstable and must not be
+//! used. Only the Graph API is wired here.
+//!
+//! ## Capability gate
+//!
+//! [`OpenAireSource::can_serve`] returns `true` only when
+//! [`CapabilityProfile.metadata.openaire`](crate::CapabilityProfile) is
+//! `true` AND the ref is a [`Ref::Doi`]. The bool is set by
+//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_OPENAIRE`, which is
+//! **off by default** (ADR-0040) — unset, this source is inert.
+//!
+//! ## Access rights are honoured, never guessed
+//!
+//! OpenAIRE aggregates records with **mixed** access rights, so unlike a
+//! pure-OA index a hit is not evidence of availability. `bestAccessRight`
+//! carries a COAR vocabulary code; only `c_abf2` (OPEN) is accepted, and
+//! anything else — EMBARGO, RESTRICTED, CLOSED, or a missing field — is
+//! refused. Returning a closed record would look like a hit and resolve to
+//! nothing readable.
+//!
+//! ## Overlap with DataCite is expected
+//!
+//! OpenAIRE mirrors a large slice of Zenodo, which [`super::datacite`]
+//! also resolves. That is why #413 ordered DataCite first: this source is
+//! consulted later in the chain, so the overlap costs nothing beyond a
+//! request that is not made.
+//!
+//! ## Metadata-only contract
+//!
+//! Per `docs/SOURCES.md` §4 this source never returns PDF bytes. Instance
+//! URLs point at publisher or repository hosts, which are reached through
+//! the `oa-publisher` key, not this one.
+//!
+//! API: public Graph API v1, no auth for basic queries.
+//! Terms: <https://graph.openaire.eu/docs/>
+
+use async_trait::async_trait;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production OpenAIRE API base.
+const DEFAULT_BASE: &str = "https://api.openaire.eu";
+
+/// COAR access-rights code for OPEN.
+///
+/// Matched on the code, not the human label: `label` is display text and
+/// may be localised or reworded, while the COAR code is a stable
+/// vocabulary term.
+const COAR_OPEN: &str = "c_abf2";
+
+/// OpenAIRE [`Source`] impl — DOI to research-product record.
+#[derive(Clone, Debug)]
+pub struct OpenAireSource {
+    /// API base URL. Production pins `https://api.openaire.eu`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin.
+    base: Url,
+}
+
+impl OpenAireSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build `/graph/v1/researchProducts?pid=<doi>&pageSize=1`.
+    ///
+    /// The DOI goes in a **query parameter**, so its `/` must be
+    /// percent-encoded — an unencoded one makes the endpoint reject the
+    /// request (observed while verifying the shape). `query_pairs_mut`
+    /// handles that, which is why this source does not share
+    /// [`super::datacite`]'s path-segment approach.
+    fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
+        let mut url =
+            self.base
+                .join("/graph/v1/researchProducts")
+                .map_err(|e| FetchError::SourceSchema {
+                    hint: format!("openaire URL construction failed: {e}"),
+                })?;
+        url.query_pairs_mut()
+            .append_pair("pid", doi.as_str())
+            .append_pair("pageSize", "1");
+        Ok(url)
+    }
+}
+
+impl Default for OpenAireSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for OpenAireSource {
+    fn name(&self) -> &str {
+        "openaire"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        profile.metadata.openaire && matches!(ref_, Ref::Doi(_))
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "openaire".into(),
+                });
+            }
+        };
+
+        if !profile.metadata.openaire {
+            return Err(FetchError::NotEligible {
+                source_key: "openaire".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("openaire returned non-JSON: {e}"),
+            })?;
+
+        // Graph envelope: { header: { numFound, .. }, results: [ .. ] }.
+        let results = envelope
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "openaire response missing `results` array (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+        let record = results.first().ok_or_else(|| FetchError::SourceSchema {
+            hint: "openaire has no research product for this DOI".to_string(),
+        })?;
+
+        if !is_open_access(record) {
+            return Err(FetchError::SourceSchema {
+                hint: format!(
+                    "openaire record is not open access (bestAccessRight.code = {})",
+                    access_right_code(record).unwrap_or("absent")
+                ),
+            });
+        }
+
+        let license = license_of(record);
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::Metadata,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: Some(license.as_str()),
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license,
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(record.clone()),
+        })
+    }
+}
+
+/// `bestAccessRight.code`, if present.
+#[must_use]
+pub fn access_right_code(record: &serde_json::Value) -> Option<&str> {
+    record
+        .get("bestAccessRight")
+        .and_then(|r| r.get("code"))
+        .and_then(|v| v.as_str())
+}
+
+/// True only for the COAR OPEN code.
+///
+/// Absent counts as **not** open. OpenAIRE aggregates mixed rights, so an
+/// unknown here is genuinely unknown, and treating it as open would return
+/// records that resolve to a paywall.
+#[must_use]
+pub fn is_open_access(record: &serde_json::Value) -> bool {
+    access_right_code(record) == Some(COAR_OPEN)
+}
+
+/// Licence from the first instance that declares one, else `"unknown"`.
+///
+/// OpenAIRE puts licences on `instances[]`, not on the record, and the
+/// value is free text from the source repository (e.g. "APS Licenses for
+/// Journal Article Re-use") rather than an SPDX id. Passed through
+/// verbatim: normalising it would mean guessing, and a wrong licence is
+/// worse than an absent one.
+fn license_of(record: &serde_json::Value) -> String {
+    record
+        .get("instances")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find_map(|i| i.get("license").and_then(|v| v.as_str()))
+        })
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, MetadataAccess, RateLimits, Ref};
+
+    /// Trimmed real shape, captured 2026-08-22 from
+    /// `GET /graph/v1/researchProducts?pid=10.1103/PhysRevB.92.125119`.
+    /// Note the licence lives on `instances[]`, not on the record, and is
+    /// publisher free text rather than an SPDX id.
+    const SAMPLE_OPEN: &str = r#"{
+        "header": {"numFound": 1, "page": 1, "pageSize": 1},
+        "results": [
+            {
+                "id": "doi_dedup___::8bd761bf23510d840dc1f38adebdc964",
+                "type": "publication",
+                "mainTitle": "Minimally entangled typical thermal states",
+                "publicationDate": "2015-09-10",
+                "bestAccessRight": {
+                    "code": "c_abf2",
+                    "label": "OPEN",
+                    "scheme": "http://vocabularies.coar-repositories.org/documentation/access_rights/"
+                },
+                "openAccessColor": "bronze",
+                "isGreen": true,
+                "instances": [
+                    {
+                        "license": "APS Licenses for Journal Article Re-use",
+                        "type": "Article",
+                        "urls": ["https://doi.org/10.1103/physrevb.92.125119"]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    const SAMPLE_CLOSED: &str = r#"{
+        "header": {"numFound": 1},
+        "results": [
+            {
+                "id": "x",
+                "mainTitle": "A Restricted Record",
+                "bestAccessRight": {"code": "c_16ec", "label": "RESTRICTED"},
+                "instances": []
+            }
+        ]
+    }"#;
+
+    const SAMPLE_EMPTY: &str = r#"{"header": {"numFound": 0}, "results": []}"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "openaire",
+            wiremock_host,
+        ));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_dir.join("test.jsonl"), session_id.clone())
+                .expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    fn profile(openaire: bool) -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.metadata = MetadataAccess {
+            openalex: false,
+            semantic_scholar: false,
+            doaj: false,
+            datacite: false,
+            hal: false,
+            openaire,
+        };
+        p
+    }
+
+    /// The DOI travels as a query parameter, so its `/` MUST be
+    /// percent-encoded — the endpoint rejects an unencoded one. This is the
+    /// opposite requirement to the DataCite source, where the slash has to
+    /// stay structural, so it is worth pinning explicitly.
+    #[test]
+    fn request_url_percent_encodes_the_doi_in_the_query() {
+        let src = OpenAireSource::new();
+        let doi = Doi::parse("10.1103/PhysRevB.92.125119").expect("valid doi");
+        let url = src.request_url(&doi).expect("url builds");
+        assert_eq!(url.path(), "/graph/v1/researchProducts");
+        assert!(
+            url.query()
+                .expect("query")
+                .contains("pid=10.1103%2FPhysRevB.92.125119"),
+            "slash must be encoded; got {}",
+            url.query().unwrap_or_default()
+        );
+        // …and it round-trips back to the original value.
+        let pid = url
+            .query_pairs()
+            .find(|(k, _)| k == "pid")
+            .expect("pid param")
+            .1
+            .into_owned();
+        assert_eq!(pid, "10.1103/PhysRevB.92.125119");
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_an_open_record_with_its_instance_license() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/graph/v1/researchProducts"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_OPEN))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = OpenAireSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevB.92.125119").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("fetch succeeds");
+        assert_eq!(got.source, "openaire");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+        assert_eq!(got.license, "APS Licenses for Journal Article Re-use");
+        let rec = got.metadata_json.expect("record");
+        assert!(is_open_access(&rec));
+    }
+
+    /// OpenAIRE aggregates MIXED access rights, so a hit is not evidence of
+    /// availability. A RESTRICTED record must be refused, not returned.
+    #[tokio::test]
+    async fn restricted_records_are_refused() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/graph/v1/researchProducts"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_CLOSED))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = OpenAireSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/restricted").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("restricted records must not be returned");
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// Only the COAR code counts. `label` is display text that may be
+    /// localised or reworded, and an absent field is genuinely unknown —
+    /// which must NOT be read as open.
+    #[test]
+    fn access_rights_are_judged_on_the_coar_code_only() {
+        let open = serde_json::json!({"bestAccessRight": {"code": "c_abf2", "label": "OPEN"}});
+        assert!(is_open_access(&open));
+
+        let embargo =
+            serde_json::json!({"bestAccessRight": {"code": "c_f1cf", "label": "EMBARGO"}});
+        assert!(!is_open_access(&embargo));
+
+        // Label says OPEN but the code does not: the code wins.
+        let lying = serde_json::json!({"bestAccessRight": {"code": "c_16ec", "label": "OPEN"}});
+        assert!(!is_open_access(&lying), "label must not override the code");
+
+        assert!(
+            !is_open_access(&serde_json::json!({})),
+            "absent is not open"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_record_surfaces_as_source_schema() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/graph/v1/researchProducts"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_EMPTY))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = OpenAireSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1234/absent").expect("doi"));
+        let err = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect_err("must not claim success");
+        assert!(
+            matches!(err, FetchError::SourceSchema { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// The regression #413 requires of every new source.
+    #[tokio::test]
+    async fn is_inert_when_the_runtime_flag_is_unset() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = OpenAireSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevB.92.125119").expect("doi"));
+
+        assert!(!src.can_serve(&profile(false), &ref_));
+        let err = src
+            .fetch(&ref_, &profile(false), &ctx)
+            .await
+            .expect_err("must refuse");
+        assert!(matches!(err, FetchError::NotEligible { .. }), "got {err:?}");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded")
+                .is_empty(),
+            "an inert source must make NO request"
+        );
+    }
+
+    #[tokio::test]
+    async fn arxiv_refs_are_not_eligible() {
+        let server = MockServer::start().await;
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = OpenAireSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Arxiv(crate::ArxivId::parse("2401.12345").expect("arxiv id"));
+        assert!(!src.can_serve(&profile(true), &ref_));
+        assert!(matches!(
+            src.fetch(&ref_, &profile(true), &ctx).await,
+            Err(FetchError::NotEligible { .. })
+        ));
+    }
+
+    #[test]
+    fn license_falls_back_to_unknown_when_no_instance_declares_one() {
+        let rec = serde_json::json!({"instances": [{"type": "Article"}]});
+        assert_eq!(license_of(&rec), "unknown");
+        assert_eq!(license_of(&serde_json::json!({})), "unknown");
+    }
+}

--- a/crates/doiget-core/src/sources/openaire.rs
+++ b/crates/doiget-core/src/sources/openaire.rs
@@ -352,6 +352,7 @@ mod tests {
             hal: false,
             openaire,
             core: false,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/openaire.rs
+++ b/crates/doiget-core/src/sources/openaire.rs
@@ -18,10 +18,10 @@
 //!
 //! ## Capability gate
 //!
-//! [`OpenAireSource::can_serve`] returns `true` only when
+//! `OpenAireSource::can_serve` returns `true` only when
 //! [`CapabilityProfile.metadata.openaire`](crate::CapabilityProfile) is
-//! `true` AND the ref is a [`Ref::Doi`]. The bool is set by
-//! [`CapabilityProfile::from_env`] from `DOIGET_ENABLE_OPENAIRE`, which is
+//! `true` AND the ref is a `Ref::Doi`. The bool is set by
+//! `CapabilityProfile::from_env` from `DOIGET_ENABLE_OPENAIRE`, which is
 //! **off by default** (ADR-0040) — unset, this source is inert.
 //!
 //! ## Access rights are honoured, never guessed
@@ -35,7 +35,7 @@
 //!
 //! ## Overlap with DataCite is expected
 //!
-//! OpenAIRE mirrors a large slice of Zenodo, which [`super::datacite`]
+//! OpenAIRE mirrors a large slice of Zenodo, which `super::datacite`
 //! also resolves. That is why #413 ordered DataCite first: this source is
 //! consulted later in the chain, so the overlap costs nothing beyond a
 //! request that is not made.
@@ -96,7 +96,7 @@ impl OpenAireSource {
     /// percent-encoded — an unencoded one makes the endpoint reject the
     /// request (observed while verifying the shape). `query_pairs_mut`
     /// handles that, which is why this source does not share
-    /// [`super::datacite`]'s path-segment approach.
+    /// `super::datacite`'s path-segment approach.
     fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
         let mut url =
             self.base

--- a/crates/doiget-core/src/sources/openaire.rs
+++ b/crates/doiget-core/src/sources/openaire.rs
@@ -351,6 +351,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -293,6 +293,7 @@ mod tests {
             semantic_scholar: false,
             doaj: false,
             datacite: false,
+            hal: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -292,6 +292,7 @@ mod tests {
             openalex: true,
             semantic_scholar: false,
             doaj: false,
+            datacite: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -294,6 +294,7 @@ mod tests {
             doaj: false,
             datacite: false,
             hal: false,
+            openaire: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -295,6 +295,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -296,6 +296,7 @@ mod tests {
             hal: false,
             openaire: false,
             core: false,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -42,7 +42,7 @@ const DEFAULT_FIELDS: &str = "title,year,citationCount,references";
 ///
 /// `Debug` is implemented manually (not derived) so the optional
 /// `api_key` is never printed: a derived `Debug` would render the raw
-/// key, contradicting the [`api_key`](Self::api_key) doc contract and
+/// key, contradicting the `api_key` doc contract and
 /// the credential-hygiene posture the TDM sources hold (their keys are
 /// `secrecy::SecretString`). S2 is not behind a `tdm-*` feature and the
 /// `secrecy` dep is `tdm-*`-gated/optional, so wrapping the field in

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -286,6 +286,7 @@ mod tests {
             hal: false,
             openaire: false,
             core: false,
+            europe_pmc: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -282,6 +282,7 @@ mod tests {
             openalex: false,
             semantic_scholar: true,
             doaj: false,
+            datacite: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -284,6 +284,7 @@ mod tests {
             doaj: false,
             datacite: false,
             hal: false,
+            openaire: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -283,6 +283,7 @@ mod tests {
             semantic_scholar: true,
             doaj: false,
             datacite: false,
+            hal: false,
         };
         p
     }

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -285,6 +285,7 @@ mod tests {
             datacite: false,
             hal: false,
             openaire: false,
+            core: false,
         };
         p
     }

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -379,9 +379,14 @@ pub fn academic_repo_hosts() -> Vec<UserExtensionHost> {
 ///
 /// Why this exists: the default allowlist covers publishers, so a Green-OA
 /// copy on an institutional repository was reachable behind one flag while
-/// a Gold-OA article routed through DOAJ was not reachable at all. For an
-/// open-access tool that polarity is backwards — `10.1109/access.2024.3495502`
-/// (IEEE Access, gold OA) is denied at `doaj.org` on a stock install.
+/// cross-publisher OA registries were not reachable at all.
+///
+/// DOAJ is deliberately NOT in this set. ADR-0037 promoted `doaj.org` to the
+/// default `oa_publisher_allowlist` unconditionally, because the project had
+/// already trusted it under the `"doaj"` metadata key and the two keys simply
+/// disagreed. The hosts below are different: none of them appears anywhere in
+/// `http.rs`, so for them this flag is genuinely new trust and opt-in is
+/// correct.
 ///
 /// Every entry is a registry or repository whose *purpose* is open
 /// distribution, not a publisher platform — enabling this must not become
@@ -391,8 +396,6 @@ pub fn academic_repo_hosts() -> Vec<UserExtensionHost> {
 /// redirect in #405 targeted the bare apex.
 pub fn oa_registry_hosts() -> Vec<UserExtensionHost> {
     const PATTERNS: &[(&str, &str)] = &[
-        ("doaj.org", "DOAJ — Directory of Open Access Journals"),
-        ("*.doaj.org", "DOAJ subdomains"),
         ("scielo.org", "SciELO — Latin American / Iberian OA network"),
         ("*.scielo.org", "SciELO national portals"),
         ("*.scielo.br", "SciELO Brazil"),
@@ -1031,7 +1034,7 @@ host = "*.uj.edu.pl"
         );
         for h in &hosts {
             // Every entry must survive the ADR-0028 D2-1 validator. Unlike
-            // the academic set these include bare apexes (`doaj.org`), so
+            // the academic set these include bare apexes (`osf.io`), so
             // the assertion is validity, not wildcard shape.
             validate_pattern(h.host.as_str()).unwrap_or_else(|e| {
                 panic!("invalid OA registry pattern {}: {e:?}", h.host.as_str())
@@ -1044,14 +1047,26 @@ host = "*.uj.edu.pl"
         }
     }
 
-    /// The denial that motivated #405 targeted the bare apex `doaj.org`.
-    /// A single-suffix wildcard does not match an apex, so the apex MUST be
-    /// listed separately or the flag would not fix the reported case.
+    /// ADR-0037 moved DOAJ out of this set and into the DEFAULT
+    /// `oa_publisher_allowlist`, so the flag must NOT carry it — otherwise
+    /// the two places disagree again, in the other direction.
     #[test]
-    fn oa_registry_hosts_cover_the_doaj_apex_that_motivated_405() {
+    fn oa_registry_hosts_exclude_doaj_which_is_now_a_default() {
         let hosts = oa_registry_hosts();
         let patterns: Vec<&str> = hosts.iter().map(|h| h.host.as_str()).collect();
-        for expected in &["doaj.org", "*.doaj.org", "scielo.org", "zenodo.org"] {
+        for gone in &["doaj.org", "*.doaj.org"] {
+            assert!(
+                !patterns.contains(gone),
+                "{gone} belongs to oa_publisher_allowlist since ADR-0037, not to this flag;                  got {patterns:?}"
+            );
+        }
+        for expected in &[
+            "scielo.org",
+            "zenodo.org",
+            "osf.io",
+            "hal.science",
+            "core.ac.uk",
+        ] {
             assert!(
                 patterns.contains(expected),
                 "expected OA registry pattern {expected} not found in {patterns:?}"

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -114,6 +114,7 @@ impl CapabilityProfile {
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
                 openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
                 core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
+                europe_pmc:      env::var("DOIGET_ENABLE_EUROPE_PMC").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -176,6 +177,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
 | `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
+| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). OA subset only: gated on `isOpenAccess`, **not** `inEPMC` — a record can be in the archive while its full text is subscription-only (#415). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -157,6 +157,13 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 
 | Variable | Type | Effect |
 |---|---|---|
+> **The `metadata` Cargo feature vs. these variables (ADR-0040, NORMATIVE).** The
+> feature decides what is *compiled*; the variables below decide what is *reachable*.
+> As of 0.8.8 `metadata` gates the whole optional non-Tier-1 source surface —
+> enrichment, resolution and retrieval — and release binaries compile it in. A source
+> is inert until its own `DOIGET_ENABLE_<NAME>` is set, so with all of them unset the
+> binary behaves exactly as a Tier-1-only build.
+
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -111,6 +111,7 @@ impl CapabilityProfile {
                 semantic_scholar: env::var("DOIGET_ENABLE_S2").is_ok(),
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
+                hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -169,6 +170,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
+| `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -110,6 +110,7 @@ impl CapabilityProfile {
                 openalex:        env::var("DOIGET_ENABLE_OPENALEX").is_ok(),
                 semantic_scholar: env::var("DOIGET_ENABLE_S2").is_ok(),
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
+                datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -167,6 +168,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
+| `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -113,6 +113,7 @@ impl CapabilityProfile {
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
                 openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
+                core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -173,6 +174,8 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
+| `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
+| `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -112,6 +112,7 @@ impl CapabilityProfile {
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
+                openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -171,6 +172,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
+| `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -35,6 +35,16 @@ A value set higher in the chain overrides any value set lower.
 
 ## 3. config.toml schema
 
+> **The file does not exist by default.** A fresh install has no
+> `config.toml` at all, and three of the four settings that most often decide the
+> outcome of a session — store location, the two allowlist flags — fail *silently*
+> when it is absent. Run **`doiget config init`** to write a fully commented
+> template to the path `doiget config path` reports; every line is commented out,
+> so it documents the choices without changing behaviour until you edit it.
+> `--force` overwrites an existing file (without it, `init` refuses, so it can
+> never silently discard a hand-written allowlist).
+
+
 ```toml
 # ~/.config/doiget/config.toml — all fields optional
 
@@ -202,6 +212,8 @@ overridable by flag:
 | `--progress` / `--no-progress` | `output.progress` |
 | `--quiet` / `-q` | implies `--mode=quiet` |
 | `--json` | implies `--mode=json` |
+| `--force` | `config init` only: overwrite an existing `config.toml` |
+| `--network` | `config doctor` only: also run the outbound report (§6.1) |
 
 `doiget serve` always runs in `mcp` mode regardless of flags. Other subcommands honor the
 mode resolution above.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -59,7 +59,7 @@ total_timeout_sec = 300
 # Without them, an OA PDF hosted off the built-in allowlist is denied with
 # `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
 trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
-trust_oa_registries  = false   # true = also allow the curated OA registries (DOAJ, SciELO, ...)
+trust_oa_registries  = false   # true = also allow the curated OA registries (SciELO, Zenodo, ...)
 
 [[network.additional_hosts]]
 host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
@@ -123,20 +123,21 @@ trust_academic_repos = true
 `trust_oa_registries = true` activates the OA-registry set:
 
 ```
-doaj.org      *.doaj.org      scielo.org    *.scielo.org   *.scielo.br
+scielo.org    *.scielo.org    *.scielo.br
 zenodo.org    *.zenodo.org    osf.io        *.osf.io
 hal.science   *.hal.science   core.ac.uk
 ```
 
 Every entry is a registry or repository whose *purpose* is open distribution, never a
 publisher platform — turning this on must not become a way to reach paywalled content.
-Note that both the apex (`doaj.org`) and the wildcard (`*.doaj.org`) appear: a
-single-suffix wildcard does **not** match the apex, and DOAJ redirects to the apex.
+Note that both the apex and the wildcard are listed where the apex serves content: a
+single-suffix wildcard does **not** match the apex.
 
-Without this flag a Gold-OA article routed through DOAJ — e.g. IEEE Access
-`10.1109/access.2024.3495502` — is denied on a stock install, while a Green-OA copy on
-an institutional repository is reachable behind `trust_academic_repos`. For an
-open-access tool that polarity is backwards, which is why the flag exists.
+**DOAJ is not in this set — it needs no flag.** `doaj.org` is on the *default*
+allowlist as of 0.8.8 (ADR-0037), because the project already trusted it under the
+`doaj` metadata source key and the two keys simply disagreed. So a Gold-OA article
+routed through DOAJ — e.g. IEEE Access `10.1109/access.2024.3495502` — works on a
+stock install with no configuration at all.
 
 `[[network.additional_hosts]]` is for anything outside either set. A pattern is either a
 literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
@@ -150,8 +151,8 @@ host = "*.uj.edu.pl"
 note = "Jagiellonian University repository"
 
 [[network.additional_hosts]]
-host = "doaj.org"
-note = "DOAJ — common redirect target for gold-OA journal content"
+host = "repository.example.edu"
+note = "a repository outside both curated sets"
 ```
 
 Run `doiget config doctor` to confirm what was loaded:
@@ -262,7 +263,7 @@ network (--network):
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...
-  probe doaj.org               not allowlisted   no request sent; ...
+  probe doaj.org               200 793 bytes     ok
 ```
 
 The flag is opt-in because it makes real outbound requests: one GET per listed host, no

--- a/docs/DECISIONS/0037-doaj-on-oa-publisher.md
+++ b/docs/DECISIONS/0037-doaj-on-oa-publisher.md
@@ -1,0 +1,81 @@
+# 0037 - `doaj.org` on `oa-publisher` unconditionally; `trust_oa_registries` for the rest
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (amends the `docs/REDIRECT_ALLOWLIST.md` §3.4 NORMATIVE host set, in the manner of [0027](0027-redirect-allowlist-society-hosts.md))
+- **Source:** #405 item 3, #409 (which found the asymmetry), #410
+
+## Context
+
+0.8.7 shipped `[network] trust_oa_registries` (#410), an opt-in flag adding a
+curated set of OA registries — DOAJ, SciELO, Zenodo, OSF, HAL, CORE — to the
+allowlist. It was chosen over widening the default because widening a default
+supply-chain posture deserves an ADR, and there was not one.
+
+#409 then established a fact that changes the DOAJ half of that argument:
+
+```rust
+// crates/doiget-core/src/http.rs, tier_2_allowlist()
+SourceAllowlist::new("doaj", vec!["doaj.org".to_string(), "*.doaj.org".to_string()]),
+```
+
+**`doaj.org` is already trusted in this codebase.** Just under the `"doaj"`
+*metadata* source key, not under `"oa-publisher"` — the key a Unpaywall-discovered
+PDF redirect is actually checked against. And `tier_2_allowlist()` is wired into
+the CLI only under `#[cfg(feature = "citation")]`, so in a stock `cargo install`
+build that trust is not reachable at all.
+
+So the question is not "should doiget extend trust to DOAJ" — the project already
+decided it trusts DOAJ. It is "why do two keys disagree about a host we have
+already accepted".
+
+[ADR-0027](0027-redirect-allowlist-society-hosts.md) answered exactly this shape
+for `*.aps.org`, which was trusted under the feature-gated `tdm-aps` key and was
+promoted to `oa-publisher` — in its words, "making the trust unconditional across
+feature configurations rather than feature-gated".
+
+0027 also drew a line for what it would *not* add: `hdl.handle.net` and
+`ruj.uj.edu.pl`, "open-ended repository / handle surfaces, not a bounded
+society-publisher host". DOAJ falls on the include side of that line — it is a
+bounded, curated index of vetted open-access journals, not an open-ended surface.
+
+The cost of the disagreement is concrete. `10.1109/access.2024.3495502` (IEEE
+Access, **gold OA**) is denied at `doaj.org` on a stock install, while a green-OA
+copy on an institutional repository is reachable behind one documented flag. For
+an OA-first tool that polarity is backwards.
+
+## Decision
+
+**Add `doaj.org` and `*.doaj.org` to `oa_publisher_allowlist()`** (`http.rs` +
+`REDIRECT_ALLOWLIST.md` §3.4 + the site projection), unconditionally, on the
+0027 precedent.
+
+**Keep `trust_oa_registries` for the remaining five** — SciELO, Zenodo, OSF, HAL,
+CORE. None of them appears anywhere in `http.rs` today, so for those the flag is
+genuinely *new* trust, not the repair of an internal disagreement, and opt-in is
+the right default. DOAJ is removed from the flag's curated set: keeping it in both
+places would be harmless but misleading about where the trust comes from.
+
+This is option 3 of the three laid out on #410.
+
+## Consequences
+
+**Positive.**
+
+- The two keys agree. A host the project already trusts for metadata is trusted
+  for the PDF leg it was always going to redirect to.
+- Gold OA is reachable out of the box, matching the tool's stated purpose.
+- Consistent with 0027 rather than a new principle.
+
+**Negative / accepted.**
+
+- The default allowlist grows by one registrable domain plus its subdomains. DOAJ
+  is a non-profit index that serves article links, not arbitrary content; the
+  supply-chain exposure is a redirect target we already accept from the same
+  organisation on another key.
+- `trust_oa_registries`, shipped one release earlier with DOAJ in it, changes
+  meaning slightly. It is one release old, opt-in, off by default, and documented
+  in `CONFIG.md` §3.1; the section is updated in the same change.
+
+**Explicitly still out of scope.** IEEE / ACM / SIAM / AMS — see
+[0039](0039-publisher-hosts-stay-off-allowlist.md).

--- a/docs/DECISIONS/0038-store-root-cwd-reaffirmed.md
+++ b/docs/DECISIONS/0038-store-root-cwd-reaffirmed.md
@@ -1,0 +1,68 @@
+# 0038 - Default store root stays `./papers` (cwd); 0036 reaffirmed against #406
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (reaffirms [0036](0036-default-store-cwd.md) unchanged)
+- **Source:** #406, dogfood 2026-08-22
+
+## Context
+
+[ADR-0036](0036-default-store-cwd.md) made the default store root `./papers`
+under the current working directory, so that fetched artifacts are visible where
+an agent or human is actually working. Its Consequences section already recorded
+the cost:
+
+> A `papers/` directory now appears in whatever directory doiget is first run
+> from. This is intentional (visibility) …
+
+#406 reported that exact symptom from a real session, plus a sharper one: a
+*denied* fetch, run inside an unrelated git worktree, left
+`<worktree>/papers/.metadata/…` behind. The issue proposed defaulting to an XDG
+data directory instead.
+
+Investigating it turned up two things that were **not** ADR-0036 working as
+designed, and one that was:
+
+1. `doiget_health` — annotated `read_only_hint = true` — answered "is the store
+   writable?" by calling `create_dir_all` on it. A *health check* created the
+   tree, in a directory that is indeterminate for a daemon. Fixed in 0.8.7.
+2. Our own test suite leaked `crates/doiget-mcp/papers/` into the repo, and
+   `papers/` was not in `.gitignore`. Fixed in 0.8.7.
+3. The metadata-only record written when the PDF leg is denied. That is
+   [#145](https://github.com/QAtlasHub/doiget/issues/145) working as intended:
+   the metadata *did* resolve, it is useful, and the CLI names its path.
+
+## Decision
+
+**Keep the cwd default. ADR-0036 stands unamended.**
+
+The evidence in #406 is real but it is evidence for (1) and (2), which are now
+fixed without moving the default. What remains — `papers/` appearing where you
+run doiget — is the accepted consequence 0036 wrote down in advance, and it is
+the property that closed the #344 agent-invisibility failure mode.
+
+Reversing it would re-open #344: artifacts landing in `~/.local/share` where
+"neither the agent nor the human sees it". The two dogfooding reports point in
+opposite directions, and 0036's is the one about the tool's primary user.
+
+Users who want a central library set `DOIGET_STORE_ROOT` or `[store] root`; 0.8.7
+makes `doiget config doctor` print the resolved path and say that it is
+cwd-relative, so the default is now self-describing rather than surprising.
+
+## Consequences
+
+**Positive.**
+
+- No breaking change to where 0.8.x writes.
+- The two genuine defects are fixed; the remaining behaviour is documented and
+  discoverable from `config doctor`.
+
+**Negative / accepted.**
+
+- Unchanged from 0036: a user who fetches from many directories accrues several
+  small stores unless they set `DOIGET_STORE_ROOT`.
+- A denied fetch still writes a metadata-only record. Anyone who wants that
+  changed should reopen it against #145's reasoning, not this ADR.
+
+**If this is revisited**, the superseding ADR needs an answer to #344 that does
+not rely on `--link`, since that was already available when #344 was filed.

--- a/docs/DECISIONS/0039-publisher-hosts-stay-off-allowlist.md
+++ b/docs/DECISIONS/0039-publisher-hosts-stay-off-allowlist.md
@@ -1,0 +1,77 @@
+# 0039 - IEEE / ACM / SIAM / AMS stay off `oa-publisher`; TDM credentials are the route
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (settles the question [0027](0027-redirect-allowlist-society-hosts.md) §"Out of scope" deferred)
+- **Source:** #407 (measured from a subscribing university network), #409
+
+## Context
+
+#407 reports that on a machine sitting directly on a subscribing university
+network — egress `157.82.60.8`, RDAP `UTNET`, no tunnel — paywalled fetches still
+fail, and identifies two independent causes:
+
+1. `oa_publisher_allowlist()` has no `*.ieee.org`, `*.acm.org`, `*.siam.org` or
+   `*.ams.org`, so doiget will not attempt the publisher leg for them.
+2. The publisher's bot wall. One diagnostic request from that address, with a
+   desktop browser User-Agent:
+
+   ```
+   $ curl -A "Mozilla/5.0 ... Chrome/120 ..." https://ieeexplore.ieee.org/document/8319344
+   status=202   body=0 bytes
+   ```
+
+   `202 Accepted` with an empty body is a challenge holding response. The
+   subscription is not the binding constraint; **being a scripted client is.**
+
+Cause 1 is not an oversight. [ADR-0027](0027-redirect-allowlist-society-hosts.md)
+scoped `oa-publisher` to physics-society and diamond-OA hosts and explicitly
+deferred open-ended surfaces "so a future ADR can revisit it on its own merits".
+This is that ADR.
+
+The measurement in #407 is what makes it decidable, and it decides it against
+adding them: **adding the hosts would not fix the fetch.** It would move the
+failure from an allowlist denial — which is honest, immediate, and names a
+policy — to a WAF challenge that looks like a successful `202`. That is strictly
+worse diagnostics for zero new capability.
+
+## Decision
+
+**Do not add IEEE, ACM, SIAM or AMS hosts to `oa-publisher`.**
+
+The supported route for programmatic access to those publishers is
+per-publisher **TDM credentials**, the mechanism ADR-0002 already established and
+`docs/CONFIG.md` §6 already documents for `[tdm.elsevier]`, `[tdm.aps]` and
+`[tdm.springer]`. That interface is the one publishers intend programs to use and
+it does not meet the web front end's bot wall at all.
+
+`[tdm.ieee]` is **deferred, not rejected.** Adding it means the four touch points
+an existing TDM source has (`sources/tdm_<vendor>.rs`, a transport allowlist in
+`http.rs`, a Cargo feature per ADR-0002, a `[tdm.<vendor>]` block in CONFIG.md §6)
+plus a ToS link in `SOURCES.md` — and it needs IEEE's actual API contract:
+endpoint, auth header, response shape, and terms. None of that can be written
+from the outside. Tracked as a follow-up.
+
+0.8.7 ships the diagnostic instead: `doiget config doctor --network` reports which
+publishers will talk to this client, classifies a `2xx` with an empty body as a
+bot challenge rather than a success, and lists non-allowlisted hosts as
+`not allowlisted` with no request sent. `docs/CONFIG.md` §6.1 states the honest
+conclusion — IP-based subscription does not imply fetchability, and a proxy fixes
+addressing but never a bot wall.
+
+## Consequences
+
+**Positive.**
+
+- The default allowlist keeps its stated shape: OA routes only. Adding
+  subscription publishers would blur the line that makes doiget deployable inside
+  institutions and eligible for directory listings.
+- The failure a user gets is the accurate one, at the earliest possible point,
+  naming a policy they can act on.
+
+**Negative / accepted.**
+
+- IEEE / ACM / SIAM / AMS literature is not fetchable by doiget today, including
+  from a subscribing network. For a corpus that is entirely IEEE — the case in
+  #407 — doiget can resolve metadata but not full text.
+- That gap closes only when someone signs up for the TDM APIs.

--- a/docs/DECISIONS/0040-source-expansion-feature-gating.md
+++ b/docs/DECISIONS/0040-source-expansion-feature-gating.md
@@ -1,0 +1,81 @@
+# 0040 - Source expansion is gated by the existing `metadata` feature, runtime-gated off
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Supersedes:** - (settles the "open decision" in #413 that blocks its child PRs)
+- **Source:** #413 (epic), #414–#418 (children)
+
+## Context
+
+#413 adds five optional OA sources — DataCite, Europe PMC, OpenAIRE, CORE, HAL —
+under a constraint it states plainly:
+
+> **With every flag unset, observable behaviour must be byte-identical to today.**
+
+and asks which Cargo feature should gate them, because `metadata` currently means
+*Tier 2 metadata enrichment*, while the new set includes **retrieval** sources and
+DataCite is a **resolution** source closer in role to Crossref. Three options were
+put:
+
+- **(a)** reuse `metadata` — zero release-workflow change, least honest naming
+- **(b)** a sibling feature, e.g. `oa-extra` — clearer, but the release build flags
+  and the CI feature matrix both grow
+- **(c)** DataCite as Tier 1 (always on) and the retrieval sources behind (b)
+
+## Decision
+
+**(a) — gate all five behind the existing `metadata` feature, each additionally
+runtime-gated by its own `DOIGET_ENABLE_<NAME>`, all off by default.**
+
+And redefine what `metadata` means, in `SOURCES.md` and `CAPABILITY.md`: *the
+optional non-Tier-1 source surface — enrichment, resolution and retrieval —
+compiled into release binaries and inert until a runtime flag turns a source on.*
+The naming objection in (a) is answered by fixing the definition rather than by
+adding a flag that carries the same code.
+
+Three reasons.
+
+**The Cargo feature is not the security boundary; the runtime flag is.** Both
+`metadata` and a hypothetical `oa-extra` ship in the release binary — `citation`
+already pulls `metadata` in, and release builds are
+`--no-default-features --features oa-only,citation`. What keeps a source inert is
+`CapabilityProfile::from_env` reading `DOIGET_ENABLE_<NAME>`, and that is
+unchanged either way. Choosing (b) would move code between two compiled-in
+buckets and change nothing observable.
+
+**(c) breaks the epic's own load-bearing constraint.** Making DataCite Tier 1
+means a DataCite-registered DOI that returns `NotFound` today would resolve — a
+behaviour change for every user with no opt-in, in direct conflict with
+"byte-identical to today". The motivation is real (a false `NotFound` in
+`doiget-citation-check`, the most visible downstream consumer), but the fix
+belongs there: that tool sets `DOIGET_ENABLE_DATACITE`. One line, in the place
+that wants the behaviour.
+
+**(b)'s cost lands where it cannot be verified before it bites.** The feature
+string appears in 13 places across the workflows; two of them —
+`release-plz.yml` and `release-sign.yml` — run **only on a tag push**, so a
+mistake there is invisible to every PR and surfaces as a broken release. Adding
+release-workflow surface is not worth a rename when the runtime gate already does
+the enforcing.
+
+## Consequences
+
+**Positive.**
+
+- Zero release-workflow change; the five child PRs are pure additive code + docs.
+- Default behaviour is byte-identical, enforced by a default-off regression test
+  per source (#413's checklist).
+- The tier vocabulary in `SOURCES.md` / `CAPABILITY.md` — which is the
+  user-facing one — keeps doing the explaining, instead of a Cargo feature name
+  that users never type.
+
+**Negative / accepted.**
+
+- `metadata` becomes a broader bucket than its name suggests, mitigated by an
+  explicit definition in both NORMATIVE docs rather than left implicit.
+- DataCite resolution stays opt-in, so the `doiget-citation-check` false positive
+  persists until that repo sets the flag.
+
+**Revisit** if the optional surface grows past this epic, or if a source ever
+needs to be excluded from release binaries — at which point the split is
+motivated by something other than naming, and (b) becomes the right answer.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -53,6 +53,10 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0034 | arXiv source bundle + individual figure download | Accepted (0.8.0, #352) | `feat/343-source-bundle-figures` | #343 / dogfood 2026-06-24 |
 | 0035 | `fetch --link`: surface fetched artifacts into the working tree | Accepted (0.8.0, #352) | `feat/344-fetch-link` | #344 / dogfood 2026-06-24 |
 | 0036 | Default store root → `./papers` (cwd); amends 0004 co-location | Accepted (0.8.0, #352) | `feat/344-default-store-cwd` | #344 problem 1 / dogfood 2026-06-24 |
+| 0037 | `doaj.org` promoted to the default `oa-publisher` allowlist; `trust_oa_registries` keeps the rest | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #405 item 3 / #409 |
+| 0038 | Store root stays cwd-relative; 0036 reaffirmed against new evidence | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #406 |
+| 0039 | IEEE / ACM / SIAM / AMS stay off `oa-publisher`; TDM credentials are the route | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #407 |
+| 0040 | Source expansion gated by the existing `metadata` feature, runtime-gated off | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #413 |
 
 ## Conventions
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -47,6 +47,9 @@ its use of these APIs polite.
   `DOIGET_ENABLE_<NAME>`, so compiling the feature in contacts nobody by itself.
   DataCite is queried by exact DOI only — never used as a search surface — and
   needs no key or account.
+- `--features metadata`: **HAL** (<https://api.archives-ouvertes.fr>, the French
+  national OA repository). Same shape: inert until `DOIGET_ENABLE_HAL` is set,
+  queried by exact DOI through the `doiId_s` field only, no key or account.
 - `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
   text-and-data-mining APIs, used **only with your own API key and explicit
   agreement**. doiget bundles no keys and shares none.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -50,6 +50,9 @@ its use of these APIs polite.
 - `--features metadata`: **HAL** (<https://api.archives-ouvertes.fr>, the French
   national OA repository). Same shape: inert until `DOIGET_ENABLE_HAL` is set,
   queried by exact DOI through the `doiId_s` field only, no key or account.
+- `--features metadata`: **OpenAIRE** (<https://api.openaire.eu>, European repository
+  aggregation). Inert until `DOIGET_ENABLE_OPENAIRE` is set; queried by exact DOI
+  through the Graph API v1 `pid` parameter only. No key or account.
 - `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
   text-and-data-mining APIs, used **only with your own API key and explicit
   agreement**. doiget bundles no keys and shares none.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -53,6 +53,10 @@ its use of these APIs polite.
 - `--features metadata`: **OpenAIRE** (<https://api.openaire.eu>, European repository
   aggregation). Inert until `DOIGET_ENABLE_OPENAIRE` is set; queried by exact DOI
   through the Graph API v1 `pid` parameter only. No key or account.
+- `--features metadata`: **CORE** (<https://api.core.ac.uk>, cross-repository OA
+  aggregation). Inert until `DOIGET_ENABLE_CORE` is set. Works with no account; if
+  you supply your own free key in `DOIGET_CORE_API_KEY` it is sent as a bearer
+  header to CORE and to nowhere else, and is never written to the provenance log.
 - `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
   text-and-data-mining APIs, used **only with your own API key and explicit
   agreement**. doiget bundles no keys and shares none.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -41,7 +41,12 @@ its use of these APIs polite.
 
 **Opt-in only — compile-time feature flag + your own configuration:**
 
-- `--features metadata`: **Semantic Scholar**, **DOAJ** (extra metadata).
+- `--features metadata`: **Semantic Scholar**, **DOAJ** (extra metadata) and
+  **DataCite** (<https://api.datacite.org>, DOI resolution for Zenodo / figshare /
+  Dryad / OSF). Each is additionally inert until you set its own
+  `DOIGET_ENABLE_<NAME>`, so compiling the feature in contacts nobody by itself.
+  DataCite is queried by exact DOI only — never used as a search surface — and
+  needs no key or account.
 - `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
   text-and-data-mining APIs, used **only with your own API key and explicit
   agreement**. doiget bundles no keys and shares none.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -57,6 +57,9 @@ its use of these APIs polite.
   aggregation). Inert until `DOIGET_ENABLE_CORE` is set. Works with no account; if
   you supply your own free key in `DOIGET_CORE_API_KEY` it is sent as a bearer
   header to CORE and to nowhere else, and is never written to the provenance log.
+- `--features metadata`: **Europe PMC** (<https://www.ebi.ac.uk>, biomedical OA full
+  text). Inert until `DOIGET_ENABLE_EUROPE_PMC` is set; queried by exact DOI only.
+  No key or account.
 - `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
   text-and-data-mining APIs, used **only with your own API key and explicit
   agreement**. doiget bundles no keys and shares none.

--- a/docs/REDIRECT_ALLOWLIST.md
+++ b/docs/REDIRECT_ALLOWLIST.md
@@ -137,7 +137,7 @@ Notes:
 | Field | Value |
 |---|---|
 | `source` | `oa-publisher` (synthetic — see notes) |
-| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `arxiv.org`, `*.arxiv.org` |
+| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `doaj.org`, `*.doaj.org`, `arxiv.org`, `*.arxiv.org` |
 
 Notes:
 
@@ -152,6 +152,15 @@ Notes:
   `HttpClient::fetch_pdf("oa-publisher", url)`.
 - **Documented OA hosts.** Each entry below is the documented OA host for the
   named publisher / repository. Changes follow the §5 update process.
+- **DOAJ (ADR-0037).** `doaj.org` + `*.doaj.org` were promoted here from the
+  `doaj` **metadata** source key (`tier_2_allowlist`), which the CLI wires in
+  only under `#[cfg(feature = "citation")]`. The two keys disagreed about a
+  host the project had already accepted, and a stock build could not reach it
+  at all — so a gold-OA article redirected through DOAJ was denied while a
+  green-OA copy on an institutional repository was reachable behind one flag.
+  Promoted on the ADR-0027 precedent that made `*.aps.org` unconditional
+  rather than feature-gated. Empirically observed via
+  `10.1109/access.2024.3495502` (IEEE Access, gold OA; #405).
 - **Empirical verification (ADR-0027).** The physics-society / diamond-OA
   hosts (`*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`) were
   added from a real `doiget batch` over 30 OpenAlex-OA

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -20,6 +20,7 @@
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
+| OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -19,6 +19,7 @@
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
+| HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -37,12 +37,25 @@ behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. Tier 2 metadata sources require
-an opt-in build:
+`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+requires an opt-in build:
 
 ```sh
 cargo install doiget --features metadata
 ```
+
+**What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
+it now carries. As of 0.8.8 it gates **the optional non-Tier-1 source surface as a
+whole** — enrichment, resolution *and* retrieval — not enrichment alone. Compiling it
+in makes that code present; it does **not** turn any source on. Every source under it
+is additionally gated at runtime by its own `DOIGET_ENABLE_<NAME>`, and with every such
+variable unset the observable behaviour of the binary is identical to a Tier-1-only
+build. The runtime flag is the boundary that matters; the Cargo feature only decides
+what is compiled.
+
+Published release binaries build `--no-default-features --features oa-only,citation`,
+and `citation = ["metadata"]`, so this code ships — inert — in the binaries you
+download.
 
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -21,6 +21,7 @@
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
+| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -18,6 +18,7 @@
 | OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -22,6 +22,7 @@
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
 | CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
+| Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "doiget",
   "display_name": "doiget",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "OA-first paper fetcher: DOIs/arXiv IDs to local PDFs + metadata via Open Access APIs.",
   "long_description": "doiget is a single-binary, stdio MCP server that turns DOIs and arXiv IDs into local PDFs and structured metadata through official Open-Access APIs (Crossref, Unpaywall, arXiv, OpenAlex). It never bypasses paywalls and makes no network call that is not the direct result of a fetch you ask for. PDFs and metadata are saved to a local store; nothing is redistributed or phoned home. It is the agent-facing companion to BiblioFetch.jl and shares the same on-disk paper store.",
   "author": {

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -117,6 +117,7 @@ impl CapabilityProfile {
                 semantic_scholar: env::var("DOIGET_ENABLE_S2").is_ok(),
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
+                hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -175,6 +176,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
+| `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -118,6 +118,7 @@ impl CapabilityProfile {
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
+                openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -177,6 +178,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
+| `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -116,6 +116,7 @@ impl CapabilityProfile {
                 openalex:        env::var("DOIGET_ENABLE_OPENALEX").is_ok(),
                 semantic_scholar: env::var("DOIGET_ENABLE_S2").is_ok(),
                 doaj:            env::var("DOIGET_ENABLE_DOAJ").is_ok(),
+                datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -173,6 +174,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |
+| `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -119,6 +119,7 @@ impl CapabilityProfile {
                 datacite:        env::var("DOIGET_ENABLE_DATACITE").is_ok(),
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
                 openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
+                core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -179,6 +180,8 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_DATACITE` | presence | Enables DataCite DOI **resolution** (Zenodo / figshare / Dryad / OSF). Unlike its siblings this is not enrichment: without it those DOIs report `NOT_FOUND` even when the record is live and open (#414). |
 | `DOIGET_ENABLE_HAL` | presence | Enables HAL, the French national OA repository. OA deposits only: a record whose `openAccess_bool` is not `true` is rejected rather than returned (#418). |
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
+| `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
+| `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -163,6 +163,13 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 
 | Variable | Type | Effect |
 |---|---|---|
+> **The `metadata` Cargo feature vs. these variables (ADR-0040, NORMATIVE).** The
+> feature decides what is *compiled*; the variables below decide what is *reachable*.
+> As of 0.8.8 `metadata` gates the whole optional non-Tier-1 source surface —
+> enrichment, resolution and retrieval — and release binaries compile it in. A source
+> is inert until its own `DOIGET_ENABLE_<NAME>` is set, so with all of them unset the
+> binary behaves exactly as a Tier-1-only build.
+
 | `DOIGET_ENABLE_OPENALEX` | presence | Enables OpenAlex (metadata only). |
 | `DOIGET_ENABLE_S2` | presence | Enables Semantic Scholar. |
 | `DOIGET_ENABLE_DOAJ` | presence | Enables DOAJ. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -120,6 +120,7 @@ impl CapabilityProfile {
                 hal:             env::var("DOIGET_ENABLE_HAL").is_ok(),
                 openaire:        env::var("DOIGET_ENABLE_OPENAIRE").is_ok(),
                 core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
+                europe_pmc:      env::var("DOIGET_ENABLE_EUROPE_PMC").is_ok(),
             },
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
@@ -182,6 +183,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
 | `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
+| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). OA subset only: gated on `isOpenAccess`, **not** `inEPMC` — a record can be in the archive while its full text is subscription-only (#415). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -41,6 +41,16 @@ A value set higher in the chain overrides any value set lower.
 
 ## 3. config.toml schema
 
+> **The file does not exist by default.** A fresh install has no
+> `config.toml` at all, and three of the four settings that most often decide the
+> outcome of a session — store location, the two allowlist flags — fail *silently*
+> when it is absent. Run **`doiget config init`** to write a fully commented
+> template to the path `doiget config path` reports; every line is commented out,
+> so it documents the choices without changing behaviour until you edit it.
+> `--force` overwrites an existing file (without it, `init` refuses, so it can
+> never silently discard a hand-written allowlist).
+
+
 ```toml
 # ~/.config/doiget/config.toml — all fields optional
 
@@ -208,6 +218,8 @@ overridable by flag:
 | `--progress` / `--no-progress` | `output.progress` |
 | `--quiet` / `-q` | implies `--mode=quiet` |
 | `--json` | implies `--mode=json` |
+| `--force` | `config init` only: overwrite an existing `config.toml` |
+| `--network` | `config doctor` only: also run the outbound report (§6.1) |
 
 `doiget serve` always runs in `mcp` mode regardless of flags. Other subcommands honor the
 mode resolution above.

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -65,7 +65,7 @@ total_timeout_sec = 300
 # Without them, an OA PDF hosted off the built-in allowlist is denied with
 # `error[CAPABILITY_DENIED]: ... redirect_not_in_allowlist`.
 trust_academic_repos = false   # true = also allow the 15 curated academic suffixes below
-trust_oa_registries  = false   # true = also allow the curated OA registries (DOAJ, SciELO, ...)
+trust_oa_registries  = false   # true = also allow the curated OA registries (SciELO, Zenodo, ...)
 
 [[network.additional_hosts]]
 host = "*.uj.edu.pl"           # single-suffix wildcard, or a literal FQDN
@@ -129,20 +129,21 @@ trust_academic_repos = true
 `trust_oa_registries = true` activates the OA-registry set:
 
 ```
-doaj.org      *.doaj.org      scielo.org    *.scielo.org   *.scielo.br
+scielo.org    *.scielo.org    *.scielo.br
 zenodo.org    *.zenodo.org    osf.io        *.osf.io
 hal.science   *.hal.science   core.ac.uk
 ```
 
 Every entry is a registry or repository whose *purpose* is open distribution, never a
 publisher platform — turning this on must not become a way to reach paywalled content.
-Note that both the apex (`doaj.org`) and the wildcard (`*.doaj.org`) appear: a
-single-suffix wildcard does **not** match the apex, and DOAJ redirects to the apex.
+Note that both the apex and the wildcard are listed where the apex serves content: a
+single-suffix wildcard does **not** match the apex.
 
-Without this flag a Gold-OA article routed through DOAJ — e.g. IEEE Access
-`10.1109/access.2024.3495502` — is denied on a stock install, while a Green-OA copy on
-an institutional repository is reachable behind `trust_academic_repos`. For an
-open-access tool that polarity is backwards, which is why the flag exists.
+**DOAJ is not in this set — it needs no flag.** `doaj.org` is on the *default*
+allowlist as of 0.8.8 (ADR-0037), because the project already trusted it under the
+`doaj` metadata source key and the two keys simply disagreed. So a Gold-OA article
+routed through DOAJ — e.g. IEEE Access `10.1109/access.2024.3495502` — works on a
+stock install with no configuration at all.
 
 `[[network.additional_hosts]]` is for anything outside either set. A pattern is either a
 literal FQDN (`ruj.uj.edu.pl`) or a **single-suffix wildcard** (`*.uj.edu.pl`). Multi-segment
@@ -156,8 +157,8 @@ host = "*.uj.edu.pl"
 note = "Jagiellonian University repository"
 
 [[network.additional_hosts]]
-host = "doaj.org"
-note = "DOAJ — common redirect target for gold-OA journal content"
+host = "repository.example.edu"
+note = "a repository outside both curated sets"
 ```
 
 Run `doiget config doctor` to confirm what was loaded:
@@ -268,7 +269,7 @@ network (--network):
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...
-  probe doaj.org               not allowlisted   no request sent; ...
+  probe doaj.org               200 793 bytes     ok
 ```
 
 The flag is opt-in because it makes real outbound requests: one GET per listed host, no

--- a/site/content/developer/redirect-allowlist.md
+++ b/site/content/developer/redirect-allowlist.md
@@ -143,7 +143,7 @@ Notes:
 | Field | Value |
 |---|---|
 | `source` | `oa-publisher` (synthetic — see notes) |
-| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `arxiv.org`, `*.arxiv.org` |
+| `redirect_hosts` | `*.springer.com`, `*.springeropen.com`, `*.springernature.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.frontiersin.org`, `*.mdpi.com`, `*.plos.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.europepmc.org`, `*.nih.gov`, `*.ncbi.nlm.nih.gov`, `*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`, `doaj.org`, `*.doaj.org`, `arxiv.org`, `*.arxiv.org` |
 
 Notes:
 
@@ -158,6 +158,15 @@ Notes:
   `HttpClient::fetch_pdf("oa-publisher", url)`.
 - **Documented OA hosts.** Each entry below is the documented OA host for the
   named publisher / repository. Changes follow the §5 update process.
+- **DOAJ (ADR-0037).** `doaj.org` + `*.doaj.org` were promoted here from the
+  `doaj` **metadata** source key (`tier_2_allowlist`), which the CLI wires in
+  only under `#[cfg(feature = "citation")]`. The two keys disagreed about a
+  host the project had already accepted, and a stock build could not reach it
+  at all — so a gold-OA article redirected through DOAJ was denied while a
+  green-OA copy on an institutional repository was reachable behind one flag.
+  Promoted on the ADR-0027 precedent that made `*.aps.org` unconditional
+  rather than feature-gated. Empirically observed via
+  `10.1109/access.2024.3495502` (IEEE Access, gold OA; #405).
 - **Empirical verification (ADR-0027).** The physics-society / diamond-OA
   hosts (`*.aps.org`, `scipost.org`, `*.scipost.org`, `*.iop.org`) were
   added from a real `doiget batch` over 30 OpenAlex-OA

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -26,6 +26,7 @@ weight = 200
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
+| OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -25,6 +25,7 @@ weight = 200
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
+| HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -24,6 +24,7 @@ weight = 200
 | OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
 | DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -28,6 +28,7 @@ weight = 200
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
 | CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
+| Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -27,6 +27,7 @@ weight = 200
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
+| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -43,12 +43,25 @@ behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. Tier 2 metadata sources require
-an opt-in build:
+`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+requires an opt-in build:
 
 ```sh
 cargo install doiget --features metadata
 ```
+
+**What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
+it now carries. As of 0.8.8 it gates **the optional non-Tier-1 source surface as a
+whole** — enrichment, resolution *and* retrieval — not enrichment alone. Compiling it
+in makes that code present; it does **not** turn any source on. Every source under it
+is additionally gated at runtime by its own `DOIGET_ENABLE_<NAME>`, and with every such
+variable unset the observable behaviour of the binary is identical to a Tier-1-only
+build. The runtime flag is the boundary that matters; the Cargo feature only decides
+what is compiled.
+
+Published release binaries build `--no-default-features --features oa-only,citation`,
+and `citation = ["metadata"]`, so this code ships — inert — in the binaries you
+download.
 
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 


### PR DESCRIPTION
Promotion of `next` → `main` for **0.8.8**. Beta stripped in #436; `version-bump` confirms
`0.8.7 → 0.8.8` is a valid +1 patch step. 19 commits, 36 files.

**You asked to review the whole batch at this point — this is that PR.**

Closes #407
Closes #409
Closes #413

(The other eight — #405, #406, #408, #414–#418 — carry `Closes` in their own commits.)

---

## The headline: the #413 source-expansion epic, complete

Five opt-in OA sources, one PR each, all merged:

| source | what it adds | notable |
|---|---|---|
| **DataCite** (#414) | resolution for Zenodo / figshare / Dryad / OSF DOIs | the only one fixing a **live false positive** in `doiget-citation-check` |
| **Europe PMC** (#415) | biomedical OA full text Unpaywall misses | gated on `isOpenAccess`, **not** `inEPMC` |
| **OpenAIRE** (#416) | European repository aggregation | mixed access rights — only COAR `c_abf2` accepted |
| **CORE** (#417) | broadest cross-repository OA index | first optional source with a credential path |
| **HAL** (#418) | French national repository | OA deposits only |

**The default binary is byte-identical to 0.8.7.** Every source is compiled in behind
`metadata` and inert until its own `DOIGET_ENABLE_<NAME>` is set — the constraint #413
imposed. Each has a regression test asserting **zero requests** with its flag unset, and
`every_tier_2_source_has_a_transport_allowlist_entry` covers all eight Tier-2 sources.

## A bug I shipped and then caught

**DataCite went into beta.4 with no transport allowlist entry** — `fetch_bytes("datacite", …)`
would have returned `UnknownSource` on the first real fetch. All 8 of its unit tests passed,
because they build their client with `new_for_tests_allow_http("datacite", …)`, **which
registers the key itself**. The tests were structurally incapable of seeing it.

Fixed in beta.5 along with a registry-completeness guard, **mutation-verified**: deleting an
entry makes the guard fail with exactly the right diagnosis. Never released — beta.4 only
ever existed on `next`.

## Four decisions you delegated

Reasoning *and rejected alternatives* are in the ADRs, so you can argue with the substance.

- **0037** — DOAJ promoted to the default allowlist. Reframed by #409: not "should we trust
  DOAJ" but "why do two keys disagree about a host we already trust". ADR-0027 precedent.
- **0038** — store root stays cwd-relative; #406's evidence was two defects, both fixed in 0.8.7.
- **0039** — IEEE/ACM/SIAM/AMS stay off. Your own 202+empty measurement decides it *against*:
  adding them converts an honest denial into a fake success. `[tdm.ieee]` → #430.
- **0040** — sources ride the existing `metadata` feature. Deciding factor: `release-plz.yml`
  and `release-sign.yml` run only on a tag push, so a new-feature rename spends surface
  **no PR can verify**.

## Also in here

- **`doiget config init`** (#408) — writes a fully commented `config.toml`. Every line
  commented out, so it documents without changing behaviour; refuses to overwrite without
  `--force`, because the file may hold a hand-written allowlist.
- **`.cargo/audit.toml`** — `main` had been red on `cargo audit` since **2026-08-10** on zero
  vulnerabilities. `cargo deny` and `cargo audit` do not share config, and
  `rustsec/audit-check` only treats warnings as fatal on `push`, so every PR was green.

## Two deliberate deviations from the issues

**#415 did not get a new `ErrorCode`** for proxy-blocked downloads. The PDF URL is surfaced
and the fetch runs through the existing `oa-publisher` leg, where a block already produces
an ADR-0023 `denial_context` naming the host and allowlist — strictly more information than
a bare code, without widening the `ERRORS.md` §3 closed set. Additive if you disagree.

**#417's key handling** treats a *blank* `DOIGET_CORE_API_KEY=` as absent, not empty —
sending an empty bearer earns a 401 that looks like a *bad* key rather than no key.

## Verification

Every PR ran `fmt --check`, clippy on both feature sets, `rustdoc -D warnings`, and
`cargo test --workspace` locally before push, then green CI before merge.
`release-version-gate.sh v0.8.8` passes G0–G6 (G3/G4 confirmed against crates.io).

## Still open after this

- **#426** — `backmerge.yml`'s PAT, excluded per your instruction. Note this bites every
  promotion: `main` is `strict: true`, so without the back-merge the *next* promotion is
  blocked. I did it by hand last time.
- **#430** — `[tdm.ieee]`, blocked on IEEE's actual API contract.