### PR TITLE
ci: compile and test the Tier-3 TDM surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
         features:
           - "oa-only"
           - "oa-only,citation"
+          # Tier 3 (ADR-0002). Opt-in builds only, so nothing here ever
+          # reaches a published binary — but until this entry existed the
+          # three `tdm-*` modules were compiled by NO job at all, and could
+          # have rotted silently. The union matches the documented install
+          # shape (`SOURCES.md` §3); the singleton proves `tdm-*` does not
+          # secretly depend on `metadata`.
+          - "oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer"
+          - "oa-only,tdm-aps"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -92,6 +100,23 @@ jobs:
       # citation_graph e2e test unvalidated.
       - run: cargo test --workspace --all-targets --no-default-features --features oa-only,citation
 
+  test-tdm:
+    name: test (tdm features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          cache-bin: false
+      # The Tier-3 tests (~1100 lines of wiremock coverage across
+      # tdm_springer / tdm_aps / tdm_elsevier) ran in NO CI job before this.
+      # They are the only thing standing between a credential-handling
+      # source and a silent regression, so they have to actually run.
+      - run: cargo test --workspace --all-targets --no-default-features --features oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer
+
   msrv:
     # MSRV is pinned in rust-toolchain.toml / Cargo.toml; the job name
     # deliberately omits the version literal so the label cannot drift.
@@ -122,3 +147,7 @@ jobs:
       # without CI noticing. Release binaries ship `oa-only,citation`, so the
       # docs for that surface have to build too.
       - run: cargo doc --workspace --no-deps --no-default-features --features oa-only,citation
+      # Same reasoning for Tier 3: these modules carry the longest
+      # doc-comments in the tree (three-gate activation, credential
+      # hygiene) and none of it was ever rendered.
+      - run: cargo doc --workspace --no-deps --no-default-features --features oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.8"
+version = "0.8.9-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.8"
+version = "0.8.9-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.8"
+version = "0.8.9-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.8"
+version       = "0.8.9-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
## What

Adds the three `tdm-*` Cargo features to clippy, test and rustdoc in `ci.yml`.

## Why

While scoping #430 (add a fourth TDM source, IEEE) I checked what CI does with the three that already exist. The answer is nothing:

| job | feature sets built |
|---|---|
| clippy | `oa-only`, `oa-only,citation` |
| test | `oa-only` |
| test (citation feature) | `oa-only,citation` |
| msrv | `oa-only` |
| rustdoc | `oa-only`, `oa-only,citation` |

`--all-features` appears in no workflow. `tdm_springer`, `tdm_aps` and `tdm_elsevier` — ~1100 lines including the #146 credential-redaction regression and the three-gate eligibility checks — were compiled by **no job at all**.

They are clean today. Verified locally on this branch:

```
clippy --features oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer -- -D warnings   green
test   --lib  same features                                    501 passed; 0 failed
```

That is luck. Nothing would have gone red if it were otherwise, and adding IEEE on top of an unchecked subsystem would compound the problem.

## Notes for review

**`test-tdm` is a separate job on purpose.** Adding a matrix axis to `test` would rename the checks to `test (ubuntu-latest, <features>)`, and `test (ubuntu-latest)` / `test (windows-latest)` are the only two required checks on `next` and `main`. Renaming them would block every PR on both lanes. `test-citation` set this precedent.

**Two clippy entries, not one.** The union matches the documented install shape (`SOURCES.md` §3). The `oa-only,tdm-aps` singleton exists because ADR-0002 declares the `tdm-*` features independent opt-ins — a union-only build would hide a `tdm-*` module that had come to depend on `metadata`.

Refs #430.