### PR TITLE
feat(source): IEEE Xplore TDM, opt-in, against an inferred contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           # have rotted silently. The union matches the documented install
           # shape (`SOURCES.md` §3); the singleton proves `tdm-*` does not
           # secretly depend on `metadata`.
-          - "oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer"
+          - "oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee"
           - "oa-only,tdm-aps"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -115,7 +115,7 @@ jobs:
       # tdm_springer / tdm_aps / tdm_elsevier) ran in NO CI job before this.
       # They are the only thing standing between a credential-handling
       # source and a silent regression, so they have to actually run.
-      - run: cargo test --workspace --all-targets --no-default-features --features oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer
+      - run: cargo test --workspace --all-targets --no-default-features --features oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee
 
   msrv:
     # MSRV is pinned in rust-toolchain.toml / Cargo.toml; the job name
@@ -150,4 +150,4 @@ jobs:
       # Same reasoning for Tier 3: these modules carry the longest
       # doc-comments in the tree (three-gate activation, credential
       # hygiene) and none of it was ever rendered.
-      - run: cargo doc --workspace --no-deps --no-default-features --features oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer
+      - run: cargo doc --workspace --no-deps --no-default-features --features oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Generate workspace coverage (lcov)
-        run: cargo llvm-cov --workspace --locked --features tdm-aps,tdm-elsevier,tdm-springer --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --locked --features tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.7"
+version = "0.8.9-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.7"
+version = "0.8.9-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.7"
+version = "0.8.9-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.7"
+version       = "0.8.9-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -32,7 +32,7 @@ readme        = "README.md"
 # - Tier 1 (Open Access)            : always compiled in.
 # - Tier 2 metadata (Phase 4)       : `metadata`.
 # - Tier 3 TDM (Phase 5, opt-in build, never in published binaries):
-#     `tdm-elsevier`, `tdm-aps`, `tdm-springer`. No `tdm-all` umbrella.
+#     `tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`. No `tdm-all` umbrella.
 #
 # See docs/SCOPE.md and docs/SOURCES.md.
 # ---------------------------------------------------------------------

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -30,6 +30,7 @@ citation = ["doiget-core/citation"]
 tdm-elsevier = ["doiget-core/tdm-elsevier", "doiget-mcp/tdm-elsevier"]
 tdm-aps      = ["doiget-core/tdm-aps", "doiget-mcp/tdm-aps"]
 tdm-springer = ["doiget-core/tdm-springer", "doiget-mcp/tdm-springer"]
+tdm-ieee     = ["doiget-core/tdm-ieee", "doiget-mcp/tdm-ieee"]
 
 [dependencies]
 doiget-core        = { workspace = true }

--- a/crates/doiget-cli/src/commands/capabilities.rs
+++ b/crates/doiget-cli/src/commands/capabilities.rs
@@ -639,6 +639,9 @@ fn compile_time_features() -> Vec<&'static str> {
     if cfg!(feature = "tdm-springer") {
         feats.push("tdm-springer");
     }
