### PR TITLE
fix(transport): register the Tier-3 allowlists in the production HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.6"
+version = "0.8.9-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.6"
+version = "0.8.9-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.6"
+version = "0.8.9-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.6"
+version       = "0.8.9-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -24,9 +24,12 @@ default  = ["oa-only"]
 oa-only  = ["doiget-core/oa-only"]
 metadata = ["doiget-core/metadata"]
 citation = ["doiget-core/citation"]
-tdm-elsevier = ["doiget-core/tdm-elsevier"]
-tdm-aps      = ["doiget-core/tdm-aps"]
-tdm-springer = ["doiget-core/tdm-springer"]
+# The `doiget-mcp/*` half matters: `doiget serve` builds its client
+# through the MCP twin of `build_http_client`, so a CLI-only feature
+# would leave the MCP surface without the Tier-3 transport gate (#454).
+tdm-elsevier = ["doiget-core/tdm-elsevier", "doiget-mcp/tdm-elsevier"]
+tdm-aps      = ["doiget-core/tdm-aps", "doiget-mcp/tdm-aps"]
+tdm-springer = ["doiget-core/tdm-springer", "doiget-mcp/tdm-springer"]
 
 [dependencies]
 doiget-core        = { workspace = true }

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1360,6 +1360,7 @@ mod tests {
         feature = "tdm-elsevier",
         feature = "tdm-springer"
     ))]
