### PR TITLE
fix(config): honour [store] root in config.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.2"
+version = "0.8.9-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.2"
+version = "0.8.9-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.2"
+version = "0.8.9-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.2"
+version       = "0.8.9-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -34,6 +34,13 @@ use super::fetch::CliExit;
 pub struct ResolvedConfig {
     /// Root of the on-disk paper store. Default: `./papers` (under the cwd).
     pub store_root: Utf8PathBuf,
+    /// Which rung of the ADR-0036 order produced `store_root` (#441).
+    ///
+    /// Reported because the failure it guards against is invisible
+    /// otherwise: a `[store] root` that is present but unread resolves to
+    /// the cwd default, and the two coincide whenever the user happens to
+    /// run from the directory they configured.
+    pub store_root_source: String,
     /// Directory holding doiget's append-only logs. Derived from
     /// `log_path`'s parent so it always agrees with the writer.
     pub log_dir: Utf8PathBuf,
@@ -83,7 +90,7 @@ impl ResolvedConfig {
         // (`super::resolve_store_root`) so `config show` / `doctor` never drifts
         // from the writer — `DOIGET_STORE_ROOT` else `./papers` under the cwd
         // (#344 / ADR-0036).
-        let store_root = super::resolve_store_root()?;
+        let (store_root, store_root_source) = super::resolve_store_root_with_source()?;
 
         // Issue #142: resolve the log path the SAME way the writer does
         // (`commands::fetch::resolve_log_path` / `commands::audit_log`):
@@ -108,6 +115,7 @@ impl ResolvedConfig {
 
         Ok(Self {
             store_root,
+            store_root_source: store_root_source.label().to_string(),
             log_dir,
             log_path,
             config_dir,
@@ -194,7 +202,14 @@ pub async fn run(
                 None,
                 &mut all_ok,
             );
-            if std::env::var_os("DOIGET_STORE_ROOT").is_none() {
+            // #441: naming the rung is the whole point. A `[store] root`
+            // that is set but unread lands on the cwd default, and the two
+            // coincide whenever the user runs from the directory they
+            // configured — so "store_root: /home/me/papers" alone cannot
+            // distinguish "your setting worked" from "your setting was
+            // ignored and you happen to be standing in it".
+            eprintln!("       from: {}", cfg.store_root_source);
+            if cfg.store_root_source == super::StoreRootSource::CwdDefault.label() {
                 eprintln!(
                     "       note: relative to the current directory (ADR-0036). Set DOIGET_STORE_ROOT"
                 );
@@ -369,6 +384,10 @@ pub(crate) fn config_template() -> &'static str {
 # work is, instead of somewhere you have to go looking for. The cost is that
 # fetching from many directories leaves several small stores. Set this for a
 # single central library.
+#
+# Overridden by DOIGET_STORE_ROOT and by --store-root, which share a rung
+# above this one. A leading `~` IS expanded here (a config file has no
+# shell, unlike the env var).
 # root = "/home/you/papers"
 
 [network]
@@ -1087,6 +1106,93 @@ mod tests {
         assert_eq!(
             cli_exit.0, 2,
             "unknown config action is misuse → exit 2, not the generic exit 1"
+        );
+    }
+    /// Build an isolated config dir containing `config.toml` with `body`.
+    fn config_home_with(body: &str) -> (tempfile::TempDir, camino::Utf8PathBuf) {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let root = camino::Utf8PathBuf::try_from(td.path().to_path_buf()).expect("utf-8 tempdir");
+        std::fs::create_dir_all(root.join("doiget").as_std_path()).expect("mkdir");
+        std::fs::write(root.join("doiget").join("config.toml").as_std_path(), body)
+            .expect("write config");
+        (td, root)
+    }
+
+    /// #441: the rung that was missing. `[store] root` must beat the cwd
+    /// default.
+    ///
+    /// The assertion that matters is the NEGATIVE one. `store_root ==
+    /// <configured>` alone would also pass if the config were ignored and
+    /// the test happened to run from the configured directory — which is
+    /// exactly how the bug hid: a user testing from `$HOME` with
+    /// `root = "$HOME/papers"` sees the right answer for the wrong reason.
+    #[test]
+    #[serial_test::serial]
+    fn store_root_in_config_beats_the_cwd_default() {
+        let _g = unset_all_doiget_config_env();
+        let lib_td = tempfile::TempDir::new().expect("tempdir");
+        let library = camino::Utf8PathBuf::try_from(lib_td.path().to_path_buf())
+            .expect("utf-8 tempdir")
+            .as_str()
+            .replace('\u{5c}', "/");
+        let (_cfg_td, cfg_root) = config_home_with(&format!("[store]\nroot = \"{library}\"\n"));
+
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+
+        let cwd_default = camino::Utf8PathBuf::try_from(std::env::current_dir().expect("cwd"))
+            .expect("utf-8 cwd")
+            .join("papers");
+        assert_ne!(
+            cfg.store_root, cwd_default,
+            "the config value was ignored and the cwd default answered instead"
+        );
+        assert_eq!(
+            cfg.store_root.as_str().replace('\u{5c}', "/"),
+            library,
+            "[store] root must win over the cwd default (ADR-0036 rung 2)"
+        );
+        assert_eq!(
+            cfg.store_root_source,
+            super::super::StoreRootSource::ConfigFile.label(),
+            "doctor must attribute it to the config file"
+        );
+    }
+
+    /// The rung ABOVE it still wins. Adding rung 2 must not demote the env
+    /// var, which is also how `--store-root` is applied.
+    #[test]
+    #[serial_test::serial]
+    fn env_beats_store_root_in_config() {
+        let _g = unset_all_doiget_config_env();
+        let (_cfg_td, cfg_root) = config_home_with("[store]\nroot = \"/from/config\"\n");
+
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+        let _e = EnvGuard::set("DOIGET_STORE_ROOT", "/from/env");
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+
+        assert_eq!(cfg.store_root.as_str(), "/from/env");
+        assert_eq!(
+            cfg.store_root_source,
+            super::super::StoreRootSource::Env.label()
+        );
+    }
+
+    /// A blank value means "unset", not "the empty path" — otherwise it
+    /// would resolve to the filesystem root.
+    #[test]
+    #[serial_test::serial]
+    fn blank_store_root_in_config_falls_through_to_the_default() {
+        let _g = unset_all_doiget_config_env();
+        let (_cfg_td, cfg_root) = config_home_with("[store]\nroot = \"   \"\n");
+
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+
+        assert_eq!(
+            cfg.store_root_source,
+            super::super::StoreRootSource::CwdDefault.label(),
+            "a blank root must not be treated as a configured value"
         );
     }
 }

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -77,37 +77,87 @@ pub(crate) fn user_config_path() -> Option<Utf8PathBuf> {
     )
 }
 
+/// Where a resolved store root came from (#441).
+///
+/// Reported by `doiget config doctor` so that a setting which did nothing
+/// can no longer look like a setting that worked. That was the sharpest
+/// part of #441: `config init` recommended `[store] root`, `doctor`
+/// confirmed the recommendation, and the value was never read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StoreRootSource {
+    /// `DOIGET_STORE_ROOT` (also how `--store-root` is applied).
+    Env,
+    /// `[store] root` in the user's `config.toml`.
+    ConfigFile,
+    /// Nothing set it — `./papers` under the cwd (ADR-0036).
+    CwdDefault,
+}
+
+impl StoreRootSource {
+    /// Short label for `config show` / `doctor`.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Env => "DOIGET_STORE_ROOT",
+            Self::ConfigFile => "[store] root in config.toml",
+            Self::CwdDefault => "default: ./papers under the cwd",
+        }
+    }
+}
+
 /// Resolve the on-disk store root.
 ///
-/// Resolution order (subset of `docs/CONFIG.md` §4 — full CLI-flag /
-/// config-file resolution lands with the `config` subcommand):
+/// Resolution order (ADR-0036, `docs/CONFIG.md` §4):
 ///
-/// 1. `DOIGET_STORE_ROOT` environment variable, if set and non-empty.
-/// 2. Fallback to `./papers` — `papers/` directly under the current working
-///    directory (#344 / ADR-0036), so fetched artifacts are visible where the
-///    user (or an LLM agent) is working rather than hidden in a far-off home
-///    directory. For a central, shared library set `DOIGET_STORE_ROOT`
-///    (e.g. `~/papers`, which also restores BiblioFetch.jl co-location —
-///    ADR-0004).
+/// 1. `DOIGET_STORE_ROOT`, if set and non-empty. `--store-root` is applied
+///    by writing this variable, so the flag rides the same rung.
+/// 2. `[store] root` in the user's `config.toml`, expanded via
+///    [`doiget_core::user_extension::expand_store_root`].
+/// 3. `./papers` — `papers/` directly under the current working directory
+///    (#344 / ADR-0036), so fetched artifacts are visible where the user
+///    (or an LLM agent) is working rather than hidden in a far-off home
+///    directory.
 ///
-/// The env-var hook is sufficient for both real use and integration tests
-/// — tests set `DOIGET_STORE_ROOT` to a `tempfile::TempDir` to keep the
-/// real working directory untouched.
+/// Rung 2 is new in #441. It was documented from the start — ADR-0036
+/// states the order, `docs/CONFIG.md` §3 lists the key, `config init`
+/// writes it into the template it generates and `config doctor` recommends
+/// it — and read by nothing, so the store silently kept following the cwd.
+/// The old doc comment on this function said the config rung "lands with
+/// the `config` subcommand"; that subcommand shipped in 0.8.8 without it.
 pub(crate) fn resolve_store_root() -> Result<Utf8PathBuf> {
+    resolve_store_root_with_source().map(|(root, _)| root)
+}
+
+/// [`resolve_store_root`] plus which rung answered.
+pub(crate) fn resolve_store_root_with_source() -> Result<(Utf8PathBuf, StoreRootSource)> {
     if let Ok(s) = std::env::var("DOIGET_STORE_ROOT") {
         // Ignore an empty value or an unexpanded "${...}" placeholder — a
         // Desktop-Extension config left blank can pass the literal
         // "${user_config.store_root}", which must not become a path (#369).
         let s = s.trim();
         if !s.is_empty() && !s.contains("${") {
-            return Ok(Utf8PathBuf::from(s));
+            return Ok((Utf8PathBuf::from(s), StoreRootSource::Env));
         }
     }
+    if let Some(root) = store_root_from_config() {
+        return Ok((root, StoreRootSource::ConfigFile));
+    }
     let cwd = std::env::current_dir().context(
-        "could not determine the current working directory for the default store root \
-         (set DOIGET_STORE_ROOT to choose an explicit store location)",
+        "could not determine the current working directory for the default store root          (set DOIGET_STORE_ROOT to choose an explicit store location)",
     )?;
     Utf8PathBuf::from_path_buf(cwd)
-        .map(|d| d.join("papers"))
+        .map(|d| (d.join("papers"), StoreRootSource::CwdDefault))
         .map_err(|p| anyhow::anyhow!("current directory path is not UTF-8: {}", p.display()))
+}
+
+/// `[store] root` from the user's `config.toml`, if any.
+///
+/// Deliberately silent on a malformed file: the store root is resolved by
+/// every subcommand, and a parse error surfaces with a proper diagnostic on
+/// the network path that owns this file. Failing every command here would
+/// turn one bad line into a total outage.
+fn store_root_from_config() -> Option<Utf8PathBuf> {
+    let path = user_config_path()?;
+    let cfg = doiget_core::user_extension::load(&path).ok()?;
+    let raw = cfg.store_root?;
+    Some(doiget_core::user_extension::expand_store_root(&raw))
 }

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -514,7 +514,7 @@ fn parse_str(
 /// answer of exactly the kind #441 was about. `DOIGET_STORE_ROOT` needs no
 /// equivalent because the shell expands it before the process starts.
 ///
-/// Kept out of [`parse_str`] so parsing stays a pure function of the file
+/// Kept out of the parser so parsing stays a pure function of the file
 /// text; both the CLI and the MCP resolver call this at the point of use,
 /// which is also what keeps their two answers identical.
 ///

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -1,5 +1,10 @@
 //! User-extensible capability gate (ADR-0028, #220).
 //!
+//! The single reader for the user's `config.toml`. Parses
+//! `[[network.additional_hosts]]`, the two `[network]` trust flags, and
+//! `[store] root` (#441) — one opener, so no two commands can disagree
+//! about which file they are describing.
+//!
 //! Parses the `[[network.additional_hosts]]` array-of-tables from the
 //! user's `config.toml`, validates each entry against the restricted
 //! ADR-0028 D2-1 pattern grammar, and merges the user-added hosts into
@@ -49,7 +54,7 @@
 //! (MCP) currently sees no effect; that is the load-bearing item
 //! S3b closes.
 
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 
 use crate::http::SourceAllowlist;
@@ -277,6 +282,25 @@ pub fn load(config_path: &Utf8Path) -> Result<UserExtensionConfig, UserExtension
 struct RawConfig {
     #[serde(default)]
     network: Option<RawNetwork>,
+    #[serde(default)]
+    store: Option<RawStore>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+/// `[store]` — read here rather than by a second reader so there is exactly
+/// one answer to "which config.toml" (#441). A separate opener is how
+/// `doiget fetch` and `doiget config doctor` once disagreed about the file
+/// they were describing.
+#[derive(Debug, Default, Deserialize)]
+struct RawStore {
+    /// `[store] root` — the central library path. Documented in
+    /// `docs/CONFIG.md` §3 and ADR-0036 since 0.7, and parsed by nobody
+    /// until #441: `resolve_store_root` read the env var and then fell
+    /// straight through to the cwd default, so the file rung the docs,
+    /// `config init` and `config doctor` all pointed at did nothing.
+    #[serde(default)]
+    root: Option<String>,
     #[serde(flatten)]
     _other: serde::de::IgnoredAny,
 }
@@ -326,6 +350,13 @@ pub struct UserExtensionConfig {
     /// `config.toml`. Callers that respect this flag SHOULD merge
     /// [`oa_registry_hosts`] into their allowlist.
     pub trust_oa_registries: bool,
+    /// `[store] root`, verbatim, when present and non-empty (#441).
+    ///
+    /// Returned as the raw string rather than a path: expanding it needs a
+    /// home directory, and this crate has no home-directory dependency.
+    /// The CLI and MCP resolvers own that step, and both place this rung
+    /// below `DOIGET_STORE_ROOT` and above the cwd default (ADR-0036).
+    pub store_root: Option<String>,
 }
 
 /// Returns the built-in curated set of academic institution host patterns.
@@ -459,11 +490,64 @@ fn parse_str(
             issues,
         });
     }
+    // An empty `root = ""` is treated as absent rather than as "the empty
+    // path": it would otherwise resolve to a store at the filesystem root
+    // or to a panic downstream, and a blank value plainly means "unset".
+    let store_root = raw
+        .store
+        .and_then(|st| st.root)
+        .map(|r| r.trim().to_string())
+        .filter(|r| !r.is_empty());
+
     Ok(UserExtensionConfig {
         additional_hosts: validated,
         trust_academic_repos,
         trust_oa_registries,
+        store_root,
     })
+}
+
+/// Turn a raw `[store] root` value into a path, expanding a leading `~`.
+///
+/// A config file has no shell, so `~/papers` written there would otherwise
+/// become a literal directory named `~` next to the cwd — a silent wrong
+/// answer of exactly the kind #441 was about. `DOIGET_STORE_ROOT` needs no
+/// equivalent because the shell expands it before the process starts.
+///
+/// Kept out of [`parse_str`] so parsing stays a pure function of the file
+/// text; both the CLI and the MCP resolver call this at the point of use,
+/// which is also what keeps their two answers identical.
+///
+/// Falls back to the value verbatim when neither `HOME` nor `USERPROFILE`
+/// is set — a wrong path the user can see beats a silent substitution.
+#[must_use]
+pub fn expand_store_root(raw: &str) -> Utf8PathBuf {
+    let rest = match raw.strip_prefix('~') {
+        Some(r) => r,
+        None => return Utf8PathBuf::from(raw),
+    };
+    // Only `~` and `~/...` — `~alice/...` is another user's home, which is
+    // not something this can resolve, so it is left verbatim.
+    // A backslash char literal is written as a unicode escape so no tool
+    // that rewrites this file can mangle it.
+    if !(rest.is_empty() || rest.starts_with('/') || rest.starts_with('\u{5c}')) {
+        return Utf8PathBuf::from(raw);
+    }
+    let home = std::env::var("HOME")
+        .ok()
+        .filter(|h| !h.is_empty())
+        .or_else(|| std::env::var("USERPROFILE").ok().filter(|h| !h.is_empty()));
+    match home {
+        Some(h) => {
+            let trimmed = rest.trim_start_matches(['/', '\u{5c}']);
+            if trimmed.is_empty() {
+                Utf8PathBuf::from(h)
+            } else {
+                Utf8PathBuf::from(h).join(trimmed)
+            }
+        }
+        None => Utf8PathBuf::from(raw),
+    }
 }
 
 /// Validate a host pattern per ADR-0028 D2-1.
@@ -1117,6 +1201,74 @@ host = "*.uj.edu.pl"
                 patterns.contains(expected),
                 "expected academic pattern {expected} not found"
             );
