### PR TITLE
fix(cli): suggest the registrable domain, not just the hop that failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.3"
+version = "0.8.9-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.3"
+version = "0.8.9-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.3"
+version = "0.8.9-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.3"
+version       = "0.8.9-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -594,11 +594,22 @@ async fn network_report(cfg: &ResolvedConfig) {
     );
     eprintln!("                  a proxy fixes addressing, never a bot wall");
 
+    // #443: this used to read "unpaywall ... may be throttled", which
+    // attributes the whole cost of an unset contact address to the metadata
+    // lookup. The reporter hit HTTP 429 on the CONTENT leg, from the
+    // publisher — the User-Agent goes out on every request, so the label
+    // has to name every request.
     match &cfg.contact_email {
-        Some(e) => eprintln!("  unpaywall       polite pool as {e}"),
-        None => eprintln!(
-            "  unpaywall       non-polite pool (no DOIGET_CONTACT_EMAIL; may be throttled)"
-        ),
+        Some(e) => eprintln!("  contact         polite User-Agent as {e} (all outbound requests)"),
+        None => {
+            eprintln!(
+                "  contact         no DOIGET_CONTACT_EMAIL — every outbound request, metadata"
+            );
+            eprintln!(
+                "                  AND publisher content, goes out on the non-polite pool and"
+            );
+            eprintln!("                  may be throttled (HTTP 429) or refused");
+        }
     }
 
     let client = match crate::commands::fetch::build_http_client(None) {

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -563,6 +563,33 @@ impl ProbeVerdict {
     }
 }
 
+/// The `doiget config doctor --network` contact-address block (#443).
+///
+/// Split out as a pure function for the same reason as
+/// `fetch::denial_note_lines`: it is a diagnostic whose exact wording is
+/// the whole point, and a diagnostic nothing asserts on is a diagnostic
+/// that can silently regress.
+///
+/// It used to read `unpaywall  non-polite pool (... may be throttled)`,
+/// which attributes the whole cost of an unset contact address to the
+/// metadata lookup. The 429 that prompted this came from the publisher on
+/// the CONTENT leg. The User-Agent goes out on every request, so the label
+/// has to say every request.
+fn contact_report_lines(contact_email: Option<&str>) -> Vec<String> {
+    match contact_email {
+        Some(e) => vec![format!(
+            "  contact         polite User-Agent as {e} (all outbound requests)"
+        )],
+        None => vec![
+            "  contact         no DOIGET_CONTACT_EMAIL — every outbound request, metadata"
+                .to_string(),
+            "                  AND publisher content, goes out on the non-polite pool and"
+                .to_string(),
+            "                  may be throttled (HTTP 429) or refused".to_string(),
+        ],
+    }
+}
+
 /// `doiget config doctor --network` — the outbound half of the report
 /// (issue #407).
 ///
@@ -594,22 +621,8 @@ async fn network_report(cfg: &ResolvedConfig) {
     );
     eprintln!("                  a proxy fixes addressing, never a bot wall");
 
-    // #443: this used to read "unpaywall ... may be throttled", which
-    // attributes the whole cost of an unset contact address to the metadata
-    // lookup. The reporter hit HTTP 429 on the CONTENT leg, from the
-    // publisher — the User-Agent goes out on every request, so the label
-    // has to name every request.
-    match &cfg.contact_email {
-        Some(e) => eprintln!("  contact         polite User-Agent as {e} (all outbound requests)"),
-        None => {
-            eprintln!(
-                "  contact         no DOIGET_CONTACT_EMAIL — every outbound request, metadata"
-            );
-            eprintln!(
-                "                  AND publisher content, goes out on the non-polite pool and"
-            );
-            eprintln!("                  may be throttled (HTTP 429) or refused");
-        }
+    for line in contact_report_lines(cfg.contact_email.as_deref()) {
+        eprintln!("{line}");
     }
 
     let client = match crate::commands::fetch::build_http_client(None) {
@@ -1204,6 +1217,37 @@ mod tests {
             cfg.store_root_source,
             super::super::StoreRootSource::CwdDefault.label(),
             "a blank root must not be treated as a configured value"
+        );
+    }
+    /// #443: the wording must not pin the cost of an unset contact address
+    /// on the metadata leg — the 429 that prompted this came from the
+    /// publisher, on the content leg.
+    #[test]
+    fn the_contact_advisory_names_every_outbound_request_not_just_unpaywall() {
+        let joined = contact_report_lines(None).join("\n");
+        assert!(
+            joined.contains("every outbound request") && joined.contains("publisher content"),
+            "the advisory must cover the content leg too:\n{joined}"
+        );
+        assert!(
+            !joined.contains("unpaywall"),
+            "naming only unpaywall is the bug:\n{joined}"
+        );
+        assert!(
+            joined.contains("429"),
+            "name the symptom the user will actually see:\n{joined}"
+        );
+    }
+
+    /// The set case says what is in effect, and does not warn.
+    #[test]
+    fn a_set_contact_address_reports_the_polite_pool_without_a_warning() {
+        let joined = contact_report_lines(Some("a@example.org")).join("\n");
+        assert!(joined.contains("a@example.org"), "{joined}");
+        assert!(joined.contains("all outbound requests"), "{joined}");
+        assert!(
+            !joined.contains("429"),
+            "no warning when it is set:\n{joined}"
         );
     }
 }

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1032,6 +1032,85 @@ pub(crate) fn cli_exit_code(code: ErrorCode) -> i32 {
     }
 }
 
