### PR TITLE
feat(orchestrator): fall through to an enabled source when the publisher refuses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.5"
+version = "0.8.9-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.5"
+version = "0.8.9-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.5"
+version = "0.8.9-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.5"
+version       = "0.8.9-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1276,7 +1276,8 @@ fn blocked_trace_lines(attempts: &[SourceAttempt], message: &str) -> Vec<String>
     // permanent block, so say which it is.
     if message.contains("429") {
         out.push(
-            "  = suggest: HTTP 429 is a rate limit, not a policy block — it is transient.              Retry later, and set DOIGET_CONTACT_EMAIL for the polite pool."
+            "  = suggest: HTTP 429 is a rate limit, not a policy block — it is transient. Retry \
+                later, and set DOIGET_CONTACT_EMAIL for the polite pool."
                 .to_string(),
         );
     }
@@ -2000,6 +2001,16 @@ host = "*.uj.edu.pl"
             joined.contains("Retry later"),
             "say what to DO, not just what happened:\n{joined}"
         );
+        // A lost `\` line continuation leaves the source indentation
+        // inside the literal, and every test above still passes because
+        // each only asserts `contains`. Nothing in this block is
+        // column-aligned, so an internal double space is that bug.
+        for line in blocked_trace_lines(&[], "network error: HTTP 429 from https://ams.org/x.pdf") {
+            assert!(
+                !line.trim_start().contains("  "),
+                "a lost line continuation left source indentation in the message:\n{line}"
+            );
+        }
     }
 
     /// The converse: a policy denial must not be described as transient,

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -142,7 +142,8 @@ pub(crate) fn resolve_store_root_with_source() -> Result<(Utf8PathBuf, StoreRoot
         return Ok((root, StoreRootSource::ConfigFile));
     }
     let cwd = std::env::current_dir().context(
-        "could not determine the current working directory for the default store root          (set DOIGET_STORE_ROOT to choose an explicit store location)",
+        "could not determine the current working directory for the default store root (set \
+            DOIGET_STORE_ROOT to choose an explicit store location)",
     )?;
     Utf8PathBuf::from_path_buf(cwd)
         .map(|d| (d.join("papers"), StoreRootSource::CwdDefault))

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -1445,7 +1445,8 @@ mod tests {
                 .collect();
             assert!(
                 reg.iter().any(|r| r == src.name()),
-                "source `{}` has no tier_3_aps_allowlist entry; a production                  fetch would fail UnknownSource. registered: {reg:?}",
+                "source `{}` has no tier_3_aps_allowlist entry; a production fetch would fail \
+                    UnknownSource. registered: {reg:?}",
                 src.name()
             );
             checked += 1;
@@ -1459,7 +1460,8 @@ mod tests {
                 .collect();
             assert!(
                 reg.iter().any(|r| r == src.name()),
-                "source `{}` has no tier_3_elsevier_allowlist entry; a production                  fetch would fail UnknownSource. registered: {reg:?}",
+                "source `{}` has no tier_3_elsevier_allowlist entry; a production fetch would \
+                    fail UnknownSource. registered: {reg:?}",
                 src.name()
             );
             checked += 1;
@@ -1473,7 +1475,8 @@ mod tests {
                 .collect();
             assert!(
                 reg.iter().any(|r| r == src.name()),
-                "source `{}` has no tier_3_springer_allowlist entry; a production                  fetch would fail UnknownSource. registered: {reg:?}",
+                "source `{}` has no tier_3_springer_allowlist entry; a production fetch would \
+                    fail UnknownSource. registered: {reg:?}",
                 src.name()
             );
             checked += 1;
@@ -1513,7 +1516,8 @@ mod tests {
         for n in names {
             assert!(
                 registered.iter().any(|r| r == n),
-                "source `{n}` has no tier_2_allowlist entry; a production fetch                  would fail UnknownSource. registered: {registered:?}"
+                "source `{n}` has no tier_2_allowlist entry; a production fetch would fail \
+                    UnknownSource. registered: {registered:?}"
             );
         }
     }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1554,7 +1554,7 @@ async fn try_optional_source_oa_fallback(
         tracing::warn!(
             source = name,
             url = raw,
-            "optional source reported an unparseable document URL; keeping Blocked"
+            "optional source reported an unparsable document URL; keeping Blocked"
         );
         return (pdf_leg, pdf_bytes);
     };

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1176,6 +1176,7 @@ async fn fetch_paper_doi(
         &mut attempts,
     )
     .await
+    .map(|(_, m)| m)
     .or(tdm_meta);
     #[cfg(not(feature = "metadata"))]
     let optional_meta: Option<Value> = tdm_meta;
@@ -1339,6 +1340,12 @@ async fn fetch_paper_doi(
     // it under the DOI safekey instead of returning Blocked.
     let (pdf_leg, pdf_bytes, arxiv_id_for_metadata, fallback_license) =
         try_arxiv_preprint_fallback(doi, pdf_leg, pdf_bytes, profile, ctx).await;
+
+    // #445: and if that did not help either, ask whoever else is switched
+    // on. Additive by construction — see the fn docs.
+    #[cfg(feature = "metadata")]
+    let (pdf_leg, pdf_bytes) =
+        try_optional_source_oa_fallback(doi, pdf_leg, pdf_bytes, profile, ctx, &mut attempts).await;
     if let Some(fl) = fallback_license {
         license = fl;
     }
@@ -1466,6 +1473,111 @@ async fn fetch_paper_doi(
         year: metadata.year,
         attempts,
     })
+}
+
+/// Which OA content URL an optional source reported, if any (#445).
+///
+/// Only the three sources that publish a direct document URL contribute.
+/// OpenAIRE's `urls[]` and DataCite's `url` point at a DOI resolver or a
+/// landing page, not a file — handing those to the OA chain would spend a
+/// request to arrive at a page the chain cannot read, and report a
+/// confusing failure. A source that contributes nothing is not a silent
+/// gap: it still appears in the attempt trace with its own outcome.
+#[cfg(feature = "metadata")]
+fn optional_source_oa_url<'a>(source: &str, meta: &'a Value) -> Option<&'a str> {
+    match source {
+        "core" => crate::sources::core_oa::open_access_pdf_url(meta),
+        "hal" => crate::sources::hal::open_access_pdf_url(meta),
+        "europe-pmc" => crate::sources::europepmc::open_access_pdf_url(meta),
+        _ => None,
+    }
+}
+
+/// Last resort for a blocked content leg: ask the enabled optional sources
+/// whether anyone else holds a copy (#445).
+///
+/// The OA chain already tries every location Unpaywall returned, advancing
+/// past each failure — so a 429 does not stop it. What stopped the reported
+/// run is that the candidate list can only ever contain Unpaywall's
+/// locations. Crossref had answered, so the optional chain was skipped
+/// entirely, and a rate limit on the single AMS URL ended a run with four
+/// other indexes switched on.
+///
+/// Each of those sources already surfaces a document URL and each module
+/// says, in its own docs, that the fetch belongs to the `oa-publisher`
+/// leg — `europepmc::open_access_pdf_url` was written for exactly this and
+/// had no caller. This is that caller.
+///
+/// Deliberately last, after the #325 arXiv fallback, so the change is
+/// purely additive: every run that succeeded before still succeeds by the
+/// same route. It costs a request only when the content leg has ALREADY
+/// failed and the user has switched a source on, so a default build with
+/// no flags set is byte-identical.
+#[cfg(feature = "metadata")]
+async fn try_optional_source_oa_fallback(
+    doi: &Doi,
+    pdf_leg: PdfLegStatus,
+    pdf_bytes: Option<Vec<u8>>,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    attempts: &mut Vec<SourceAttempt>,
+) -> (PdfLegStatus, Option<Vec<u8>>) {
+    if pdf_bytes.is_some() || !matches!(pdf_leg, PdfLegStatus::Blocked { .. }) {
+        return (pdf_leg, pdf_bytes);
+    }
+
+    // Reaching here means Crossref answered (a Crossref failure with no PDF
+    // returns NotFound further up), so `attempts` is a row of `NotNeeded`
+    // that carries no information. Running the chain for real replaces it
+    // with what actually happened.
+    let ref_ = Ref::Doi(doi.clone());
+    let mut discard = CrossrefFields::default();
+    let mut fresh: Vec<SourceAttempt> = Vec::new();
+    let resolved =
+        resolve_optional_chain(&ref_, profile, ctx, false, &mut discard, &mut fresh).await;
+    if !fresh.is_empty() {
+        *attempts = fresh;
+    }
+
+    let Some((name, meta)) = resolved else {
+        return (pdf_leg, pdf_bytes);
+    };
+    let Some(raw) = optional_source_oa_url(name, &meta) else {
+        tracing::debug!(
+            source = name,
+            doi = %doi.as_str(),
+            "optional source resolved but reported no document URL"
+        );
+        return (pdf_leg, pdf_bytes);
+    };
+    let Ok(url) = url::Url::parse(raw) else {
+        tracing::warn!(
+            source = name,
+            url = raw,
+            "optional source reported an unparseable document URL; keeping Blocked"
+        );
+        return (pdf_leg, pdf_bytes);
+    };
+
+    tracing::info!(
+        source = name,
+        doi = %doi.as_str(),
+        url = %url,
+        "OA chain exhausted; trying a copy reported by an optional source (#445)"
+    );
+    match try_fetch_oa_pdf(doi, &url, ctx).await {
+        Ok((bytes, _final_url)) => (PdfLegStatus::Fetched, Some(bytes)),
+        Err(e) => {
+            // Keep the ORIGINAL block. The publisher's 429 is what the user
+            // needs to see; a second failure from a repository would bury it.
+            tracing::warn!(
+                source = name,
+                error = %e,
+                "optional-source copy also failed; keeping the original block"
+            );
+            (pdf_leg, pdf_bytes)
+        }
+    }
 }
 
 /// Auto preprint fallback (issue #325). Called after the DOI OA PDF chain