+        }
+    }
+    /// #441: `[store] root` reaches the caller at all.
+    #[test]
+    fn store_root_is_parsed_from_the_same_file_as_the_network_gate() {
+        let cfg = parse_str(
+            "[store]\nroot = \"/home/alice/papers\"\n\n[network]\ntrust_academic_repos = true\n",
+            Utf8Path::new("test.toml"),
+        )
+        .expect("parses");
+        assert_eq!(cfg.store_root.as_deref(), Some("/home/alice/papers"));
+        assert!(
+            cfg.trust_academic_repos,
+            "the network section must still be read from the same pass"
+        );
+    }
+
+    /// A blank value is "unset", not the empty path — which would resolve
+    /// to the filesystem root.
+    #[test]
+    fn blank_store_root_parses_as_absent() {
+        let cfg =
+            parse_str("[store]\nroot = \"  \"\n", Utf8Path::new("test.toml")).expect("parses");
+        assert_eq!(cfg.store_root, None);
+    }
+
+    /// No `[store]` table at all is fine, and must not disturb anything.
+    #[test]
+    fn absent_store_table_is_not_an_error() {
+        let cfg = parse_str(
+            "[network]\ntrust_oa_registries = true\n",
+            Utf8Path::new("t.toml"),
+        )
+        .expect("parses");
+        assert_eq!(cfg.store_root, None);
+        assert!(cfg.trust_oa_registries);
+    }
+
+    /// A config file has no shell, so `~` must be expanded here or it
+    /// becomes a literal directory named `~`.
+    #[test]
+    #[serial_test::serial]
+    fn expand_store_root_resolves_a_leading_tilde() {
+        let prior_home = std::env::var("HOME").ok();
+        let prior_profile = std::env::var("USERPROFILE").ok();
+        std::env::set_var("HOME", "/home/alice");
+        std::env::remove_var("USERPROFILE");
+
+        assert_eq!(
+            expand_store_root("~/papers")
+                .as_str()
+                .replace('\u{5c}', "/"),
+            "/home/alice/papers"
+        );
+        assert_eq!(expand_store_root("~").as_str(), "/home/alice");
+        // Absolute and relative paths pass through untouched.
+        assert_eq!(expand_store_root("/srv/papers").as_str(), "/srv/papers");
+        assert_eq!(expand_store_root("papers").as_str(), "papers");
+        // `~alice` is another user's home; not something this can resolve,
+        // so it must be left alone rather than silently mangled.
+        assert_eq!(expand_store_root("~bob/papers").as_str(), "~bob/papers");
+
+        match prior_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        if let Some(v) = prior_profile {
+            std::env::set_var("USERPROFILE", v);
         }
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3969,6 +3969,13 @@ fn resolve_store_root() -> Option<Utf8PathBuf> {
             return Some(Utf8PathBuf::from(s.trim()));
         }
     }