+/// Widening suggestions for a refused host, most specific first (#443).
+///
+/// The `= help:` block used to name only the hop that was just refused, so
+/// a publisher whose PDF sits behind `www.x.org -> pubs.x.org` cost the
+/// user one edit-run cycle per hop. Naming the registrable domain too ends
+/// it in one.
+///
+/// It is also the policy-consistent suggestion. The built-in allowlist is
+/// written almost entirely as registrable-domain wildcards
+/// (`*.springer.com`, `*.wiley.com`, `*.aps.org`), and ADR-0027's stated
+/// mitigation for widening the trusted surface is exactly that they are
+/// "bounded registrable-domain wildcards". Suggesting a bare FQDN was both
+/// more work for the user and narrower than the convention the project
+/// applies to itself. The apex is offered alongside the wildcard because a
+/// single-suffix wildcard does not match it — the reason the built-in list
+/// already carries both forms for `doaj.org`, `arxiv.org` and friends.
+///
+/// Conservative by construction: a suggestion is emitted only when the
+/// derived parent is clearly registrable. Getting this exactly right needs
+/// the public suffix list, and a wrong guess here is not cosmetic — it
+/// would invite the user to trust `*.co.uk`.
+fn widening_suggestions(host: &str) -> Vec<(String, &'static str)> {
+    let mut out = vec![(host.to_string(), "this hop only")];
+    let labels: Vec<&str> = host.split('.').filter(|l| !l.is_empty()).collect();
+    if labels.len() < 2 || looks_like_public_suffix(&labels) {
+        return out;
+    }
+    if labels.len() == 2 {
+        // Already the apex: the useful widening is its subdomains.
+        out.push((format!("*.{host}"), "and its subdomains"));
+        return out;
+    }
+    let parent_labels = &labels[1..];
+    if looks_like_public_suffix(parent_labels) {
+        return out;
+    }
+    let parent = parent_labels.join(".");
+    out.push((format!("*.{parent}"), "the whole publisher"));
+    out.push((parent, "apex too (a wildcard does not match it)"));
+    out
+}
+
+/// Whether `labels` looks like a public suffix rather than something a
+/// single organisation registered.
+///
+/// Deliberately crude and deliberately over-cautious: the cost of a false
+/// positive is one missing suggestion, and the cost of a false negative is
+/// telling a user to trust every domain under `co.uk`.
+fn looks_like_public_suffix(labels: &[&str]) -> bool {
+    match labels {
+        // A bare TLD.
+        [_] => true,
+        // `co.uk`, `ac.jp`, `com.au`, … — a known second level under a
+        // two-letter ccTLD. `example.co.uk` has three labels and is NOT
+        // caught here, which is correct.
+        [sld, tld] => {
+            tld.len() == 2
+                && matches!(
+                    *sld,
+                    "co" | "com"
+                        | "ne"
+                        | "net"
+                        | "or"
+                        | "org"
+                        | "ac"
+                        | "edu"
+                        | "gov"
+                        | "go"
+                        | "gr"
+                        | "lg"
+                        | "mil"
+                        | "id"
+                        | "in"
+                )
+        }
+        _ => false,
+    }
+}
+
 /// Build the ADR-0023 `denial_context` advisory lines shared by
 /// [`render_fetch_error`] and [`render_blocked_error`]: the `= note:`
 /// naming what was attempted and what the allowlist held, plus — for
@@ -1079,9 +1158,11 @@ fn denial_note_lines(dc: &DenialContext, config_path: Option<&camino::Utf8Path>)
             .to_string(),
     );
     if dc.attempted.is_some() {
-        out.push(format!(
-            "          [[network.additional_hosts]] host = \"{attempted}\"   # or this one"
-        ));
+        for (pattern, why) in widening_suggestions(attempted) {
+            out.push(format!(
+                "          [[network.additional_hosts]] host = \"{pattern}\"   # {why}"
+            ));
+        }
     }
     out.push("          see docs/CONFIG.md §3.1 for both".to_string());
     out