+    #[allow(clippy::vec_init_then_push)]
     fn the_production_client_registers_every_tier_3_source_key() {
         // Every base override must be clear or `build_http_client` takes
         // the test-mode branch, which registers whatever it is given and
@@ -1382,23 +1383,27 @@ mod tests {
 
         let client = build_http_client(None).expect("production client builds");
 
-        let mut checked = 0_usize;
-        for key in [
-            #[cfg(feature = "tdm-aps")]
-            "tdm-aps",
-            #[cfg(feature = "tdm-elsevier")]
-            "tdm-elsevier",
-            #[cfg(feature = "tdm-springer")]
-            "tdm-springer",
-        ] {
+        // Built by push rather than an array literal: with a single
+        // `tdm-*` feature compiled the literal is a one-element loop,
+        // which clippy denies. Same shape as `tier_3_allowlists()`,
+        // and the `vec_init_then_push` allow is on the fn for the same
+        // reason it is there — the pushes are `#[cfg]`-gated, so an
+        // attribute per element is not expressible.
+        let mut keys: Vec<&str> = Vec::new();
+        #[cfg(feature = "tdm-aps")]
+        keys.push("tdm-aps");
+        #[cfg(feature = "tdm-elsevier")]
+        keys.push("tdm-elsevier");
+        #[cfg(feature = "tdm-springer")]
+        keys.push("tdm-springer");
+        assert!(!keys.is_empty(), "the guard must have checked something");
+        for key in keys {
             assert!(
                 client.source_allowlist(key).is_some(),
                 "the production client has no allowlist for `{key}`; the orchestrator \
                  reaches this source and the fetch would die at UnknownSource (#454)"
             );
-            checked += 1;
         }
-        assert!(checked > 0, "the guard must have checked something");
     }
 
     #[test]

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -49,7 +49,8 @@ use super::output::print_err;
 #[cfg(feature = "citation")]
 use doiget_core::http::tier_2_allowlist;
 use doiget_core::http::{
-    discovery_allowlist, fulltext_allowlist, oa_publisher_allowlist, tier_1_allowlist, HttpClient,
+    discovery_allowlist, fulltext_allowlist, oa_publisher_allowlist, tier_1_allowlist,
+    tier_3_allowlists, HttpClient,
 };
 use doiget_core::orchestrator::{
     fetch_paper as core_fetch_paper, FetchPaperOutcome, PdfLegStatus, SourceAttempt,
@@ -265,6 +266,13 @@ pub(crate) fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> 
         // the runtime gate; the allowlist is the transport gate.
         #[cfg(feature = "citation")]
         allowlists.extend(tier_2_allowlist());
+        // #454: the Tier-3 transport gate. #444 made the orchestrator
+        // reach these sources; without this line the fetch it then issues
+        // under `tdm-aps` / `tdm-elsevier` / `tdm-springer` dies at
+        // `UnknownSource`. Empty in a default build (ADR-0002 — no Tier-3
+        // feature is compiled into published binaries), so this is a
+        // no-op for the shipped surface.
+        allowlists.extend(tier_3_allowlists());
 
         // ADR-0028 D2: merge user-extension hosts from
         // `<config_dir>/doiget/config.toml`. See
@@ -1308,6 +1316,91 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    /// Save an env var and restore it on drop.
+    ///
+    /// Both client-builder tests below have to clear the
+    /// `DOIGET_*_BASE` overrides to reach the production branch, and
+    /// leaving one cleared would silently reroute an unrelated test.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+    impl EnvGuard {
+        fn save(key: &'static str) -> Self {
+            Self {
+                key,
+                prev: std::env::var(key).ok(),
+            }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    /// #454: the guard the list-level one in `http.rs` cannot be.
+    ///
+    /// `every_tier_3_source_has_a_transport_allowlist_entry` asserts that
+    /// `tier_3_aps_allowlist()` *contains* `"tdm-aps"`. It says nothing
+    /// about whether anything hands that list to a client, and for three
+    /// releases nothing did — so the assertion passed while a production
+    /// fetch returned `UnknownSource { source_key: "tdm-aps" }`.
+    ///
+    /// This asserts the object the fetch actually goes through. It cannot
+    /// pass for the reason that one did, because there is no list here to
+    /// be right about in isolation.
+    #[test]
+    #[serial]
+    #[cfg(any(
+        feature = "tdm-aps",
+        feature = "tdm-elsevier",
+        feature = "tdm-springer"
+    ))]
+    fn the_production_client_registers_every_tier_3_source_key() {
+        // Every base override must be clear or `build_http_client` takes
+        // the test-mode branch, which registers whatever it is given and
+        // would prove nothing.
+        let _g: Vec<EnvGuard> = [
+            "DOIGET_ARXIV_BASE",
+            "DOIGET_CROSSREF_BASE",
+            "DOIGET_UNPAYWALL_BASE",
+            "DOIGET_OA_PUBLISHER_BASE",
+            "DOIGET_OPENALEX_BASE",
+            "DOIGET_AR5IV_BASE",
+        ]
+        .iter()
+        .map(|k| {
+            let g = EnvGuard::save(k);
+            std::env::remove_var(k);
+            g
+        })
+        .collect();
+
+        let client = build_http_client(None).expect("production client builds");
+
+        let mut checked = 0_usize;
+        for key in [
+            #[cfg(feature = "tdm-aps")]
+            "tdm-aps",
+            #[cfg(feature = "tdm-elsevier")]
+            "tdm-elsevier",
+            #[cfg(feature = "tdm-springer")]
+            "tdm-springer",
+        ] {
+            assert!(
+                client.source_allowlist(key).is_some(),
+                "the production client has no allowlist for `{key}`; the orchestrator \
+                 reaches this source and the fetch would die at UnknownSource (#454)"
+            );
+            checked += 1;
+        }
+        assert!(checked > 0, "the guard must have checked something");
+    }
+
     #[test]
     fn new_session_id_is_26_chars() {
         // ULID textual form is fixed-width 26 chars (Crockford base32).
@@ -1355,29 +1448,10 @@ host = "*.uj.edu.pl"
         drop(f);
 
         // Save + override env so `config_dir_utf8()` lands on the
-        // tempdir. Restored on Drop by EnvGuard. We also clear the
+        // tempdir. Restored on Drop by `EnvGuard` (module-level since
+        // #454, which needed the same save/restore). We also clear the
         // five `DOIGET_*_BASE` env vars to force the production
         // branch of `build_http_client`.
-        struct EnvGuard {
-            key: &'static str,
-            prev: Option<String>,
-        }
-        impl EnvGuard {
-            fn save(key: &'static str) -> Self {
-                Self {
-                    key,
-                    prev: std::env::var(key).ok(),
-                }
-            }
-        }
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                match &self.prev {
-                    Some(v) => std::env::set_var(self.key, v),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
         let _g0 = EnvGuard::save("XDG_CONFIG_HOME");
         let _g1 = EnvGuard::save("APPDATA");
         let _g2 = EnvGuard::save("HOME");

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -387,6 +387,34 @@ pub fn tier_3_elsevier_allowlist() -> Vec<SourceAllowlist> {
     )]
 }
 
+/// Every Tier-3 TDM allowlist this build actually compiled in.
+///
+/// #454: the three per-publisher builders above had no caller. Both client
+/// builders — `doiget_cli::commands::fetch::build_http_client` and its MCP
+/// twin — assemble the client by naming a list of allowlist functions, and
+/// neither named these. So #444 taught the orchestrator to reach the
+/// sources and the transport then refused a source key it had never been
+/// told about: `UnknownSource { source_key: "tdm-aps" }`, which reads like
+/// an internal error rather than a missing registration.
+///
+/// One function rather than three `#[cfg]` blocks at each call site: a
+/// fourth publisher is then a single edit here, and the two client builders
+/// cannot drift apart — which is the drift that produced this bug.
+///
+/// Empty in a default build, where no Tier-3 feature is compiled in.
+#[must_use]
+pub fn tier_3_allowlists() -> Vec<SourceAllowlist> {
+    #[allow(unused_mut)]
+    let mut out: Vec<SourceAllowlist> = Vec::new();
+    #[cfg(feature = "tdm-aps")]
+    out.extend(tier_3_aps_allowlist());
+    #[cfg(feature = "tdm-elsevier")]
+    out.extend(tier_3_elsevier_allowlist());
+    #[cfg(feature = "tdm-springer")]
+    out.extend(tier_3_springer_allowlist());
+    out
+}
+
 /// Hard-coded Phase 1 allowlist for the synthetic `"oa-publisher"` source —
 /// the publisher / preprint / repository hosts to which Unpaywall's
 /// `best_oa_location.url` (or `url_for_pdf`) typically resolves.
@@ -1426,6 +1454,16 @@ mod tests {
     /// because `new_for_tests_allow_http` registers the key itself — the
     /// DataCite near-miss in 0.8.8. Now that Tier 3 is actually reached,
     /// the same trap applies to it.
+    ///
+    /// **This guard is necessary and not sufficient**, and #454 is the
+    /// proof: it asserts the builder *returns* the key, which stayed true
+    /// for three releases while no client was ever handed the list, so a
+    /// production fetch died at exactly the `UnknownSource` described
+    /// above. The sufficient half is
+    /// `the_production_client_registers_every_tier_3_source_key`, in
+    /// `doiget-cli` and `doiget-mcp` — it asserts the client, which is the
+    /// object the fetch goes through. Keep both: this one localises the
+    /// failure to the list, that one catches the list never arriving.
     #[cfg(any(
         feature = "tdm-aps",
         feature = "tdm-elsevier",

--- a/crates/doiget-mcp/Cargo.toml
+++ b/crates/doiget-mcp/Cargo.toml
@@ -24,6 +24,14 @@ default = []
 # advertises 12 tools instead of 13 in that build.
 citation = ["doiget-core/citation"]
 
+# Tier 3 — opt-in build only, never published (ADR-0002). doiget-mcp has
+# no TDM code of its own; these exist so `build_http_client_for_fetch`
+# compiles the same Tier-3 transport registration the CLI does, and so
+# the #454 guard over that registration is compiled at all.
+tdm-elsevier = ["doiget-core/tdm-elsevier"]
+tdm-aps      = ["doiget-core/tdm-aps"]
+tdm-springer = ["doiget-core/tdm-springer"]
+
 [dependencies]
 doiget-core        = { workspace = true }
 tokio              = { workspace = true }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -47,7 +47,8 @@ use doiget_core::dry_run::{
     build_dry_run_envelope, build_fetch_plan, rate_limit_budget as core_rate_limit_budget,
 };
 use doiget_core::http::{
-    fulltext_allowlist, oa_publisher_allowlist, tier_1_allowlist, tier_2_allowlist, HttpClient,
+    fulltext_allowlist, oa_publisher_allowlist, tier_1_allowlist, tier_2_allowlist,
+    tier_3_allowlists, HttpClient,
 };
 use doiget_core::orchestrator::{
     batch_fetch as core_batch_fetch, batch_fetch_plans, fetch_paper as core_fetch_paper,
@@ -3758,6 +3759,10 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
         // OA, always-on. Register `ar5iv.labs.arxiv.org` under the
         // `"ar5iv"` source key so `paper_text::paper_text` can reach it.
         allowlists.extend(fulltext_allowlist());
+        // #454: the Tier-3 transport gate, mirroring the CLI builder.
+        // Empty in a default build; the `CapabilityProfile` grant is
+        // still what decides whether a TDM source is ever called.
+        allowlists.extend(tier_3_allowlists());
 
         // ADR-0028 D2: merge user-extension hosts from
         // `<config_dir>/doiget/config.toml`. Mirrors the CLI path in
@@ -4422,6 +4427,53 @@ mod tests {
              got: {:?}",
             oa.redirect_hosts
         );
+    }
+
+    /// #454: the MCP half of the Tier-3 transport gate.
+    ///
+    /// `build_http_client_for_fetch` is a hand-maintained twin of the CLI
+    /// builder, and the two drifting is what left the Tier-3 allowlists
+    /// with no caller in either. A guard in only one crate would let them
+    /// drift again in the other.
+    #[test]
+    #[serial_test::serial]
+    #[cfg(any(
+        feature = "tdm-aps",
+        feature = "tdm-elsevier",
+        feature = "tdm-springer"
+    ))]
+    fn the_production_client_registers_every_tier_3_source_key() {
+        // Any base override takes the test-mode branch, which registers
+        // whatever it is handed and would prove nothing.
+        let _guards = [
+            EnvGuard::unset("DOIGET_ARXIV_BASE"),
+            EnvGuard::unset("DOIGET_ARXIV_SRC_BASE"),
+            EnvGuard::unset("DOIGET_CROSSREF_BASE"),
+            EnvGuard::unset("DOIGET_UNPAYWALL_BASE"),
+            EnvGuard::unset("DOIGET_OA_PUBLISHER_BASE"),
+            EnvGuard::unset("DOIGET_OPENALEX_BASE"),
+            EnvGuard::unset("DOIGET_AR5IV_BASE"),
+        ];
+
+        let client = build_http_client_for_fetch().expect("production client builds");
+
+        let mut checked = 0_usize;
+        for key in [
+            #[cfg(feature = "tdm-aps")]
+            "tdm-aps",
+            #[cfg(feature = "tdm-elsevier")]
+            "tdm-elsevier",
+            #[cfg(feature = "tdm-springer")]
+            "tdm-springer",
+        ] {
+            assert!(
+                client.source_allowlist(key).is_some(),
+                "the production MCP client has no allowlist for `{key}`; a TDM fetch \
+                 would die at UnknownSource (#454)"
+            );
+            checked += 1;
+        }
+        assert!(checked > 0, "the guard must have checked something");
     }
 
     /// Set XDG_CONFIG_HOME / APPDATA / HOME / USERPROFILE so

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4442,6 +4442,7 @@ mod tests {
         feature = "tdm-elsevier",
         feature = "tdm-springer"
     ))]