+    // `[store] root` from the same `config.toml` the network gate reads
+    // (#441). Kept in step with the CLI resolver deliberately: a store root
+    // that differs between `doiget fetch` and `doiget serve` would put an
+    // agent's downloads somewhere the user's own commands cannot see.
+    if let Some(root) = store_root_from_config() {
+        return Some(root);
+    }
     // Default: `papers/` under the current working directory (#344 / ADR-0036),
     // so an agent's fetches land where the work is; set DOIGET_STORE_ROOT for a
     // central library.
@@ -3976,6 +3983,18 @@ fn resolve_store_root() -> Option<Utf8PathBuf> {
     Utf8PathBuf::from_path_buf(cwd)
         .ok()
         .map(|d| d.join("papers"))
+}
+
+/// `[store] root` from the user's `config.toml`, if any (#441).
+///
+/// Silent on a malformed file for the same reason as the CLI twin: the
+/// store root is resolved on nearly every tool call, and the parse error
+/// surfaces with a proper diagnostic on the path that owns the file.
+fn store_root_from_config() -> Option<Utf8PathBuf> {
+    let path = config_dir_utf8().ok()?.join("doiget").join("config.toml");
+    let cfg = doiget_core::user_extension::load(&path).ok()?;
+    let raw = cfg.store_root?;
+    Some(doiget_core::user_extension::expand_store_root(&raw))
 }
 
 /// Best-effort writability probe for the resolved store root.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -49,6 +49,8 @@ A value set higher in the chain overrides any value set lower.
 # ~/.config/doiget/config.toml — all fields optional
 
 [store]