@@ -1774,5 +1855,94 @@ host = "*.uj.edu.pl"
             b"USER-DATA",
             "the user's file must be left untouched"
         );
+    }
+    /// #443, the reported case: `www.ams.org -> pubs.ams.org` cost two
+    /// edit-run cycles because the help named only the hop that failed.
+    #[test]
+    fn a_refused_hop_also_offers_the_registrable_domain() {
+        let mut dc = denial(DenialReason::RedirectNotInAllowlist);
+        dc.attempted = Some("pubs.ams.org".to_string());
+        let joined = denial_note_lines(&dc, None).join("\n");
+
+        assert!(joined.contains(r#"host = "pubs.ams.org""#), "{joined}");
+        assert!(
+            joined.contains(r#"host = "*.ams.org""#),
+            "the whole-publisher wildcard is what ends the loop in one step:\n{joined}"
+        );
+        assert!(
+            joined.contains(r#"host = "ams.org""#),
+            "a single-suffix wildcard does not match the apex, so offer it too:\n{joined}"
+        );
+    }
+
+    /// A suggestion the config parser would reject is worse than none: the
+    /// user pastes it and gets a second, more confusing error.
+    #[test]
+    fn every_suggestion_is_a_pattern_the_validator_accepts() {
+        for host in [
+            "pubs.ams.org",
+            "www.ams.org",
+            "ams.org",
+            "strathprints.strath.ac.uk",
+            "repository.ruj.uj.edu.pl",
+            "link.springer.com",
+        ] {
+            for (pattern, _) in widening_suggestions(host) {
+                doiget_core::user_extension::validate_pattern(&pattern).unwrap_or_else(|e| {
+                    panic!("suggested `{pattern}` for `{host}`, which the validator rejects: {e:?}")
+                });
+            }
+        }
+    }
+
+    /// The one suggestion that must never appear. Deriving the registrable
+    /// domain by stripping a label is right for `pubs.ams.org` and very
+    /// wrong for `foo.co.uk` — trusting `*.co.uk` is trusting a whole
+    /// country's registry.
+    #[test]
+    fn a_public_suffix_is_never_offered() {
+        for (host, forbidden) in [
+            ("foo.co.uk", "co.uk"),
+            ("foo.ac.jp", "ac.jp"),
+            ("foo.com.au", "com.au"),
+            ("example.org", "org"),
+        ] {
+            let joined: String = widening_suggestions(host)
+                .into_iter()
+                .map(|(p, _)| p)
+                .collect::<Vec<_>>()
+                .join(" ");
+            assert!(
+                !joined
+                    .split(' ')
+                    .any(|p| p == forbidden || p == format!("*.{forbidden}")),
+                "offered the public suffix `{forbidden}` for `{host}`: {joined}"
+            );
+        }
+    }
+
+    /// `strathprints.strath.ac.uk` — four labels, so the parent
+    /// `strath.ac.uk` is a real registration, not a public suffix.
+    #[test]
+    fn a_four_label_academic_host_still_gets_its_institution_wildcard() {
+        let got: Vec<String> = widening_suggestions("strathprints.strath.ac.uk")
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        assert!(
+            got.iter().any(|p| p == "*.strath.ac.uk"),
+            "expected the institution wildcard; got {got:?}"
+        );
+    }
+
+    /// An apex host has no parent worth naming; the useful widening is
+    /// downward.
+    #[test]
+    fn an_apex_host_offers_its_subdomains() {
+        let got: Vec<String> = widening_suggestions("ams.org")
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        assert_eq!(got, vec!["ams.org".to_string(), "*.ams.org".to_string()]);
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -112,6 +112,17 @@ runs against the built-in allowlist only.
 | `trust_oa_registries` | bool | `false` | Adds the curated **OA registries / repositories** — where cross-publisher **Gold OA** is indexed or hosted. |
 | `[[network.additional_hosts]]` | array of tables | empty | Adds individual hosts. `host` is required; `note` is optional and free-text. |
 
+**Prefer the registrable-domain wildcard.** A publisher often redirects across its own
+subdomains — `www.ams.org` → `pubs.ams.org` — so an entry for the exact host that was
+refused buys you one hop and another denial. `*.ams.org` covers the publisher in one
+line, and matches how the built-in list is written (ADR-0027 bounds the trusted surface
+to registrable-domain wildcards for established publishers). Add the apex alongside it
+when the publisher redirects there too: a single-suffix wildcard does **not** match
+`ams.org` itself, which is why the built-in list carries both forms for `doaj.org`,
+`arxiv.org` and `europepmc.org`.
+
+The denial message suggests all three, most specific first (#443).
+
 The two flags are separate because the trust arguments differ — "this institution
 publishes its own work here" is not "this registry indexes open content across
 publishers" — so you can take either without the other.

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -118,6 +118,17 @@ runs against the built-in allowlist only.
 | `trust_oa_registries` | bool | `false` | Adds the curated **OA registries / repositories** — where cross-publisher **Gold OA** is indexed or hosted. |
 | `[[network.additional_hosts]]` | array of tables | empty | Adds individual hosts. `host` is required; `note` is optional and free-text. |
 
+**Prefer the registrable-domain wildcard.** A publisher often redirects across its own
+subdomains — `www.ams.org` → `pubs.ams.org` — so an entry for the exact host that was
+refused buys you one hop and another denial. `*.ams.org` covers the publisher in one
+line, and matches how the built-in list is written (ADR-0027 bounds the trusted surface
+to registrable-domain wildcards for established publishers). Add the apex alongside it
+when the publisher redirects there too: a single-suffix wildcard does **not** match
+`ams.org` itself, which is why the built-in list carries both forms for `doaj.org`,
+`arxiv.org` and `europepmc.org`.
+
+The denial message suggests all three, most specific first (#443).
+
 The two flags are separate because the trust arguments differ — "this institution
 publishes its own work here" is not "this registry indexes open content across
 publishers" — so you can take either without the other.


### PR DESCRIPTION
Closes #443.

## The bug

Fetching an AMS article denied `www.ams.org`. The user added exactly the host the `= help:` block named, retried, and was denied `pubs.ams.org`. One edit-run cycle per hop. `*.ams.org` cleared it in one.

Naming only the refused hop is also narrower than the convention doiget applies to itself — the built-in allowlist is written almost entirely as registrable-domain wildcards, and ADR-0027's stated mitigation for widening the trusted surface is that entries are *"bounded registrable-domain wildcards for established"* publishers.

## After

```
= help: that host is not on the allowlist yet; widen it in ~/.config/doiget/config.toml
        [network] trust_academic_repos = true   # 15 curated academic suffixes
        [network] trust_oa_registries  = true   # DOAJ, SciELO, Zenodo, OSF, HAL
        [[network.additional_hosts]] host = "pubs.ams.org"   # this hop only
        [[network.additional_hosts]] host = "*.ams.org"      # the whole publisher
        [[network.additional_hosts]] host = "ams.org"        # apex too (a wildcard does not match it)
        see docs/CONFIG.md §3.1 for both
```

The apex is offered because a single-suffix wildcard does not match it — the reason the built-in list already carries both forms for `doaj.org`, `arxiv.org` and `europepmc.org`.

## The risky part, and how it is bounded

"Strip one label and offer it as a wildcard" is right for `pubs.ams.org` and **very wrong** for `foo.co.uk` — suggesting `*.co.uk` invites the user to trust a whole country's registry. Getting it exactly right needs the public suffix list, which is a dependency this does not justify.

`looks_like_public_suffix` is crude and deliberately over-cautious: a false positive costs one missing suggestion, a false negative costs the user's security posture.

| host | widening offered |
|---|---|
| `pubs.ams.org` | `*.ams.org`, `ams.org` |
| `strathprints.strath.ac.uk` | `*.strath.ac.uk`, `strath.ac.uk` |
| `ams.org` (apex) | `*.ams.org` |
| `foo.co.uk` / `foo.ac.jp` / `foo.com.au` | **none** |
| `example.org` | **none** |

## Tests

Two carry the weight:

- **`every_suggestion_is_a_pattern_the_validator_accepts`** — every emitted pattern is fed to `user_extension::validate_pattern`. A suggestion the parser rejects is worse than none: the user pastes it and gets a second, more confusing error.
- **`a_public_suffix_is_never_offered`** — the one output that must never appear.

Plus the reported AMS case, the four-label academic host, and the apex case.

```
test result: ok. 804 passed; 0 failed        (was 799)
clippy / rustdoc, oa-only and oa-only,citation: GREEN
```

## Also in here: the issue's related observation

`doctor --network` read:

```
unpaywall       non-polite pool (no DOIGET_CONTACT_EMAIL; may be throttled)
```

which attributes the whole cost of an unset contact address to the metadata lookup. The 429 the reporter actually hit came from the **publisher, on the content leg**. The User-Agent goes out on every request, so the label now says so:

```
contact         no DOIGET_CONTACT_EMAIL — every outbound request, metadata
                AND publisher content, goes out on the non-polite pool and
                may be throttled (HTTP 429) or refused
```

**Known gap:** `network_report` writes to stderr directly, so this string has no test. Making it testable means the `denial_note_lines` treatment — split the line builder out as a pure function. Worth doing; not folded in here to keep the diff about #443.