+    #[allow(clippy::vec_init_then_push)]
     fn the_production_client_registers_every_tier_3_source_key() {
         // Any base override takes the test-mode branch, which registers
         // whatever it is handed and would prove nothing.
@@ -4457,23 +4458,27 @@ mod tests {
 
         let client = build_http_client_for_fetch().expect("production client builds");
 
-        let mut checked = 0_usize;
-        for key in [
-            #[cfg(feature = "tdm-aps")]
-            "tdm-aps",
-            #[cfg(feature = "tdm-elsevier")]
-            "tdm-elsevier",
-            #[cfg(feature = "tdm-springer")]
-            "tdm-springer",
-        ] {
+        // Built by push rather than an array literal: with a single
+        // `tdm-*` feature compiled the literal is a one-element loop,
+        // which clippy denies. Same shape as `tier_3_allowlists()`,
+        // and the `vec_init_then_push` allow is on the fn for the same
+        // reason it is there — the pushes are `#[cfg]`-gated, so an
+        // attribute per element is not expressible.
+        let mut keys: Vec<&str> = Vec::new();
+        #[cfg(feature = "tdm-aps")]
+        keys.push("tdm-aps");
+        #[cfg(feature = "tdm-elsevier")]
+        keys.push("tdm-elsevier");
+        #[cfg(feature = "tdm-springer")]
+        keys.push("tdm-springer");
+        assert!(!keys.is_empty(), "the guard must have checked something");
+        for key in keys {
             assert!(
                 client.source_allowlist(key).is_some(),
                 "the production MCP client has no allowlist for `{key}`; a TDM fetch \
                  would die at UnknownSource (#454)"
             );
-            checked += 1;
         }
-        assert!(checked > 0, "the guard must have checked something");
     }
 
     /// Set XDG_CONFIG_HOME / APPDATA / HOME / USERPROFILE so


### PR DESCRIPTION
Closes #454. Unblocks #430.

## The bug

The three Tier-3 allowlist builders had no caller. `build_http_client` and its MCP twin both assemble the client by naming a list of builders, and neither named these — so the production client had no entry under the `tdm-*` source keys.

```
fetch_bytes("tdm-aps", ..) -> UnknownSource { source_key: "tdm-aps" }
```

#444 made the orchestrator *reach* the three sources. The transport gate they then have to pass was never opened. A user who compiles the feature, obtains a key and signs the agreement still cannot fetch, and `UnknownSource` reads like an internal error rather than a missing registration.

Third instance of this shape after #442 and #438, and the reason it survived all three is the same each time: the thing that was tested was not the thing production runs.

## The fix

One `doiget_core::http::tier_3_allowlists()` — the union of whichever Tier-3 features compiled — extended into both builders. Not three `#[cfg]` blocks at each of two call sites: the two builders drifting apart is exactly what produced this, and a fourth publisher is now a single edit in one place.

Empty in a default build (ADR-0002 — no Tier-3 feature reaches a published binary), so the shipped surface is byte-identical.

## Why the existing guard did not catch it, and what the new one does differently

`every_tier_3_source_has_a_transport_allowlist_entry` asserts that `tier_3_aps_allowlist()` **contains** `"tdm-aps"`. That was true the whole time. Its own doc comment names the trap it does not catch:

> fails `UnknownSource` in production while every unit test passes, because `new_for_tests_allow_http` registers the key itself

It describes the failure it cannot see. The list-level guard is necessary and not sufficient, and that comment now says so.

The new guard asserts the **client** — the object the fetch actually goes through — and so cannot pass for that reason, because there is no list in it to be right about in isolation. It lives in **both** `doiget-cli` and `doiget-mcp`: a guard in one crate would let the hand-maintained twins drift again in the other.

Mutation-verified — with the two `extend` calls removed:

```
the_production_client_registers_every_tier_3_source_key ... FAILED
  the production client has no allowlist for `tdm-aps`; the orchestrator
  reaches this source and the fetch would die at UnknownSource (#454)
```

and green with them restored, in both crates.

## Feature plumbing

`doiget-mcp` gains `tdm-elsevier` / `tdm-aps` / `tdm-springer` passthroughs, and `doiget-cli` forwards to them. Without this the MCP half of the guard is `#[cfg]`-ed out and never compiles — and more to the point, `doiget serve` builds its client through the MCP twin, so a CLI-only feature would leave the MCP surface without the Tier-3 transport gate.

## Checks

```
fmt / clippy (oa-only)                                  GREEN
clippy (oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer)  GREEN
test  (oa-only)                                         0 failures
test  (oa-only,metadata,tdm-*)                          0 failures
```