+# Overridden by DOIGET_STORE_ROOT and --store-root (one rung above).
+# A leading `~` is expanded; the env var relies on the shell for that.
 root = "/home/alice/papers"
 
 [cache]

--- a/docs/DECISIONS/0036-default-store-cwd.md
+++ b/docs/DECISIONS/0036-default-store-cwd.md
@@ -40,6 +40,31 @@ Resolution order is otherwise unchanged: `DOIGET_STORE_ROOT` env >
 single central library sets `DOIGET_STORE_ROOT=~/papers` (or `store.root`
 in `config.toml`), which also restores BiblioFetch.jl co-location.
 
+### Amendment 1 (2026-08-23, #441) — the config rung now exists
+
+The order above described an implementation that did not exist. Until #441
+`resolve_store_root` read `DOIGET_STORE_ROOT` and fell straight through to
+the cwd default; `[store] root` was parsed by nothing, while `docs/CONFIG.md`
+§3 listed it, `doiget config init` wrote it into its template and
+`doiget config doctor` recommended it. A user could follow every piece of
+the tool's own advice and have the setting silently ignored — worst of all
+when they tested from the directory they had configured, where the ignored
+value and the cwd default coincide.
+
+Two clarifications to the sentence above, now that it is implemented:
+
+- **The flag and the env var share one rung.** `--store-root` is applied by
+  writing `DOIGET_STORE_ROOT`, so the flag wins over an inherited env value
+  (the usual CLI convention) rather than losing to it. The original wording
+  put the env var first; no build ever behaved that way.
+- **A leading `~` is expanded for the config value only.** The env var is
+  expanded by the shell before doiget sees it; a config file has no shell,
+  so `~/papers` written there would otherwise become a literal `~`
+  directory.
+
+`doiget config doctor` now prints which rung answered, so a setting that is
+present but not honoured can no longer look like one that worked.
+
 This **amends ADR-0004**: doiget and BiblioFetch.jl no longer co-locate
 their stores *by default*. The shared on-disk *format* (STORE.md) — the
 actual coexistence contract — is unchanged; pointing both tools at the

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -55,6 +55,8 @@ A value set higher in the chain overrides any value set lower.
 # ~/.config/doiget/config.toml — all fields optional
 
 [store]