@@ -3460,7 +3572,7 @@ async fn resolve_optional_chain(
     crossref_answered: bool,
     extracted: &mut CrossrefFields,
     attempts: &mut Vec<SourceAttempt>,
-) -> Option<Value> {
+) -> Option<(&'static str, Value)> {
     // Built eagerly so the trace lists every source in a fixed order even
     // when none is consulted — an empty trace would be indistinguishable
     // from "no chain exists", which is the confusion this whole mechanism
@@ -3503,7 +3615,7 @@ async fn resolve_optional_chain(
         ("core", "DOIGET_ENABLE_CORE", &core),
     ];
 
-    let mut resolved: Option<Value> = None;
+    let mut resolved: Option<(&'static str, Value)> = None;
 
     for (name, env, src) in chain {
         debug_assert_eq!(name, src.name(), "chain name must match Source::name");
@@ -3532,7 +3644,7 @@ async fn resolve_optional_chain(
                     *extracted = extract_optional_fields(name, meta);
                 }
                 attempts.push(SourceAttempt::new(name, AttemptOutcome::Resolved));
-                resolved = r.metadata_json;
+                resolved = r.metadata_json.map(|m| (name, m));
             }
             Err(e) => {
                 tracing::debug!(source = name, error = %e, "optional source did not resolve");
@@ -4436,6 +4548,213 @@ mod tdm_chain_tests {
             hint.contains("tdm-aps") && hint.contains("consulted:"),
             "the trace must record tdm-aps as consulted; got:
 {hint}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #445: does a blocked content leg actually fall through to another source?
+// ---------------------------------------------------------------------------
+//
+// The reported run had four indexes switched on and consulted none of them,
+// because the candidate list can only contain Unpaywall's locations and
+// Crossref had already answered. So the assertion that matters is REACH:
+// the mock must record a request to the optional source AND to the copy it
+// reported. A `Fetched` outcome alone would not prove which route produced it.
+
+#[cfg(all(test, feature = "metadata"))]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod oa_fallthrough_tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{path, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, RateLimits, Ref};
+
+    struct EnvSet(Vec<(&'static str, Option<String>)>);
+    impl EnvSet {
+        fn new(pairs: &[(&'static str, String)]) -> Self {
+            Self(
+                pairs
+                    .iter()
+                    .map(|(k, v)| {
+                        let old = std::env::var(k).ok();
+                        std::env::set_var(k, v);
+                        (*k, old)
+                    })
+                    .collect(),
+            )
+        }
+    }
+    impl Drop for EnvSet {
+        fn drop(&mut self) {
+            for (k, old) in &self.0 {
+                match old {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    /// Crossref answers, Unpaywall points at a host that 429s, CORE holds a
+    /// repository copy.
+    async fn server_with_a_rate_limited_publisher_and_a_repository_copy() -> MockServer {
+        let server = MockServer::start().await;
+        let base = server.uri();
+
+        Mock::given(path_regex("^/works/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                "{\"status\":\"ok\",\"message\":{\"title\":[\"Computing multiple roots\"]}}",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(path_regex("^/10\\.1090"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                "{{\"doi\":\"10.1090/example\",\"is_oa\":true,\"oa_status\":\"bronze\",\"best_oa_location\":\
+                 {{\"url_for_pdf\":\"{base}/blocked.pdf\",\"license\":\"cc-by\"}}}}"
+            )))
+            .mount(&server)
+            .await;
+        // The publisher rate-limits. This is the failure that used to end
+        // the whole run.
+        Mock::given(path("/blocked.pdf"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+        Mock::given(path("/v3/search/works"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                "{{\"totalHits\":1,\"results\":[{{\"id\":1,\
+                 \"title\":\"Computing multiple roots\",\"doi\":\"10.1090/example\",\
+                 \"downloadUrl\":\"{base}/repo.pdf\"}}]}}"
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(path("/repo.pdf"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_bytes(b"%PDF-1.4\nrepository copy\n".to_vec()),
+            )
+            .mount(&server)
+            .await;
+        server
+    }
+
+    fn ctx_for(host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let dir = Utf8PathBuf::try_from(td.path().to_path_buf()).expect("utf-8");
+        let host_only = host.split(':').next().unwrap_or(host);
+        let http = Arc::new(HttpClient::new_for_tests_allow_http_multi(&[
+            ("crossref", host),
+            ("unpaywall", host),
+            // The content leg compares the URL HOST, without the port,
+            // so this entry must be the bare address.
+            ("oa-publisher", host_only),
+            ("core", host),
+        ]));
+        let session_id = "01J000000000000000000FALL".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(dir.join("t.jsonl"), session_id.clone()).expect("log opens"),
+        );
+        (
+            td,
+            FetchContext {
+                http,
+                rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+                log,
+                session_id,
+                cache_root: None,
+            },
+        )
+    }
+
+    async fn run_fetch(
+        server: &MockServer,
+        core_enabled: bool,
+    ) -> (FetchPaperOutcome, Vec<String>) {
+        let base = server.uri();
+        let mut env = vec![
+            ("DOIGET_CROSSREF_BASE", base.clone()),
+            ("DOIGET_UNPAYWALL_BASE", base.clone()),
+            ("DOIGET_ARXIV_BASE", base.clone()),
+            ("DOIGET_CORE_BASE", base.clone()),
+            ("DOIGET_CONTACT_EMAIL", "test@example.org".to_string()),
+        ];
+        if core_enabled {
+            env.push(("DOIGET_ENABLE_CORE", "1".to_string()));
+        } else {
+            std::env::remove_var("DOIGET_ENABLE_CORE");
+        }
+        let _env = EnvSet::new(&env);
+
+        let profile = CapabilityProfile::from_env().expect("profile");
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let store_td = TempDir::new().expect("tempdir");
+        let root = Utf8PathBuf::try_from(store_td.path().to_path_buf()).expect("utf-8");
+        let store = crate::store::FsStore::new(root.clone()).expect("store");
+
+        let ref_ = Ref::Doi(Doi::parse("10.1090/example").expect("doi"));
+        let outcome = fetch_paper(&ref_, &profile, &ctx, &store, &root)
+            .await
+            .expect("crossref answered, so the fetch resolves either way");
+        let paths = server
+            .received_requests()
+            .await
+            .expect("recorded")
+            .iter()
+            .map(|r| r.url.path().to_string())
+            .collect();
+        (outcome, paths)
+    }
+
+    /// THE regression for #445. A 429 on the only Unpaywall location must
+    /// not end a run with another source switched on.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_rate_limited_publisher_falls_through_to_an_enabled_source() {
+        let server = server_with_a_rate_limited_publisher_and_a_repository_copy().await;
+        let (outcome, paths) = run_fetch(&server, true).await;
+
+        assert!(
+            paths.iter().any(|p| p == "/v3/search/works"),
+            "CORE was never consulted; paths were {paths:?}"
+        );
+        assert!(
+            paths.iter().any(|p| p == "/repo.pdf"),
+            "the copy CORE reported was never fetched; paths were {paths:?}; leg={:?}",
+            outcome.pdf_leg
+        );
+        assert!(
+            matches!(outcome.pdf_leg, PdfLegStatus::Fetched),
+            "the run should have recovered; got {:?}",
+            outcome.pdf_leg
+        );
+    }
+
+    /// The other half of the contract: with no flag set, behaviour is
+    /// unchanged. The fall-through must not spend a request the user did
+    /// not ask for.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn with_no_source_enabled_the_run_is_unchanged() {
+        let server = server_with_a_rate_limited_publisher_and_a_repository_copy().await;
+        let (outcome, paths) = run_fetch(&server, false).await;
+
+        assert!(
+            !paths.iter().any(|p| p == "/v3/search/works"),
+            "a disabled source must cost nothing; paths were {paths:?}"
+        );
+        assert!(
+            matches!(outcome.pdf_leg, PdfLegStatus::Blocked { .. }),
+            "without a fallback source this must still be Blocked; got {:?}",
+            outcome.pdf_leg
         );
     }
 }

--- a/crates/doiget-core/src/sources/core_oa.rs
+++ b/crates/doiget-core/src/sources/core_oa.rs
@@ -259,6 +259,21 @@ fn license_of(work: &serde_json::Value) -> String {
         .to_string()
 }
 
+/// The OA download location CORE reports for a work, if any (#445).
+///
+/// CORE's `downloadUrl` points at a repository host reached through the
+/// `oa-publisher` key, not this one — see the metadata-only contract in the
+/// module docs. This surfaces it so the OA chain can try it; the fetch is
+/// still performed by the `oa-publisher` leg, with its allowlist and its
+/// ADR-0023 denial context.
+#[must_use]
+pub fn open_access_pdf_url(record: &serde_json::Value) -> Option<&str> {
+    record
+        .get("downloadUrl")
+        .and_then(serde_json::Value::as_str)
+        .filter(|u| !u.is_empty())
+}
+
 fn truncate_for_hint(body: &[u8]) -> String {
     const MAX: usize = 200;
     let s = String::from_utf8_lossy(body);

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -232,6 +232,31 @@ pub fn first_str<'a>(doc: &'a serde_json::Value, field: &str) -> Option<&'a str>
     })
 }
 
+/// The OA file HAL reports for a deposit, if any (#445).
+///
+/// `fileMain_s` is the deposit's main document on `hal.science`, reached
+/// through the `oa-publisher` key (via `trust_oa_registries`) rather than
+/// this source's own key — the API host and the content host are separate
+/// allowlist entries on purpose.
+///
+/// Gated on `openAccess_bool`: HAL indexes closed deposits too, and a URL
+/// that resolves to a landing page behind a wall is worse than no URL,
+/// because the chain would spend a request and report a confusing failure.
+#[must_use]
+pub fn open_access_pdf_url(record: &serde_json::Value) -> Option<&str> {
+    if record
+        .get("openAccess_bool")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        return None;
+    }
+    record
+        .get("fileMain_s")
+        .and_then(serde_json::Value::as_str)
+        .filter(|u| !u.is_empty())
+}
+
 fn truncate_for_hint(body: &[u8]) -> String {
     const MAX: usize = 200;
     let s = String::from_utf8_lossy(body);

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -400,7 +400,8 @@ mod tests {
         let foreign = Ref::Doi(Doi::parse("10.1016/j.example.2024.001").expect("DOI parses"));
         assert!(
             !src.can_serve(&profile, &foreign),
-            "must NOT serve a Elsevier DOI even with a valid grant -- that              would disclose an unrelated lookup to American Physical Society (APS)"
+            "must NOT serve a Elsevier DOI even with a valid grant -- that would disclose an \
+                unrelated lookup to American Physical Society (APS)"
         );
 
         for p in PUBLISHER_PREFIXES {

--- a/crates/doiget-core/src/sources/tdm_elsevier.rs
+++ b/crates/doiget-core/src/sources/tdm_elsevier.rs
@@ -419,7 +419,8 @@ mod tests {
         let foreign = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
         assert!(
             !src.can_serve(&profile, &foreign),
-            "must NOT serve a APS DOI even with a valid grant -- that              would disclose an unrelated lookup to Elsevier BV"
+            "must NOT serve a APS DOI even with a valid grant -- that would disclose an \
+                unrelated lookup to Elsevier BV"
         );
 
         for p in PUBLISHER_PREFIXES {

--- a/crates/doiget-core/src/sources/tdm_springer.rs
+++ b/crates/doiget-core/src/sources/tdm_springer.rs
@@ -519,7 +519,8 @@ mod tests {
         let foreign = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
         assert!(
             !src.can_serve(&profile, &foreign),
-            "must NOT serve a APS DOI even with a valid grant -- that              would disclose an unrelated lookup to Springer Nature"
+            "must NOT serve a APS DOI even with a valid grant -- that would disclose an \
+                unrelated lookup to Springer Nature"
         );
 
         for p in PUBLISHER_PREFIXES {

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -172,6 +172,28 @@ asked" and from "wrong publisher".
 `DOIGET_SPRINGER_BASE` override the API base, mirroring `DOIGET_CROSSREF_BASE`.
 Intended for tests and for institutional proxies.
 
+### When the publisher refuses the content
+
+The OA chain already tries every location Unpaywall returned, advancing past
+each failure — a 429 on one host does not stop it. What it could not do was
+look beyond that list: when Crossref resolved the DOI, the optional sources
+were skipped entirely, so a rate limit on the single publisher URL ended a run
+with other indexes switched on (#445).
+
+If the content leg is still blocked after the arXiv preprint fallback
+(#325), doiget now asks the **enabled** optional sources whether anyone else
+holds a copy, and tries the document URL they report. Three of them publish
+one: CORE (`downloadUrl`), HAL (`fileMain_s`, gated on `openAccess_bool`) and
+Europe PMC (`fullTextUrlList`). OpenAIRE and DataCite report a DOI resolver or
+a landing page rather than a file, so they contribute no URL — their outcome
+still appears in the attempt trace.
+
+The fetch itself stays on the `oa-publisher` leg, with its allowlist and its
+ADR-0023 denial context, exactly as each source's own docs describe.
+
+This costs a request only when the content leg has **already** failed and the
+user has switched a source on. With no flags set, behaviour is unchanged.
+
 ## 5. Adding a new source
 
 A new source addition requires:

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -178,6 +178,28 @@ asked" and from "wrong publisher".
 `DOIGET_SPRINGER_BASE` override the API base, mirroring `DOIGET_CROSSREF_BASE`.
 Intended for tests and for institutional proxies.
 
+### When the publisher refuses the content
+
+The OA chain already tries every location Unpaywall returned, advancing past
+each failure — a 429 on one host does not stop it. What it could not do was
+look beyond that list: when Crossref resolved the DOI, the optional sources
+were skipped entirely, so a rate limit on the single publisher URL ended a run
+with other indexes switched on (#445).
+
+If the content leg is still blocked after the arXiv preprint fallback
+(#325), doiget now asks the **enabled** optional sources whether anyone else
+holds a copy, and tries the document URL they report. Three of them publish
+one: CORE (`downloadUrl`), HAL (`fileMain_s`, gated on `openAccess_bool`) and
+Europe PMC (`fullTextUrlList`). OpenAIRE and DataCite report a DOI resolver or
+a landing page rather than a file, so they contribute no URL — their outcome
+still appears in the attempt trace.
+
+The fetch itself stays on the `oa-publisher` leg, with its allowlist and its
+ADR-0023 denial context, exactly as each source's own docs describe.
+
+This costs a request only when the content leg has **already** failed and the
+user has switched a source on. With no flags set, behaviour is unchanged.
+
 ## 5. Adding a new source
 
 A new source addition requires:


### PR DESCRIPTION
Closes #445 (the behaviour half; the reporting half landed in #448).

## The diagnosis in the issue was half right

> A content-leg failure does not fall through to the next source

The OA chain **does** advance past every candidate failure, 429 included — that loop was already there. What it cannot do is look beyond Unpaywall's list. Crossref had answered, so the optional chain was skipped entirely (`NotNeeded`), and one rate-limited AMS URL was the whole candidate set.

So the fix is not "add 429 to the trigger list". It is: when the content leg is exhausted, **ask whoever else is switched on**.

## The parts that already existed

Three sources surface a document URL, and each module's own docs say the fetch belongs to the `oa-publisher` leg:

```rust
/// The URL is handed to the existing `oa-publisher` fetch leg rather than
/// downloaded here; see the module docs for why ...
pub fn open_access_pdf_url(record: &serde_json::Value) -> Option<&str>
```

`grep -rn open_access_pdf_url crates/ | grep -v europepmc.rs` → **nothing**. Written for exactly this, never called. Third instance this cycle of designed-documented-never-wired, after #438 and #442.

| source | field | contributes |
|---|---|---|
| Europe PMC | `fullTextUrlList` | yes (accessor already existed) |
| CORE | `downloadUrl` | yes (added) |
| HAL | `fileMain_s`, gated on `openAccess_bool` | yes (added) |
| OpenAIRE | `urls[]` → DOI resolver | **no** |
| DataCite | `url` → landing page | **no** |

The last two are a deliberate refusal to guess: neither points at a file, and handing the chain a landing page spends a request to reach something it cannot read. Not silent — they still appear in the attempt trace with their own outcome.

HAL's gate matters for the same reason: HAL indexes closed deposits, and a URL that lands on a wall is worse than no URL.

## Additive by construction

- Runs **last**, after the #325 arXiv fallback, so every run that succeeded before succeeds by the same route.
- Costs a request only when the content leg has **already** failed and a flag is on.
- A failure of the alternative copy keeps the **original** block — the publisher's 429 is what the user needs to see; a repository's second failure would bury it.

## Tests assert reach, not outcome

`Fetched` alone would not say which route produced it. The positive test requires the mock to record **both** the CORE query and the fetch of the copy CORE reported:

```
paths must contain /v3/search/works   ← CORE was consulted
paths must contain /repo.pdf          ← its copy was actually fetched
pdf_leg == Fetched
```

Mutation-verified:

```
a_rate_limited_publisher_falls_through_to_an_enabled_source ... FAILED
  CORE was never consulted; paths were ["/works/...", "/10.1090%2Fexample",
    "/blocked.pdf", "/blocked.pdf", "/blocked.pdf", "/blocked.pdf"]
with_no_source_enabled_the_run_is_unchanged                 ... ok
```

The negative control is the other half of the contract: with no flag set, the run must be **byte-identical** — same Blocked outcome, and no request to CORE at all.

```
oa-only        passed=811 failed=0
metadata (lib) passed=496 failed=0
clippy / rustdoc, both surfaces: GREEN
```

## Observation, not fixed here

The mutation output above shows `/blocked.pdf` fetched **four times**. The HTTP layer retries a 429 against the same host three times before giving up. Retrying a rate limit on the same host is the one case where backing off to a different source is the better move, and it also costs ~8s of wall clock in the test. Existing behaviour, out of scope for this diff — say the word and I will file it.