+    if cfg!(feature = "tdm-ieee") {
+        feats.push("tdm-ieee");
+    }
     feats
 }
 

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1358,7 +1358,8 @@ mod tests {
     #[cfg(any(
         feature = "tdm-aps",
         feature = "tdm-elsevier",
-        feature = "tdm-springer"
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
     ))]
     #[allow(clippy::vec_init_then_push)]
     fn the_production_client_registers_every_tier_3_source_key() {
@@ -1396,6 +1397,8 @@ mod tests {
         keys.push("tdm-elsevier");
         #[cfg(feature = "tdm-springer")]
         keys.push("tdm-springer");
+        #[cfg(feature = "tdm-ieee")]
+        keys.push("tdm-ieee");
         assert!(!keys.is_empty(), "the guard must have checked something");
         for key in keys {
             assert!(

--- a/crates/doiget-core/Cargo.toml
+++ b/crates/doiget-core/Cargo.toml
@@ -25,6 +25,7 @@ citation = ["metadata"]
 tdm-elsevier = ["dep:secrecy"]
 tdm-aps      = ["dep:secrecy"]
 tdm-springer = ["dep:secrecy"]
+tdm-ieee     = ["dep:secrecy"]
 
 [dependencies]
 tokio       = { workspace = true }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -387,6 +387,36 @@ pub fn tier_3_elsevier_allowlist() -> Vec<SourceAllowlist> {
     )]
 }
 
+/// Hard-coded allowlist for the IEEE Xplore TDM source (#430).
+/// Compile-gated by the `tdm-ieee` Cargo feature so default release
+/// binaries never include the host pattern (per ADR-0002 and
+/// `docs/SOURCES.md` §3).
+///
+/// Returned entry:
+/// - `"tdm-ieee"` → `ieeexploreapi.ieee.org` (production base) +
+///   `*.ieee.org` (covers load-balancing subdomains; the redirect
+///   closure denies anything outside the wildcard).
+///
+/// Note the API host is deliberately NOT `ieeexplore.ieee.org`, the web
+/// front end: ADR-0039 records that the front end answers a scripted
+/// client with `202` and an empty body regardless of entitlement, which
+/// is why the TDM API is the supported route at all.
+///
+/// Three-gate activation: Cargo feature compiled in, `DOIGET_KEY_IEEE`
+/// env var present, and `DOIGET_AGREE_TDM_IEEE=1`. The
+/// `CapabilityProfile` gate enforces the env-var pair; this allowlist is
+/// the transport gate.
+#[cfg(feature = "tdm-ieee")]
+pub fn tier_3_ieee_allowlist() -> Vec<SourceAllowlist> {
+    vec![SourceAllowlist::new(
+        "tdm-ieee",
+        vec![
+            "ieeexploreapi.ieee.org".to_string(),
+            "*.ieee.org".to_string(),
+        ],
+    )]
+}
+
 /// Every Tier-3 TDM allowlist this build actually compiled in.
 ///
 /// #454: the three per-publisher builders above had no caller. Both client
@@ -412,6 +442,8 @@ pub fn tier_3_allowlists() -> Vec<SourceAllowlist> {
     out.extend(tier_3_elsevier_allowlist());
     #[cfg(feature = "tdm-springer")]
     out.extend(tier_3_springer_allowlist());
+    #[cfg(feature = "tdm-ieee")]
+    out.extend(tier_3_ieee_allowlist());
     out
 }
 
@@ -1109,15 +1141,20 @@ impl HttpClient {
 /// secret in the query string. Other pairs and their order are
 /// preserved; a URL with no `api_key` pair is rendered unchanged.
 fn redact_api_key_query(url: &url::Url) -> String {
-    const API_KEY_PARAM: &str = "api_key";
-    if url.query_pairs().all(|(k, _)| k != API_KEY_PARAM) {
+    /// Every spelling a source puts a secret under. Springer uses
+    /// `api_key`; IEEE (#430) uses `apikey`, one word. A source that
+    /// invents a third spelling and does not add it here leaks its key
+    /// into `HttpError::HttpStatus`, which is `tracing`-logged.
+    const API_KEY_PARAMS: &[&str] = &["api_key", "apikey"];
+    let is_secret = |k: &str| API_KEY_PARAMS.contains(&k);
+    if url.query_pairs().all(|(k, _)| !is_secret(&k)) {
         return url.to_string();
     }
     let mut redacted = url.clone();
     let pairs: Vec<(String, String)> = url
         .query_pairs()
         .map(|(k, v)| {
-            if k == API_KEY_PARAM {
+            if is_secret(&k) {
                 (k.into_owned(), "REDACTED".to_string())
             } else {
                 (k.into_owned(), v.into_owned())
@@ -1467,7 +1504,8 @@ mod tests {
     #[cfg(any(
         feature = "tdm-aps",
         feature = "tdm-elsevier",
-        feature = "tdm-springer"
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
     ))]
     #[test]
     fn every_tier_3_source_has_a_transport_allowlist_entry() {
@@ -1514,6 +1552,21 @@ mod tests {
             assert!(
                 reg.iter().any(|r| r == src.name()),
                 "source `{}` has no tier_3_springer_allowlist entry; a production fetch would \
+                    fail UnknownSource. registered: {reg:?}",
+                src.name()
+            );
+            checked += 1;
+        }
+        #[cfg(feature = "tdm-ieee")]
+        {
+            let src = crate::sources::tdm_ieee::TdmIeeeSource::new();
+            let reg: Vec<String> = tier_3_ieee_allowlist()
+                .iter()
+                .map(|a| a.source.clone())
+                .collect();
+            assert!(
+                reg.iter().any(|r| r == src.name()),
+                "source `{}` has no tier_3_ieee_allowlist entry; a production fetch would \
                     fail UnknownSource. registered: {reg:?}",
                 src.name()
             );

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1080,6 +1080,8 @@ pub struct CapabilityProfile {
     pub tdm_aps: Option<TdmGrant>,
     /// Tier 3 grants are populated only when both env var and feature compile-in are set.
     pub tdm_springer: Option<TdmGrant>,
+    /// Tier 3 grants are populated only when both env var and feature compile-in are set.
+    pub tdm_ieee: Option<TdmGrant>,
     /// Hard-coded rate limits for this process.
     pub rate_limits: RateLimits,
 }
@@ -1230,6 +1232,12 @@ impl CapabilityProfile {
             "tdm-springer",
             cfg!(feature = "tdm-springer"),
         )?;
+        let tdm_ieee = resolve_tdm_grant(
+            "DOIGET_AGREE_TDM_IEEE",
+            "DOIGET_KEY_IEEE",
+            "tdm-ieee",
+            cfg!(feature = "tdm-ieee"),
+        )?;
 
         Ok(Self {
             oa: AlwaysOn,
@@ -1237,6 +1245,7 @@ impl CapabilityProfile {
             tdm_elsevier,
             tdm_aps,
             tdm_springer,
+            tdm_ieee,
             rate_limits: RateLimits::HARD_CODED,
         })
     }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -3726,6 +3726,11 @@ async fn resolve_tdm_chain(
         crate::sources::tdm_springer::TdmSpringerSource::new,
         crate::sources::tdm_springer::TdmSpringerSource::with_base,
     );
+    #[cfg(feature = "tdm-ieee")]
+    let ieee = optional_base("DOIGET_IEEE_BASE").map_or_else(
+        crate::sources::tdm_ieee::TdmIeeeSource::new,
+        crate::sources::tdm_ieee::TdmIeeeSource::with_base,
+    );
 
     // Not a `vec![]` literal: each entry is `#[cfg]`-gated on its own
     // publisher feature, and attribute-per-element inside a vec literal
@@ -3755,6 +3760,14 @@ async fn resolve_tdm_chain(
         prefixes: crate::sources::tdm_springer::PUBLISHER_PREFIXES,
         publisher: "Springer Nature",
         src: &springer,
+    });
+    #[cfg(feature = "tdm-ieee")]
+    chain.push(Entry {
+        name: "tdm-ieee",
+        enable_hint: "DOIGET_KEY_IEEE + DOIGET_AGREE_TDM_IEEE",
+        prefixes: crate::sources::tdm_ieee::PUBLISHER_PREFIXES,
+        publisher: "IEEE",
+        src: &ieee,
     });
 
     let mut resolved: Option<Value> = None;
@@ -4218,7 +4231,8 @@ mod chain_tests {
     test,
     feature = "tdm-aps",
     feature = "tdm-elsevier",
-    feature = "tdm-springer"
+    feature = "tdm-springer",
+    feature = "tdm-ieee"
 ))]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tdm_chain_tests {
@@ -4245,6 +4259,7 @@ mod tdm_chain_tests {
                 "DOIGET_APS_BASE",
                 "DOIGET_ELSEVIER_BASE",
                 "DOIGET_SPRINGER_BASE",
+                "DOIGET_IEEE_BASE",
             ];
             Self(
                 VARS.iter()
@@ -4309,6 +4324,7 @@ mod tdm_chain_tests {
             ("tdm-aps", host),
             ("tdm-elsevier", host),
             ("tdm-springer", host),
+            ("tdm-ieee", host),
         ]));
         let session_id = "01J0000000000000000000TDM".to_string();
         let log = Arc::new(
@@ -4339,6 +4355,7 @@ mod tdm_chain_tests {
         p.tdm_aps = Some(grant("DOIGET_AGREE_TDM_APS"));
         p.tdm_elsevier = Some(grant("DOIGET_AGREE_TDM_ELSEVIER"));
         p.tdm_springer = Some(grant("DOIGET_AGREE_TDM_SPRINGER"));
+        p.tdm_ieee = Some(grant("DOIGET_AGREE_TDM_IEEE"));
         p
     }
 
@@ -4347,6 +4364,7 @@ mod tdm_chain_tests {
         p.tdm_aps = None;
         p.tdm_elsevier = None;
         p.tdm_springer = None;
+        p.tdm_ieee = None;
         p
     }
 
@@ -4368,6 +4386,10 @@ mod tdm_chain_tests {
             ("10.1103/PhysRevX.10.011001", "tdm-aps"),
             ("10.1016/j.example.2024.001", "tdm-elsevier"),
             ("10.1007/s00220-024-05001-x", "tdm-springer"),
+            ("10.1109/TSP.2018.2812747", "tdm-ieee"),
+            // The conference prefix, which is half of what #407 measured
+            // and the half most likely to be dropped by a later edit.
+            ("10.23919/example.2024.001", "tdm-ieee"),
         ] {
             let server = MockServer::start().await;
             Mock::given(method("GET"))
@@ -4404,16 +4426,19 @@ mod tdm_chain_tests {
         let _bases = BaseGuard::to(&server.uri());
         let (_td, ctx) = ctx_for(&server.address().to_string());
 
-        // An IEEE DOI: no compiled-in TDM publisher owns 10.1109.
-        let ref_ = Ref::Doi(Doi::parse("10.1109/TSP.2018.2812747").expect("doi"));
+        // An AMS DOI: no compiled-in TDM publisher owns 10.1090. This
+        // was an IEEE DOI until #430 gave 10.1109 an owner — the test
+        // needs a prefix that stays foreign, and ADR-0039 names AMS as
+        // one of the publishers still without a TDM source.
+        let ref_ = Ref::Doi(Doi::parse("10.1090/s0025-5718-04-01692-8").expect("doi"));
         let mut attempts = Vec::new();
         resolve_tdm_chain(&ref_, &all_gates_open(), &ctx, false, &mut attempts).await;
 
-        for name in ["tdm-aps", "tdm-elsevier", "tdm-springer"] {
+        for name in ["tdm-aps", "tdm-elsevier", "tdm-springer", "tdm-ieee"] {
             let o = outcome(&attempts, name);
             assert!(
                 matches!(o, AttemptOutcome::WrongPublisher { .. }),
-                "{name} must be WrongPublisher for an IEEE DOI, got {o:?}"
+                "{name} must be WrongPublisher for an AMS DOI, got {o:?}"
             );
             assert!(
                 !o.render().contains("DOIGET_KEY"),
@@ -4421,7 +4446,7 @@ mod tdm_chain_tests {
                 o.render()
             );
             assert!(
-                o.render().contains("10.1109"),
+                o.render().contains("10.1090"),
                 "the message must name the prefix that did not match: {}",
                 o.render()
             );
@@ -4482,7 +4507,7 @@ mod tdm_chain_tests {
         let mut attempts = Vec::new();
         resolve_tdm_chain(&ref_, &all_gates_open(), &ctx, true, &mut attempts).await;
 
-        for name in ["tdm-aps", "tdm-elsevier", "tdm-springer"] {
+        for name in ["tdm-aps", "tdm-elsevier", "tdm-springer", "tdm-ieee"] {
             assert_eq!(
                 outcome(&attempts, name),
                 &AttemptOutcome::NotNeeded,

--- a/crates/doiget-core/src/provenance.rs
+++ b/crates/doiget-core/src/provenance.rs
@@ -216,6 +216,8 @@ pub enum Capability {
     TdmAps,
     /// Springer TDM (Tier 3, opt-in build).
     TdmSpringer,
+    /// IEEE TDM (Tier 3, opt-in build).
+    TdmIeee,
 }
 
 /// Errors emitted by the provenance log writer. Callers MUST treat any
@@ -1973,6 +1975,7 @@ mod tests {
             (Capability::TdmElsevier, "\"tdm-elsevier\""),
             (Capability::TdmAps, "\"tdm-aps\""),
             (Capability::TdmSpringer, "\"tdm-springer\""),
+            (Capability::TdmIeee, "\"tdm-ieee\""),
         ];
         for (cap, expected) in cases {
             let got = serde_json::to_string(&cap).expect("serialize");

--- a/crates/doiget-core/src/sources/mod.rs
+++ b/crates/doiget-core/src/sources/mod.rs
@@ -75,3 +75,6 @@ pub mod tdm_aps;
 
 #[cfg(feature = "tdm-elsevier")]
 pub mod tdm_elsevier;
+
+#[cfg(feature = "tdm-ieee")]
+pub mod tdm_ieee;

--- a/crates/doiget-core/src/sources/tdm_ieee.rs
+++ b/crates/doiget-core/src/sources/tdm_ieee.rs
@@ -1,0 +1,597 @@
+//! IEEE Xplore TDM source — DOI metadata via the
+//! `/api/v1/search/articles` endpoint (Tier 3).
+//!
+//! Spec: `docs/SOURCES.md` §1 Tier 3 row + §4 "TDM sources (Phase 5)",
+//! `docs/CAPABILITY.md` §2, ADR-0002 (per-publisher Cargo features),
+//! ADR-0019 (eight safeguards), ADR-0039 (per-publisher TDM credentials
+//! are the supported route for IEEE / ACM / SIAM / AMS — their web hosts
+//! answer a scripted client with `202` + an empty body regardless of
+//! entitlement, so `oa-publisher` cannot reach them).
+//!
+//! Whole module gated by `#[cfg(feature = "tdm-ieee")]` so default
+//! release binaries never include the host pattern or the env-var read
+//! path (ADR-0002).
+//!
+//! ## The contract here is INFERRED, not confirmed against a live key
+//!
+//! Issue #430 is explicit that IEEE's programme contract — endpoint,
+//! auth shape, response shape, rate limits, terms — could not be
+//! obtained from outside the programme. What is implemented below is
+//! the shape IEEE's own developer portal and its published SDKs
+//! describe:
+//!
+//! - base `https://ieeexploreapi.ieee.org`, path `/api/v1/search/articles`
+//! - the key as an `apikey` **query parameter** (not a header)
+//! - a JSON envelope `{ total_records, total_searched, articles: [...] }`
+//!
+//! Everything that could be wrong is wrong *loudly*: a response that is
+//! not that shape becomes [`FetchError::SourceSchema`] naming what was
+//! missing and quoting the body, so the first run against a real key
+//! reports the actual shape rather than silently returning nothing.
+//! `DOIGET_IEEE_BASE` exists so that run can be replayed against a
+//! recorded fixture without touching production.
+//!
+//! Do not promote the `docs/SOURCES.md` row out of its "unverified"
+//! marking until a fetch with a real key has been observed.
+//!
+//! ## Three-gate activation
+//!
+//! Per `docs/CAPABILITY.md` §2 a fetch only succeeds when ALL THREE
+//! gates pass:
+//!
+//! 1. The binary was built with `--features tdm-ieee`.
+//! 2. The user set `DOIGET_KEY_IEEE=<api-key>`.
+//! 3. The user set `DOIGET_AGREE_TDM_IEEE=1`.
+//!
+//! Gates 2 + 3 are checked at startup by
+//! [`CapabilityProfile::from_env`] and surface as
+//! `profile.tdm_ieee = Some(TdmGrant)`. This source mirrors that check
+//! in [`can_serve`](TdmIeeeSource::can_serve) and again in
+//! [`fetch`](TdmIeeeSource::fetch) (defensive). The key is read once at
+//! startup and carried in [`TdmGrant::api_key`](crate::TdmGrant) (issue
+//! #153); this source consumes it from the grant and never re-reads
+//! `DOIGET_KEY_IEEE` at fetch time.
+//!
+//! ## Credential hygiene — key in the URL (issue #146)
+//!
+//! IEEE is the second query-param-auth source after Springer Nature:
+//! the documented parameter is `apikey` (one word — Springer's is
+//! `api_key`), and no header-auth path is documented for either the
+//! metadata or the full-text endpoint. The #146 preference for a header
+//! is therefore not available against this upstream.
+//!
+//! Same residual-risk mitigation as Springer: every URL leaving this
+//! module — [`FetchResult::final_url`] and any error string — goes
+//! through `redact_apikey_in_url` first, and `http.rs` redacts the same
+//! parameter out of `HttpError::HttpStatus`. The key still appears on
+//! the wire and in IEEE's own server-side logs; that is inherent to
+//! query-param auth and is accepted residual risk, recorded in
+//! `docs/CAPABILITY.md` §1.
+//!
+//! ## Metadata-only contract
+//!
+//! `FetchResult.pdf_bytes` is always `None`, matching the three
+//! existing Tier-3 sources. IEEE does document a separate full-text
+//! endpoint, but retrieving it requires the eight ADR-0019 safeguards
+//! wired through the orchestrator — and, unlike the shape below, its
+//! contract cannot be inferred at all from outside the programme.
+
+#![cfg(feature = "tdm-ieee")]
+
+use async_trait::async_trait;
+use secrecy::ExposeSecret;
+use url::Url;
+
+use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use crate::source::{FetchContext, FetchError, FetchResult, Source};
+use crate::{CapabilityProfile, Ref};
+
+/// Production IEEE Xplore API base URL.
+const DEFAULT_BASE: &str = "https://ieeexploreapi.ieee.org";
+
+/// DOI registrant prefixes IEEE actually owns.
+///
+/// #442: without this the source would answer `can_serve` for ANY DOI,
+/// so wiring it into the chain would send every lookup — including DOIs
+/// belonging to other publishers — to IEEE. That is a politeness
+/// problem (`docs/SOURCES.md` §6) and a privacy one
+/// (`docs/PRIVACY.md`): it would disclose the user's whole reading list
+/// to a publisher who has no part in it.
+///
+/// Scoped to the DOIs this publisher registered, the disclosure is
+/// nil — resolving such a DOI goes through them anyway.
+///
+/// Verified against the Crossref registrant registry
+/// (`api.crossref.org/prefixes/<prefix>`) on 2026-08-24; both resolve to
+/// "Institute of Electrical and Electronics Engineers (IEEE)".
+/// `10.1109` is the journal / transactions / Access family, `10.23919`
+/// the conference proceedings IEEE co-publishes.
+///
+/// Deliberately conservative: a publisher may own prefixes not listed
+/// here. A miss is not silent — it is recorded in the attempt trace as
+/// `not consulted (DOI prefix ... is not ...)`, so it is diagnosable
+/// from the error message rather than looking like a lookup failure.
+pub(crate) const PUBLISHER_PREFIXES: &[&str] = &["10.1109", "10.23919"];
+
+/// The query-parameter name IEEE expects, and the value it is replaced
+/// with in any URL that leaves this module bound for a log or
+/// recorded-provenance sink (issue #146).
+///
+/// One word, unlike Springer's `api_key`. `http.rs::redact_api_key_query`
+/// knows both spellings; a third source with a third spelling must be
+/// added there too or its key reaches `HttpError::HttpStatus`.
+const API_KEY_PARAM: &str = "apikey";
+const REDACTED: &str = "REDACTED";
+
+/// IEEE Xplore TDM [`Source`] impl — DOI → first matching `articles[]`
+/// entry from `/api/v1/search/articles`.
+#[derive(Clone, Debug)]
+pub struct TdmIeeeSource {
+    /// API base URL. Production pins `https://ieeexploreapi.ieee.org`;
+    /// [`with_base`](Self::with_base) lets wiremock substitute an
+    /// `http://127.0.0.1:N` origin — and lets the inferred response
+    /// shape above be re-tested against a recorded real response.
+    base: Url,
+}
+
+impl TdmIeeeSource {
+    /// Production constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            #[allow(clippy::expect_used)]
+            base: Url::parse(DEFAULT_BASE).expect("hard-coded base URL is valid"),
+        }
+    }
+
+    /// Test-only constructor accepting an arbitrary base URL.
+    pub fn with_base(base: Url) -> Self {
+        Self { base }
+    }
+
+    /// Build the `/api/v1/search/articles?doi=<doi>&format=json&apikey=<key>`
+    /// URL.
+    ///
+    /// `doi` is a first-class search parameter on the Metadata Search
+    /// API, so no Lucene-style filter string is needed. `format=json`
+    /// is sent explicitly rather than relying on the documented JSON
+    /// default: this module only knows how to parse JSON, and an
+    /// upstream default flip would otherwise surface as a parse error
+    /// instead of a request we never made correctly.
+    fn request_url(&self, doi: &crate::Doi, api_key: &str) -> Result<Url, FetchError> {
+        let mut url =
+            self.base
+                .join("/api/v1/search/articles")
+                .map_err(|e| FetchError::SourceSchema {
+                    hint: format!("tdm-ieee URL construction failed: {e}"),
+                })?;
+        url.query_pairs_mut()
+            .append_pair("doi", doi.as_str())
+            .append_pair("format", "json")
+            .append_pair(API_KEY_PARAM, api_key);
+        Ok(url)
+    }
+}
+
+/// Return a copy of `url` with the `apikey` query-parameter value
+/// replaced by `REDACTED`, preserving every other pair and ordering.
+///
+/// IEEE only documents query-param auth (issue #146), so the key
+/// unavoidably appears on the wire and in IEEE's own logs. This keeps it
+/// out of *our* sinks: the `FetchResult::final_url` the orchestrator
+/// persists into the metadata TOML `url` field, and any error string
+/// this module produces. If no `apikey` pair is present the URL is
+/// returned structurally unchanged.
+fn redact_apikey_in_url(url: &Url) -> Url {
+    if url.query_pairs().all(|(k, _)| k != API_KEY_PARAM) {
+        return url.clone();
+    }
+    let mut redacted = url.clone();
+    // Re-serialize the pairs, swapping only the apikey value. `clear()`
+    // first so we don't append onto the existing query string.
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(k, v)| {
+            if k == API_KEY_PARAM {
+                (k.into_owned(), REDACTED.to_string())
+            } else {
+                (k.into_owned(), v.into_owned())
+            }
+        })
+        .collect();
+    redacted.query_pairs_mut().clear().extend_pairs(pairs);
+    redacted
+}
+
+impl Default for TdmIeeeSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Source for TdmIeeeSource {
+    fn name(&self) -> &str {
+        "tdm-ieee"
+    }
+
+    fn can_serve(&self, profile: &CapabilityProfile, ref_: &Ref) -> bool {
+        let Ref::Doi(doi) = ref_ else {
+            return false;
+        };
+        // Both halves matter: the grant is the user's opt-in, the prefix
+        // keeps that opt-in from leaking unrelated DOIs to the publisher
+        // (#442). The orchestrator checks the same two conditions so it
+        // can tell them apart in the trace; this is the defensive mirror.
+        profile.tdm_ieee.is_some() && PUBLISHER_PREFIXES.contains(&doi.prefix())
+    }
+
+    async fn fetch(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<FetchResult, FetchError> {
+        let doi = match ref_ {
+            Ref::Doi(d) => d,
+            Ref::Arxiv(_) => {
+                return Err(FetchError::NotEligible {
+                    source_key: "tdm-ieee".into(),
+                });
+            }
+        };
+
+        // Defensive gate (1/3 + 2/3): the runtime grant must be
+        // populated and carries the key validated at startup (issue
+        // #153). `CapabilityProfile` is immutable for the process
+        // lifetime (`docs/CAPABILITY.md` §6), so the startup grant is
+        // the single source of truth — no env re-read.
+        let grant = profile
+            .tdm_ieee
+            .as_ref()
+            .ok_or_else(|| FetchError::NotEligible {
+                source_key: "tdm-ieee".into(),
+            })?;
+        let api_key = grant.api_key.expose_secret();
+        if api_key.is_empty() {
+            return Err(FetchError::NotEligible {
+                source_key: "tdm-ieee".into(),
+            });
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi, api_key)?;
+        let (body, final_url) = ctx.http.fetch_bytes(self.name(), url).await?;
+        // Issue #146: IEEE auth is query-param only; strip the key from
+        // the URL before it can reach the metadata TOML / any log.
+        let final_url = redact_apikey_in_url(&final_url);
+
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| FetchError::SourceSchema {
+                hint: format!("tdm-ieee returned non-JSON: {e}"),
+            })?;
+
+        // Inferred envelope: { total_records, total_searched, articles: [...] }.
+        // The hint quotes the body because this shape is the part of the
+        // contract that could not be confirmed from outside the
+        // programme (#430) — the first run against a real key has to be
+        // able to report what actually arrived.
+        let articles = envelope
+            .get("articles")
+            .and_then(|a| a.as_array())
+            .ok_or_else(|| FetchError::SourceSchema {
+                hint: format!(
+                    "tdm-ieee response missing `articles` array (got: {})",
+                    truncate_for_hint(&body)
+                ),
+            })?;
+        let first = articles.first().ok_or_else(|| FetchError::SourceSchema {
+            hint: "tdm-ieee returned 0 articles for this DOI".to_string(),
+        })?;
+
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::TdmIeee,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(body.len() as u64),
+            license: None,
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(FetchResult {
+            source: self.name().to_string(),
+            license: "unknown".into(),
+            pdf_bytes: None,
+            final_url: Some(final_url),
+            metadata_json: Some(first.clone()),
+        })
+    }
+}
+
+fn truncate_for_hint(body: &[u8]) -> String {
+    const MAX: usize = 200;
+    let s = String::from_utf8_lossy(body);
+    if s.len() <= MAX {
+        s.into_owned()
+    } else {
+        format!("{}…", &s[..MAX])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::http::HttpClient;
+    use crate::provenance::ProvenanceLog;
+    use crate::rate_limiter::RateLimiter;
+    use crate::{CapabilityProfile, Doi, RateLimits, Ref, TdmGrant};
+
+    const SAMPLE_ENVELOPE_HIT: &str = r#"{
+        "total_records": 1,
+        "total_searched": 6000000,
+        "articles": [
+            {
+                "doi": "10.1109/TSP.2018.2812747",
+                "title": "Example IEEE Transactions Article",
+                "publication_title": "IEEE Transactions on Signal Processing",
+                "article_number": "8307462"
+            }
+        ]
+    }"#;
+
+    const SAMPLE_ENVELOPE_EMPTY: &str = r#"{
+        "total_records": 0,
+        "total_searched": 6000000,
+        "articles": []
+    }"#;
+
+    /// The failure this module is most likely to meet on its first run
+    /// against a real key: a well-formed JSON response in a shape the
+    /// inferred contract did not predict.
+    const SAMPLE_UNEXPECTED_SHAPE: &str = r#"{"error": "Developer Inactive"}"#;
+
+    fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let log_dir =
+            Utf8PathBuf::try_from(td.path().to_path_buf()).expect("temp dir path must be UTF-8");
+        let log_path = log_dir.join("test.jsonl");
+
+        let http = Arc::new(HttpClient::new_for_tests_allow_http(
+            "tdm-ieee",
+            wiremock_host,
+        ));
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimits::HARD_CODED));
+        let session_id = "01J0000000000000000000TEST".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(log_path, session_id.clone()).expect("provenance log opens"),
+        );
+        let ctx = FetchContext {
+            http,
+            rate_limiter,
+            log,
+            session_id,
+            cache_root: None,
+        };
+        (td, ctx)
+    }
+
+    /// Sentinel test key used in the happy-path wiremock matcher.
+    const TEST_KEY: &str = "test-key-xyz";
+
+    fn profile_with_ieee_grant() -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.tdm_ieee = Some(TdmGrant {
+            // Issue #153: the key flows through the grant, not the env
+            // var, so the fixture seeds it directly.
+            api_key: secrecy::SecretString::from(TEST_KEY.to_string()),
+            agree_env_var: "DOIGET_AGREE_TDM_IEEE".to_string(),
+            ..Default::default()
+        });
+        p
+    }
+
+    /// Grant whose key is empty — exercises the fail-closed branch.
+    fn profile_with_empty_key_grant() -> CapabilityProfile {
+        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        p.tdm_ieee = Some(TdmGrant {
+            api_key: secrecy::SecretString::from(String::new()),
+            agree_env_var: "DOIGET_AGREE_TDM_IEEE".to_string(),
+            ..Default::default()
+        });
+        p
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn fetch_doi_returns_first_article_and_passes_key_in_query() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/search/articles"))
+            .and(query_param("doi", "10.1109/TSP.2018.2812747"))
+            .and(query_param("format", "json"))
+            .and(query_param("apikey", TEST_KEY))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ENVELOPE_HIT))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = TdmIeeeSource::with_base(Url::parse(&server.uri()).expect("wiremock URI parses"));
+        let profile = profile_with_ieee_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1109/TSP.2018.2812747").expect("DOI parses"));
+
+        let result = src.fetch(&ref_, &profile, &ctx).await.expect("fetch ok");
+
+        assert_eq!(result.source, "tdm-ieee");
+        assert!(result.pdf_bytes.is_none(), "metadata-only contract");
+        // Issue #146: the returned final_url must NOT carry the real key.
+        let final_url = result.final_url.expect("final_url present");
+        assert!(
+            !final_url.as_str().contains(TEST_KEY),
+            "apikey must be redacted out of final_url: {final_url}"
+        );
+        assert!(
+            final_url
+                .query_pairs()
+                .any(|(k, v)| k == "apikey" && v == "REDACTED"),
+            "redacted apikey sentinel must be present: {final_url}"
+        );
+        let meta = result.metadata_json.expect("metadata_json present");
+        assert_eq!(meta["title"], "Example IEEE Transactions Article");
+    }
+
+    /// #430: the response shape is inferred, so the failure has to name
+    /// what was missing AND quote what arrived. Anything less and the
+    /// first run against a real key reports "no records" for a response
+    /// that may have been a perfectly good record in another shape.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn an_unexpected_envelope_names_the_field_and_quotes_the_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/search/articles"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_UNEXPECTED_SHAPE))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = TdmIeeeSource::with_base(Url::parse(&server.uri()).expect("wiremock URI parses"));
+        let profile = profile_with_ieee_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1109/TSP.2018.2812747").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("unexpected shape must not look like success");
+        let FetchError::SourceSchema { hint } = err else {
+            panic!("expected SourceSchema, got a different error");
+        };
+        assert!(hint.contains("articles"), "name the missing field: {hint}");
+        assert!(
+            hint.contains("Developer Inactive"),
+            "quote what actually arrived, or the real shape stays invisible: {hint}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn an_empty_articles_array_is_a_miss_not_a_hit() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/search/articles"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ENVELOPE_EMPTY))
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = TdmIeeeSource::with_base(Url::parse(&server.uri()).expect("wiremock URI parses"));
+        let profile = profile_with_ieee_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1109/example").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("0 articles must not be a hit");
+        assert!(matches!(err, FetchError::SourceSchema { .. }));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn fetch_with_empty_grant_key_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = TdmIeeeSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
+        let profile = profile_with_empty_key_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1109/example").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("empty grant key must fail-close");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn fetch_without_grant_is_not_eligible() {
+        let (_td, ctx) = build_test_context("http://127.0.0.1:1");
+        let src = TdmIeeeSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
+        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let ref_ = Ref::Doi(Doi::parse("10.1109/example").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("no grant must fail-close");
+        assert!(matches!(err, FetchError::NotEligible { .. }));
+    }
+
+    #[test]
+    fn redact_apikey_in_url_replaces_only_the_key() {
+        let u = Url::parse(
+            "https://ieeexploreapi.ieee.org/api/v1/search/articles?doi=10.1109/x&apikey=SUPERSECRET",
+        )
+        .expect("parses");
+        let r = redact_apikey_in_url(&u);
+        assert!(!r.as_str().contains("SUPERSECRET"), "key must be gone: {r}");
+        assert!(
+            r.query_pairs().any(|(k, v)| k == "doi" && v == "10.1109/x"),
+            "other pairs preserved: {r}"
+        );
+        assert!(r
+            .query_pairs()
+            .any(|(k, v)| k == "apikey" && v == "REDACTED"));
+        // No-op when there is no apikey pair.
+        let clean =
+            Url::parse("https://ieeexploreapi.ieee.org/api/v1/search/articles?doi=10.1109/x")
+                .expect("parses");
+        assert_eq!(redact_apikey_in_url(&clean), clean);
+    }
+
+    /// #442, restated for the fourth source: a grant is an opt-in to
+    /// disclose IEEE's own DOIs to IEEE, not the user's whole reading
+    /// list.
+    #[test]
+    fn can_serve_refuses_another_publishers_doi_even_with_a_valid_grant() {
+        let src = TdmIeeeSource::new();
+        let profile = profile_with_ieee_grant();
+        let own = Ref::Doi(Doi::parse("10.1109/TSP.2018.2812747").expect("DOI parses"));
+        let foreign = Ref::Doi(Doi::parse("10.1007/example").expect("DOI parses"));
+
+        assert!(src.can_serve(&profile, &own), "must serve an IEEE DOI");
+        assert!(
+            !src.can_serve(&profile, &foreign),
+            "must NOT serve a Springer DOI even with a valid grant -- that \
+             would disclose an unrelated lookup to IEEE"
+        );
+    }
+
+    /// The conference prefix is the one most likely to be dropped by a
+    /// future edit, and it is exactly the surface #407 measured.
+    #[test]
+    fn both_registered_ieee_prefixes_are_served() {
+        let src = TdmIeeeSource::new();
+        let profile = profile_with_ieee_grant();
+        for doi in ["10.1109/example", "10.23919/example"] {
+            let ref_ = Ref::Doi(Doi::parse(doi).expect("DOI parses"));
+            assert!(src.can_serve(&profile, &ref_), "must serve {doi}");
+        }
+    }
+}

--- a/crates/doiget-mcp/Cargo.toml
+++ b/crates/doiget-mcp/Cargo.toml
@@ -31,6 +31,7 @@ citation = ["doiget-core/citation"]
 tdm-elsevier = ["doiget-core/tdm-elsevier"]
 tdm-aps      = ["doiget-core/tdm-aps"]
 tdm-springer = ["doiget-core/tdm-springer"]
+tdm-ieee     = ["doiget-core/tdm-ieee"]
 
 [dependencies]
 doiget-core        = { workspace = true }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -199,11 +199,11 @@ impl Server {
     /// succeed. The spec'd output shape is
     /// `{ oa_enabled, metadata_sources: string[], tdm_enabled,
     /// tdm_elsevier, tdm_aps, tdm_springer, rate_limit_per_sec }`;
-    /// `ok` and `tier_1/2/3` are emitted additively for back-compat.
+    /// `ok`, `tier_1/2/3` and `tdm_ieee` (#430) are emitted additively.
     #[tool(
         description = "WHEN TO USE: Determine which sources the running doiget instance is allowed to use.\n\
                        INPUTS: none.\n\
-                       OUTPUTS: { oa_enabled, metadata_sources, tdm_enabled, tdm_elsevier, tdm_aps, tdm_springer, rate_limit_per_sec } (plus additive ok, tier_1, tier_2, tier_3).\n\
+                       OUTPUTS: { oa_enabled, metadata_sources, tdm_enabled, tdm_elsevier, tdm_aps, tdm_springer, rate_limit_per_sec } (plus additive ok, tier_1, tier_2, tier_3, tdm_ieee).\n\
                        COSTS: <1 ms.\n\
                        SIDE EFFECTS: none.\n\
                        LIMITS: none.",
@@ -4053,7 +4053,9 @@ fn probe_store_writable(path: &camino::Utf8Path) -> bool {
 /// fields and additionally retain `ok` and `tier_1/2/3` as **additive**
 /// fields — the e2e handshake test and pre-#141 agents rely on them and
 /// §7 (a TypeScript object type, structurally open) does not forbid
-/// extra keys. `metadata_sources` is the spec-canonical view of the
+/// extra keys. `tdm_ieee` (#430) joins them on the same footing: a
+/// fourth publisher must not silently change the meaning of the three
+/// booleans §7 names. `metadata_sources` is the spec-canonical view of the
 /// enabled Tier-2 metadata sources.
 ///
 /// - `metadata_sources` reflects the `MetadataAccess` booleans (the
@@ -4090,6 +4092,9 @@ fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
     if profile.tdm_springer.is_some() {
         tier_3.push("tdm-springer");
     }
+    if profile.tdm_ieee.is_some() {
+        tier_3.push("tdm-ieee");
+    }
 
     let tdm_enabled = !tier_3.is_empty();
 
@@ -4101,6 +4106,10 @@ fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
         "tdm_elsevier": profile.tdm_elsevier.is_some(),
         "tdm_aps": profile.tdm_aps.is_some(),
         "tdm_springer": profile.tdm_springer.is_some(),
+        // Additive per the §7 note that consumers must tolerate extra
+        // keys; the four `tdm_*` booleans named in the contract are all
+        // still present and unchanged (#430).
+        "tdm_ieee": profile.tdm_ieee.is_some(),
         "rate_limit_per_sec": profile.rate_limits.max_fetches_per_second(),
         // -- additive (back-compat; not part of the §7 contract) --
         "ok": true,
@@ -4440,7 +4449,8 @@ mod tests {
     #[cfg(any(
         feature = "tdm-aps",
         feature = "tdm-elsevier",
-        feature = "tdm-springer"
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
     ))]
     #[allow(clippy::vec_init_then_push)]
     fn the_production_client_registers_every_tier_3_source_key() {
@@ -4471,6 +4481,8 @@ mod tests {
         keys.push("tdm-elsevier");
         #[cfg(feature = "tdm-springer")]
         keys.push("tdm-springer");
+        #[cfg(feature = "tdm-ieee")]
+        keys.push("tdm-ieee");
         assert!(!keys.is_empty(), "the guard must have checked something");
         for key in keys {
             assert!(

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -29,6 +29,7 @@ pub struct CapabilityProfile {
     pub tdm_elsevier: Option<TdmGrant>,
     pub tdm_aps: Option<TdmGrant>,
     pub tdm_springer: Option<TdmGrant>,
+    pub tdm_ieee: Option<TdmGrant>,
     pub rate_limits: RateLimits,
 }
 
@@ -48,7 +49,8 @@ pub struct MetadataAccess {
 pub struct TdmGrant {
     // Present only under a `tdm-*` feature (see the note above). `secrecy`
     // 0.10 replaced `Secret<String>` with `SecretString` (= `SecretBox<str>`).
-    #[cfg(any(feature = "tdm-elsevier", feature = "tdm-aps", feature = "tdm-springer"))]
+    #[cfg(any(feature = "tdm-elsevier", feature = "tdm-aps",
+              feature = "tdm-springer", feature = "tdm-ieee"))]
     pub api_key:       SecretString,
     pub agreed_at:     DateTime<Utc>,
     pub agree_env_var: String,            // e.g. "DOIGET_AGREE_TDM_ELSEVIER"
@@ -119,6 +121,7 @@ impl CapabilityProfile {
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
             tdm_springer: read_tdm_grant("DOIGET_AGREE_TDM_SPRINGER", "DOIGET_KEY_SPRINGER")?,
+            tdm_ieee:     read_tdm_grant("DOIGET_AGREE_TDM_IEEE",     "DOIGET_KEY_IEEE")?,
             rate_limits:  RateLimits::HARD_CODED,
         })
     }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -248,6 +248,15 @@ agreed = true
 [tdm.springer]
 api_key = "..."
 agreed = true
+
+# Requires a build with `--features tdm-ieee`. The endpoint and response
+# shape are INFERRED from IEEE's public developer portal, not confirmed
+# against a live programme key (#430) — a response in another shape is
+# reported as a schema error naming the field and quoting the body,
+# rather than silently returning nothing.
+[tdm.ieee]
+api_key = "..."
+agreed = true
 ```
 
 If both env var and credentials.toml provide the same key, env var wins.
@@ -258,7 +267,10 @@ Being on a subscribing university network does **not** make paywalled content
 fetchable. Two independent things sit in the way, and only one of them is doiget's:
 
 1. **The allowlist.** IEEE, ACM, SIAM and AMS are not on the default `oa-publisher`
-   allowlist, so doiget will not attempt the publisher leg for them at all.
+   allowlist, so doiget will not attempt the publisher leg for them at all. IEEE now
+   has a TDM route instead (`[tdm.ieee]` above, `--features tdm-ieee`) — that is a
+   different host (`ieeexploreapi.ieee.org`, the API) under a different source key,
+   not a widening of `oa-publisher`.
 2. **The publisher's bot wall.** Even from a subscribing address, a scripted client
    commonly gets `202 Accepted` with an **empty body** — a challenge holding response,
    not a paywall and not a 403. The subscription is not the binding constraint; being a

--- a/docs/DECISIONS/0042-tdm-ieee-inferred-contract.md
+++ b/docs/DECISIONS/0042-tdm-ieee-inferred-contract.md
@@ -1,0 +1,107 @@
+# 0042 - `tdm-ieee` ships against an inferred contract, marked unverified
+
+- **Date:** 2026-08-24
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #430 (deferred from #407 by [0039](0039-publisher-hosts-stay-off-allowlist.md))
+
+## Context
+
+[ADR-0039](0039-publisher-hosts-stay-off-allowlist.md) settled that per-publisher
+TDM credentials are the supported route for IEEE / ACM / SIAM / AMS: their web
+front ends answer a scripted client with `202` and an empty body regardless of
+entitlement, so widening `oa-publisher` would move the failure one step later
+rather than fix it. #430 is the IEEE half of that route.
+
+#430 states its own blocker plainly: IEEE's programme contract — endpoint, auth
+shape, response shape, rate limits, terms — could not be obtained from outside
+the programme, which requires registration and a project summary before a key is
+issued.
+
+What *is* public, from IEEE's developer portal and its published SDKs:
+
+- base `https://ieeexploreapi.ieee.org`, path `/api/v1/search/articles`
+- the key as an `apikey` **query parameter**; no header-auth path is documented
+- a JSON envelope `{ total_records, total_searched, articles: [...] }`
+
+Not public: whether the TDM programme uses this same API surface, the response
+shape under a TDM entitlement, and the rate limits.
+
+`SOURCES.md` §5 requires an ADR locking the Tier and the Cargo feature name for
+any new Tier-3 source. This is it, and it has one more thing to lock: what it
+means to ship a source whose upstream contract is a reading of documentation
+rather than an observation.
+
+Three options:
+
+- **(a)** wait for a key — leave #430 open until someone joins the programme
+- **(b)** implement against the public shape, marked unverified, failing loudly
+- **(c)** implement against the public shape and present it as verified
+
+## Decision
+
+**(b) — implement, mark unverified, and make every uncertain assumption fail
+loudly rather than quietly.** Tier 3, Cargo feature `tdm-ieee`, prefixes
+`10.1109` and `10.23919` per [0041](0041-tdm-sources-scoped-to-publisher-prefixes.md).
+
+Concretely:
+
+- The `SOURCES.md` §1 row is marked **`(unverified)`**, and §4 carries a
+  subsection naming exactly which three facts are inferred. The marking is not
+  decoration: it may not be removed until a fetch with a real key has been
+  observed.
+- A response that is not the expected envelope is a `SourceSchema` error that
+  **names the missing field and quotes the body**. The first run against a real
+  key therefore reports the actual contract instead of returning "no records"
+  for a response that may have been a perfectly good record in another shape.
+- `DOIGET_IEEE_BASE` exists from the start — unlike the first three Tier-3
+  sources, which shipped without a base override and so could not be pointed
+  anywhere, which is why nothing could prove they were reachable (#442). Here it
+  also serves the specific purpose of replaying a recorded real response against
+  a fixture.
+- `format=json` is sent explicitly rather than relying on the documented default,
+  so an upstream default flip surfaces as a request we made wrong rather than as
+  a parse error.
+- The full-text endpoint is **not** implemented. Its contract cannot be inferred
+  at all from outside the programme, and it would additionally need the eight
+  ADR-0019 safeguards wired through the orchestrator. `tdm-ieee` is
+  metadata-only, like the other three.
+
+**(a) was rejected** because the cost of waiting is asymmetric. The gates are
+opt-in three times over (feature, key, agreement), so an unverified source is
+inert for every user who has not joined the programme — which is everyone who
+cannot verify it either. Waiting keeps the module unwritten and the *next*
+person still cannot start, because the missing piece is the one thing a key
+holder can supply in five minutes and a non-holder can never supply at all.
+
+**(c) was rejected** outright. An unverified contract presented as verified is
+the failure mode this project has spent three issues on: #442, #438 and #454 are
+all "documented as working, never actually reached". Shipping a fourth on a
+guess and not saying so would be the same defect with a new name.
+
+## Consequences
+
+**Positive.**
+
+- A key holder can exercise the whole path today, and the first failure they hit
+  reports the real contract rather than a shrug.
+- IEEE was the corpus #407 measured as metadata-resolvable but unfetchable. That
+  gap now has a route, gated behind the user's own agreement with IEEE.
+- ACM / SIAM / AMS can follow the same shape, and this ADR is the precedent for
+  how to do so before a key exists.
+
+**Negative / accepted.**
+
+- The source may not work on first contact. That is stated in `SOURCES.md` §1,
+  §4 and in the module docs, and the failure is diagnostic rather than silent.
+- Rate limits are unknown; the source runs under the same hard-coded limiter as
+  every other, which may be more or less polite than IEEE requires.
+  `SOURCES.md` §6 commits to adopting a stricter published limit once known.
+- The key travels in the URL query, as Springer's does. `redact_api_key_query`
+  now knows both spellings (`api_key`, `apikey`); a third source with a third
+  spelling that does not add it there leaks its key into `HttpError::HttpStatus`.
+  This is a registry that must be maintained by hand, and the module docs say so.
+
+**Revisit** when a run with a real programme key is observed: correct whatever it
+disagrees with, drop the `(unverified)` marking, and record the observed rate
+limits.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -58,6 +58,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0039 | IEEE / ACM / SIAM / AMS stay off `oa-publisher`; TDM credentials are the route | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #407 |
 | 0040 | Source expansion gated by the existing `metadata` feature, runtime-gated off | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #413 |
 | 0041 | Tier-3 TDM sources are scoped to their publisher's DOI prefixes | Accepted (0.8.9) | `fix/442-tier3-orchestrator-wiring` | #442 |
+| 0042 | `tdm-ieee` ships against an inferred contract, marked unverified | Accepted (0.8.9) | `feat/430-tdm-ieee` | #430 |
 
 ## Conventions
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -60,14 +60,20 @@ its use of these APIs polite.
 - `--features metadata`: **Europe PMC** (<https://www.ebi.ac.uk>, biomedical OA full
   text). Inert until `DOIGET_ENABLE_EUROPE_PMC` is set; queried by exact DOI only.
   No key or account.
-- `--features tdm-springer | tdm-aps | tdm-elsevier`: the respective publisher
-  text-and-data-mining APIs, used **only with your own API key and explicit
-  agreement**. doiget bundles no keys and shares none. Each is consulted **only
-  for DOI prefixes that publisher registered** (ADR-0041) — enabling `tdm-aps`
-  does not disclose your Elsevier or IEEE lookups to APS — and only after
-  Crossref failed to resolve the DOI. Since a publisher is asked only about DOIs
-  it issued, and resolving such a DOI goes through it anyway, enabling one of
+- `--features tdm-springer | tdm-aps | tdm-elsevier | tdm-ieee`: the respective
+  publisher text-and-data-mining APIs, used **only with your own API key and
+  explicit agreement**. doiget bundles no keys and shares none. Each is consulted
+  **only for DOI prefixes that publisher registered** (ADR-0041) — enabling
+  `tdm-aps` does not disclose your Elsevier or IEEE lookups to APS — and only
+  after Crossref failed to resolve the DOI. Since a publisher is asked only about
+  DOIs it issued, and resolving such a DOI goes through it anyway, enabling one of
   these tells that publisher nothing it could not already observe.
+
+  Two of them — `tdm-springer` and `tdm-ieee` (<https://ieeexploreapi.ieee.org>) —
+  send the key as a **URL query parameter**, because neither upstream documents a
+  header-auth path. It is therefore visible to that publisher's own server-side and
+  proxy logs. doiget strips it from every URL it keeps: the metadata record, the
+  provenance log and any error text (issue #146).
 
 ## What is stored locally
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -26,6 +26,7 @@
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
+| IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
 ## 2. User responsibility
 
@@ -68,6 +69,7 @@ Tier 3 TDM sources are individually feature-flagged and require user-driven buil
 cargo install doiget --features metadata,tdm-springer
 cargo install doiget --features metadata,tdm-aps
 cargo install doiget --features metadata,tdm-elsevier
+cargo install doiget --features metadata,tdm-ieee
 ```
 
 There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
@@ -136,7 +138,7 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 Each requires:
 
-1. A Cargo feature compiled in (`tdm-elsevier`, `tdm-aps`, `tdm-springer`).
+1. A Cargo feature compiled in (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`).
 2. The user's API key in `DOIGET_KEY_<PUBLISHER>` env or `[tdm.<publisher>] api_key` in
    credentials.toml.
 3. The agreement env `DOIGET_AGREE_TDM_<PUBLISHER>=1`.
@@ -153,10 +155,31 @@ your Elsevier lookups to APS.
 | `tdm-aps` | `10.1103` |
 | `tdm-elsevier` | `10.1016`, `10.1006`, `10.1053` |
 | `tdm-springer` | `10.1007`, `10.1038`, `10.1057`, `10.1140` |
+| `tdm-ieee` | `10.1109`, `10.23919` |
 
 The lists are deliberately conservative, so a publisher may own a prefix not
 listed. That is visible rather than silent: the fetch error names it, as
 `not consulted (DOI prefix 10.xxxx is not <publisher>)`.
+
+#### IEEE Xplore — an inferred contract (#430)
+
+`tdm-ieee` is the one Tier-3 source whose upstream contract has **not** been
+confirmed against a live programme key. IEEE's programme requires registration
+and a project summary before a key is issued, so the endpoint
+(`https://ieeexploreapi.ieee.org/api/v1/search/articles`), the auth shape (the
+key as an `apikey` **query parameter**, as with Springer rather than the
+`X-API-Key` header APS and Elsevier use) and the response envelope
+(`{ total_records, total_searched, articles: [...] }`) are taken from IEEE's
+public developer portal and SDKs.
+
+The failure mode is loud, not silent: a response in any other shape is a schema
+error naming the missing field and quoting the body, so the first run against a
+real key reports the actual contract. `DOIGET_IEEE_BASE` replays that response
+against a fixture. **Do not drop the "unverified" marking in §1 until such a run
+has been observed.**
+
+Rate limits are likewise unknown; the source is subject to the same hard-coded
+limiter as every other, which may be more or less polite than IEEE requires.
 
 **When they run.** Strictly after Crossref, and only when Crossref produced
 nothing — the same rule the Tier-2 chain follows, so enabling a TDM source can

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -35,6 +35,7 @@ pub struct CapabilityProfile {
     pub tdm_elsevier: Option<TdmGrant>,
     pub tdm_aps: Option<TdmGrant>,
     pub tdm_springer: Option<TdmGrant>,
+    pub tdm_ieee: Option<TdmGrant>,
     pub rate_limits: RateLimits,
 }
 
@@ -54,7 +55,8 @@ pub struct MetadataAccess {
 pub struct TdmGrant {
     // Present only under a `tdm-*` feature (see the note above). `secrecy`
     // 0.10 replaced `Secret<String>` with `SecretString` (= `SecretBox<str>`).
-    #[cfg(any(feature = "tdm-elsevier", feature = "tdm-aps", feature = "tdm-springer"))]
+    #[cfg(any(feature = "tdm-elsevier", feature = "tdm-aps",
+              feature = "tdm-springer", feature = "tdm-ieee"))]
     pub api_key:       SecretString,
     pub agreed_at:     DateTime<Utc>,
     pub agree_env_var: String,            // e.g. "DOIGET_AGREE_TDM_ELSEVIER"
@@ -125,6 +127,7 @@ impl CapabilityProfile {
             tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
             tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
             tdm_springer: read_tdm_grant("DOIGET_AGREE_TDM_SPRINGER", "DOIGET_KEY_SPRINGER")?,
+            tdm_ieee:     read_tdm_grant("DOIGET_AGREE_TDM_IEEE",     "DOIGET_KEY_IEEE")?,
             rate_limits:  RateLimits::HARD_CODED,
         })
     }

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -254,6 +254,15 @@ agreed = true
 [tdm.springer]
 api_key = "..."
 agreed = true
+
+# Requires a build with `--features tdm-ieee`. The endpoint and response
+# shape are INFERRED from IEEE's public developer portal, not confirmed
+# against a live programme key (#430) — a response in another shape is
+# reported as a schema error naming the field and quoting the body,
+# rather than silently returning nothing.
+[tdm.ieee]
+api_key = "..."
+agreed = true
 ```
 
 If both env var and credentials.toml provide the same key, env var wins.
@@ -264,7 +273,10 @@ Being on a subscribing university network does **not** make paywalled content
 fetchable. Two independent things sit in the way, and only one of them is doiget's:
 
 1. **The allowlist.** IEEE, ACM, SIAM and AMS are not on the default `oa-publisher`
-   allowlist, so doiget will not attempt the publisher leg for them at all.
+   allowlist, so doiget will not attempt the publisher leg for them at all. IEEE now
+   has a TDM route instead (`[tdm.ieee]` above, `--features tdm-ieee`) — that is a
+   different host (`ieeexploreapi.ieee.org`, the API) under a different source key,
+   not a widening of `oa-publisher`.
 2. **The publisher's bot wall.** Even from a subscribing address, a scripted client
    commonly gets `202 Accepted` with an **empty body** — a challenge holding response,
    not a paywall and not a 403. The subscription is not the binding constraint; being a

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -32,6 +32,7 @@ weight = 200
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
+| IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
 ## 2. User responsibility
 
@@ -74,6 +75,7 @@ Tier 3 TDM sources are individually feature-flagged and require user-driven buil
 cargo install doiget --features metadata,tdm-springer
 cargo install doiget --features metadata,tdm-aps
 cargo install doiget --features metadata,tdm-elsevier
+cargo install doiget --features metadata,tdm-ieee
 ```
 
 There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
@@ -142,7 +144,7 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 Each requires:
 
-1. A Cargo feature compiled in (`tdm-elsevier`, `tdm-aps`, `tdm-springer`).
+1. A Cargo feature compiled in (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`).
 2. The user's API key in `DOIGET_KEY_<PUBLISHER>` env or `[tdm.<publisher>] api_key` in
    credentials.toml.
 3. The agreement env `DOIGET_AGREE_TDM_<PUBLISHER>=1`.
@@ -159,10 +161,31 @@ your Elsevier lookups to APS.
 | `tdm-aps` | `10.1103` |
 | `tdm-elsevier` | `10.1016`, `10.1006`, `10.1053` |
 | `tdm-springer` | `10.1007`, `10.1038`, `10.1057`, `10.1140` |
+| `tdm-ieee` | `10.1109`, `10.23919` |
 
 The lists are deliberately conservative, so a publisher may own a prefix not
 listed. That is visible rather than silent: the fetch error names it, as
 `not consulted (DOI prefix 10.xxxx is not <publisher>)`.
+
+#### IEEE Xplore — an inferred contract (#430)
+
+`tdm-ieee` is the one Tier-3 source whose upstream contract has **not** been
+confirmed against a live programme key. IEEE's programme requires registration
+and a project summary before a key is issued, so the endpoint
+(`https://ieeexploreapi.ieee.org/api/v1/search/articles`), the auth shape (the
+key as an `apikey` **query parameter**, as with Springer rather than the
+`X-API-Key` header APS and Elsevier use) and the response envelope
+(`{ total_records, total_searched, articles: [...] }`) are taken from IEEE's
+public developer portal and SDKs.
+
+The failure mode is loud, not silent: a response in any other shape is a schema
+error naming the missing field and quoting the body, so the first run against a
+real key reports the actual contract. `DOIGET_IEEE_BASE` replays that response
+against a fixture. **Do not drop the "unverified" marking in §1 until such a run
+has been observed.**
+
+Rate limits are likewise unknown; the source is subject to the same hard-coded
+limiter as every other, which may be more or less polite than IEEE requires.
 
 **When they run.** Strictly after Crossref, and only when Crossref produced
 nothing — the same rule the Tier-2 chain follows, so enabling a TDM source can


### PR DESCRIPTION
Closes #430. Builds on #454 (without it this source would be reachable and unfetchable, like the other three).

## What this is for

#407 measured a corpus that is entirely IEEE — Weiss et al., analytic parahermitian EVD, IEEE TSP 2018–2024, none on arXiv — as metadata-resolvable but **not fetchable**. ADR-0039 settled why widening `oa-publisher` cannot fix that: the web front end answers a scripted client with `202` and an empty body regardless of entitlement. TDM is the only route that is not the web front end. This is the IEEE half of it.

## The honest part: the contract is inferred

#430's blocker was never the key — that is the user's to obtain and pass in `DOIGET_KEY_IEEE`. It is that IEEE's **programme contract** (endpoint, auth shape, response shape, rate limits) is behind registration and a project summary.

What is public, from IEEE's developer portal and its published SDKs, is what is implemented:

| | inferred value |
|---|---|
| base + path | `https://ieeexploreapi.ieee.org` `/api/v1/search/articles` |
| auth | `apikey` **query parameter** (not a header) |
| envelope | `{ total_records, total_searched, articles: [...] }` |

**ADR-0042** records the decision to ship that rather than wait, and what it costs. The alternative — waiting — is asymmetric: the gates are opt-in three times over, so an unverified source is inert for everyone who cannot verify it either, and the missing piece is the one thing a key holder supplies in five minutes and a non-holder never can.

### Every uncertain assumption fails loudly

- A response in another shape is a `SourceSchema` error that **names the missing field and quotes the body** — so the first run against a real key reports the actual contract, instead of "0 articles" for what may have been a perfectly good record.
- `DOIGET_IEEE_BASE` exists **from the start**, so that run can be replayed against a fixture. The first three Tier-3 sources shipped without a base override, which is precisely why nothing could prove they were reachable (#442).
- `format=json` is sent explicitly rather than relying on the documented default, so an upstream flip surfaces as a request we made wrong, not a parse error.
- `SOURCES.md` §1 carries **`(unverified)`** and §4 names the three inferred facts. ADR-0042 forbids removing the marking before a real run is observed.

```rust
#[tokio::test]
async fn an_unexpected_envelope_names_the_field_and_quotes_the_body() { ... }
    assert!(hint.contains("articles"),        "name the missing field");
    assert!(hint.contains("Developer Inactive"), "quote what actually arrived");
```

## Credential hygiene (#146)

IEEE is the **second** query-param-auth source after Springer, and spells it `apikey` where Springer spells it `api_key`. Both redactors now know both spellings — the module-local one for `final_url`, and `http.rs::redact_api_key_query` for `HttpError::HttpStatus`, which is `tracing`-logged. That registry is hand-maintained and the module docs say so out loud.

## Scope

Metadata-only, like the other three. The full-text endpoint's contract cannot be inferred at all from outside the programme, and would additionally need the eight ADR-0019 safeguards wired through the orchestrator.

Prefixes `10.1109` and `10.23919`, both checked against the Crossref registrant registry (both → "Institute of Electrical and Electronics Engineers (IEEE)"), per ADR-0041.

**One existing test had to move:** `a_foreign_doi_is_wrong_publisher_not_disabled` used `10.1109` *because nothing owned it*. It now uses an AMS DOI (`10.1090`), which ADR-0039 lists among the publishers still without a TDM source.

## Touch points

`tdm_ieee.rs` · `sources/mod.rs` · `http.rs` (allowlist + redaction) · `lib.rs` (`CapabilityProfile.tdm_ieee`) · `provenance.rs` (`Capability::TdmIeee`) · `orchestrator.rs` (chain entry + `DOIGET_IEEE_BASE`) · `capabilities.rs` · `doiget-mcp` (`tdm_ieee` emitted **additively**; the four §7 booleans are unchanged) · three `Cargo.toml`s · CI matrices · `CONFIG.md` §6 · `SOURCES.md` §1/§3/§4 · `CAPABILITY.md` · `PRIVACY.md` · site projection · ADR-0042 + INDEX.

## Checks

```
clippy  oa-only | oa-only,citation | oa-only,tdm-aps | four-way union   GREEN
test    oa-only                                                  0 failures
test    oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee  0 failures
cargo metadata --locked                                          in sync
```

CI's `tdm` jobs (clippy / test / doc / coverage) now compile `tdm-ieee` too, so this surface cannot rot the way #440 found the first three had.