+# Overridden by DOIGET_STORE_ROOT and --store-root (one rung above).
+# A leading `~` is expanded; the env var relies on the shell for that.
 root = "/home/alice/papers"
 
 [cache]


### PR DESCRIPTION
Closes #441.

## The bug

ADR-0036 states the order `DOIGET_STORE_ROOT` > `--store-root` > config file > `./papers`. **The config rung did not exist.** `resolve_store_root` read the env var and fell through to the cwd default; `[store] root` was parsed by nothing.

Everything that could have told the user was instead recommending it:

| surface | says |
|---|---|
| ADR-0036 | config file is rung 3 |
| `docs/CONFIG.md` §3 | lists `[store] root` |
| `doiget config init` | writes `# root = "/home/you/papers"` into its template |
| `doiget config doctor` | "Set DOIGET_STORE_ROOT (or store.root in config.toml)" |

And `[network]` from the same file **was** honoured, so the file looked read.

The nastiest part is the coincidence: verify from the directory you configured and the ignored value equals the cwd default, so it looks like it worked.

## What changed

- **`[store] root` is parsed by `user_extension`** — the reader that already owns this file. Deliberately not a second opener: `doiget fetch` and `doiget config doctor` once described different `config.toml`s, and one file must have one answer.
- **`expand_store_root` expands a leading `~`.** A config file has no shell, so `~/papers` would otherwise become a literal `~` directory. The env var needs no equivalent.
- **Both resolvers consult it** — CLI and the MCP twin. A store root that differed between `doiget fetch` and `doiget serve` would put an agent's downloads where the user's own commands cannot see them.
- **`config doctor` prints which rung answered.** This is the part that makes the class of bug visible rather than only fixed:

