### PR TITLE
fix(cli): emit the resolution trace when the content leg is blocked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.4"
+version = "0.8.9-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.4"
+version = "0.8.9-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.4"
+version = "0.8.9-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.4"
+version       = "0.8.9-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -51,7 +51,9 @@ use doiget_core::http::tier_2_allowlist;
 use doiget_core::http::{
     discovery_allowlist, fulltext_allowlist, oa_publisher_allowlist, tier_1_allowlist, HttpClient,
 };
-use doiget_core::orchestrator::{fetch_paper as core_fetch_paper, FetchPaperOutcome, PdfLegStatus};
+use doiget_core::orchestrator::{
+    fetch_paper as core_fetch_paper, FetchPaperOutcome, PdfLegStatus, SourceAttempt,
+};
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
 use doiget_core::source::{FetchContext, FetchError};
@@ -1253,6 +1255,46 @@ fn render_blocked_error(
             arxiv_id
         ));
     }
+    for line in blocked_trace_lines(&outcome.attempts, message) {
+        print_err(format_args!("{line}"));
+    }
+}
+
+/// The `= note:`/`= suggest:` block appended to a blocked PDF leg (#445).
+///
+/// #413 attached the resolution trace to `NotFound` only. But "found
+/// nowhere" and "found at one host that refused me" raise the same next
+/// question — *did anything else have it?* — and only the first one got an
+/// answer. A user with five optional sources enabled saw a bare 429 and no
+/// indication that none of the five had been consulted.
+///
+/// Pure so the wording is asserted rather than assumed.
+fn blocked_trace_lines(attempts: &[SourceAttempt], message: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    // A rate limit is the one failure where retrying the same host later is
+    // right and reconfiguring is wrong. The bare text reads like a
+    // permanent block, so say which it is.
+    if message.contains("429") {
+        out.push(
+            "  = suggest: HTTP 429 is a rate limit, not a policy block — it is transient.              Retry later, and set DOIGET_CONTACT_EMAIL for the polite pool."
+                .to_string(),
+        );
+    }
+    if attempts.is_empty() {
+        return out;
+    }
+    let lead = if doiget_core::orchestrator::nothing_was_consulted(attempts) {
+        "no other source was consulted for this DOI"
+    } else {
+        "the other sources were consulted and offered no alternative copy"
+    };
+    out.push(format!("  = note: {lead}:"));
+    out.extend(
+        doiget_core::orchestrator::render_attempts(attempts)
+            .lines()
+            .map(|l| format!("  {l}")),
+    );
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -1944,5 +1986,94 @@ host = "*.uj.edu.pl"
             .map(|(p, _)| p)
             .collect();
         assert_eq!(got, vec!["ams.org".to_string(), "*.ams.org".to_string()]);
+    }
+    /// #445: a 429 reads like a permanent block. It is the one failure
+    /// where retrying the same host later is right and reconfiguring is
+    /// wrong, so the message has to say which it is.
+    #[test]
+    fn a_rate_limited_block_says_the_limit_is_transient() {
+        let joined = blocked_trace_lines(&[], "network error: HTTP 429 from https://ams.org/x.pdf")
+            .join("\n");
+        assert!(joined.contains("429"), "{joined}");
+        assert!(joined.contains("transient"), "{joined}");
+        assert!(
+            joined.contains("Retry later"),
+            "say what to DO, not just what happened:\n{joined}"
+        );
+    }
+
+    /// The converse: a policy denial must not be described as transient,
+    /// or the user retries forever instead of editing the allowlist.
+    #[test]
+    fn a_policy_block_is_not_described_as_transient() {
+        let joined =
+            blocked_trace_lines(&[], "redirect target x.example not in allowlist").join("\n");
+        assert!(
+            !joined.contains("transient"),
+            "an allowlist denial is permanent until reconfigured:\n{joined}"
+        );
+    }
+
+    /// The half of #445 that the #413 trace already answered for
+    /// `NotFound`: *did anything else have it?*
+    #[test]
+    fn a_blocked_leg_reports_which_other_sources_were_consulted() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        let attempts = vec![
+            SourceAttempt::new("core", AttemptOutcome::NoRecord),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: "DOIGET_ENABLE_HAL",
+                },
+            ),
+        ];
+        let joined = blocked_trace_lines(&attempts, "HTTP 429").join("\n");
+        assert!(
+            joined.contains("the other sources were consulted"),
+            "at least one WAS consulted:\n{joined}"
+        );
+        assert!(
+            joined.contains("core") && joined.contains("no record"),
+            "{joined}"
+        );
+        assert!(
+            joined.contains("DOIGET_ENABLE_HAL"),
+            "a source that was never asked must still name its switch:\n{joined}"
+        );
+    }
+
+    /// All five flags off is a configuration problem, not a data problem,
+    /// and must not read as "nothing else has this paper".
+    #[test]
+    fn a_blocked_leg_with_nothing_consulted_says_so() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        let attempts = vec![
+            SourceAttempt::new(
+                "core",
+                AttemptOutcome::Disabled {
+                    env: "DOIGET_ENABLE_CORE",
+                },
+            ),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: "DOIGET_ENABLE_HAL",
+                },
+            ),
+        ];
+        let joined = blocked_trace_lines(&attempts, "HTTP 429").join("\n");
+        assert!(
+            joined.contains("no other source was consulted"),
+            "must not imply the paper is unavailable elsewhere:\n{joined}"
+        );
+    }
+
+    /// An arXiv fetch has no optional chain; it must not grow an empty
+    /// note block.
+    #[test]
+    fn no_attempts_means_no_trace_block() {
+        let lines = blocked_trace_lines(&[], "not-a-pdf body");
+        assert!(lines.is_empty(), "{lines:?}");
     }
 }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -843,6 +843,17 @@ pub struct FetchPaperOutcome {
     pub authors: Vec<String>,
     /// Publication year, when known (#344 identity confirmation).
     pub year: Option<i32>,
+    /// One [`SourceAttempt`] per optional source, consulted or not (#445).
+    ///
+    /// #413 attached this trace to `NotFound` only, so the question it
+    /// exists to answer — *did anything else have this paper?* — went
+    /// unanswered on the outcome where a user is most likely to ask it: an
+    /// OA copy was located at a host that then refused to serve it. "Found
+    /// nowhere" and "found at one host that refused me" have the same next
+    /// step, so they get the same trace.
+    ///
+    /// Empty for an arXiv ref, which has no optional chain.
+    pub attempts: Vec<SourceAttempt>,
 }
 
 impl FetchPaperOutcome {
@@ -881,6 +892,7 @@ impl FetchPaperOutcome {
             title: String::new(),
             authors: Vec::new(),
             year: None,
+            attempts: Vec::new(),
         }
     }
 }