```
[ ok ] store_root: /home/souta/papers
       from: [store] root in config.toml
```

## Tests pin the order, not the default

The issue named this precisely — existing tests set `DOIGET_STORE_ROOT`, which is the rung that already worked.

The load-bearing assertion is the **negative** one. `store_root == <configured>` alone also passes when the config is ignored and the test runs from the configured directory, which is exactly how this hid:

```rust
assert_ne!(cfg.store_root, cwd_default,
    "the config value was ignored and the cwd default answered instead");
```

Mutation-verified by removing the rung:

```
store_root_in_config_beats_the_cwd_default          ... FAILED
  assertion `left != right` failed: the config value was ignored
  and the cwd default answered instead
env_beats_store_root_in_config                      ... ok
blank_store_root_in_config_falls_through_to_default ... ok
```

Seven tests total: three CLI order tests, four core ones (parsing, blank-is-absent, absent table, `~` expansion including `~bob/...` left alone).

## ADR-0036 Amendment 1

Records that the rung was unimplemented, and corrects two things the original order statement got wrong:

- **`--store-root` and the env var share a rung.** The flag is applied by writing `DOIGET_STORE_ROOT`, so the flag wins over an inherited env value — the usual CLI convention. The ADR said env-beats-flag; no build ever behaved that way.
- **`~` expansion applies to the config value only.**

Flagging the second one for review since it edits a stated decision: I matched the ADR text to the implementation rather than the other way round, because flag-beats-env is both the convention and the shipped behaviour. Say the word if you'd rather change the code.

## Local verification

```
clippy  --features oa-only -D warnings     GREEN
test    --features oa-only                 799 passed, 0 failed   (was 792)
```

`site/content/` regenerated via `scripts/sync_docs_to_site.sh`.