@@ -1077,6 +1089,8 @@ async fn fetch_paper_arxiv(
         title: metadata.title.clone(),
         authors: metadata.authors.clone(),
         year: metadata.year,
+        // arXiv resolves directly; the optional chain is a DOI concept.
+        attempts: Vec::new(),
     })
 }
 
@@ -1450,6 +1464,7 @@ async fn fetch_paper_doi(
         title: metadata.title.clone(),
         authors: metadata.authors.clone(),
         year: metadata.year,
+        attempts,
     })
 }
 


### PR DESCRIPTION
Refs #445 — the reporting half. The fall-through half lands separately.

## The gap

#413 attached the resolution trace to `NotFound` only. "Found nowhere" and "found at one host that refused me" raise the same next question — *did anything else have it?* — and only the first got an answer.

With five optional sources enabled, a 429 from the publisher printed a bare transport error and no indication that none of the five had been consulted.

## After

```
error[NETWORK_ERROR]: doi:10.1090/s0025-5718-04-01692-8: an OA PDF was found
  but could not be retrieved: network error: HTTP 429 from https://www.ams.org/...
  = note: metadata-only record written to .../doi_10.1090_....toml
  = suggest: HTTP 429 is a rate limit, not a policy block — it is transient.
             Retry later, and set DOIGET_CONTACT_EMAIL for the polite pool.
  = note: no other source was consulted for this DOI:
    datacite     not consulted (set DOIGET_ENABLE_DATACITE to enable)
    europe-pmc   not consulted (set DOIGET_ENABLE_EUROPE_PMC to enable)
    ...
```

The 429 line is the issue's optional item, and it earns its place: a rate limit is the one failure where retrying the same host later is right and reconfiguring is wrong, and the bare text reads like a permanent block. **A test asserts the converse too** — an allowlist denial must not be called transient, or the user retries forever instead of editing the allowlist.

## Shape

`FetchPaperOutcome` gains `attempts`. `blocked_trace_lines` is pure, like `denial_note_lines` and `contact_report_lines`, so the wording is asserted rather than assumed.

Five tests: transient-vs-permanent both ways, "some were consulted", "none were consulted" (a configuration problem that must not read as "this paper is unavailable elsewhere"), and empty-attempts producing no empty note block.

```
tests passed=811 failed=0     (was 804)
clippy / rustdoc, oa-only and oa-only,citation: GREEN
```

## On the `--mode json` part of #445

The issue says `--mode json` "emits the plain error text, not JSON" on this path. True, but the reason is not what it looks like, and I got it wrong in the first version of this description — correcting it here because it changes what the follow-up should be.

`doiget fetch` takes the mode and never reads it:

```rust
// crates/doiget-cli/src/commands/fetch.rs:693
    _mode: super::output::OutputMode,
    // `_mode` is threaded per ADR-0017 / #144. Quiet-suppression of the
    // success line is tracked in #203. The dry-run plan envelope is
    // product output ... and is unaffected by mode.
```

That comment points at #203, which is **closed** (it was quiet-suppression). The JSON-body work was staged as **#204**, also closed — and its scope was *human-table* commands: `info / list-recent / search / config show / audit-log / provenance migrate`. **`fetch` is not in that list and never was.**

So this is not an oversight, and not a tracked-but-unfinished item. It is an unasked design question: `doiget fetch`'s product is the file on disk, and the only JSON it emits today is the `--dry-run` plan envelope. Whether a failed fetch should also produce a machine-readable envelope is a new ask, and #445 is the first time anyone has wanted one.

Worth doing — an agent hitting a 429 has no programmatic way to read the trace this PR adds — but it is a JSON-envelope feature for the whole command, not a line in this diff. Happy to file it as its own issue with that framing.
