### PR TITLE
fix(tdm-ieee): correct the contract from first contact, and make the feature compile alone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
           # secretly depend on `metadata`.
           - "oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee"
           - "oa-only,tdm-aps"
+          # #460: `tdm-ieee` alone did not compile — `TdmGrant::api_key`
+          # is gated on an `any(...)` that listed the first three
+          # publishers and not the fourth, and the union job hid it
+          # because the others were always present. One singleton is not
+          # enough; each new publisher needs its own.
+          - "oa-only,tdm-ieee"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.8"
+version = "0.8.9-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.8"
+version = "0.8.9-beta.9"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.8"
+version = "0.8.9-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.8"
+version       = "0.8.9-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -1047,12 +1047,13 @@ impl HttpClient {
                 return Err(HttpError::HttpStatus {
                     status: code,
                     // Issue #146: Springer Nature authenticates via an
-                    // `api_key` URL query parameter (no header path
-                    // upstream). This error string is logged and may
-                    // surface to the user, so strip any `api_key`
-                    // value before it leaves the client. No other
-                    // source puts a secret in the query string, so
-                    // this is a no-op for them.
+                    // `api_key` URL query parameter, and IEEE via
+                    // `apikey` (#430) — neither documents a header
+                    // path. This error string is logged and may
+                    // surface to the user, so strip either spelling
+                    // before it leaves the client. A no-op for every
+                    // other source, none of which puts a secret in
+                    // the query string.
                     url: redact_api_key_query(&final_url),
                 });
             }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1033,7 +1033,8 @@ pub struct TdmGrant {
     #[cfg(any(
         feature = "tdm-elsevier",
         feature = "tdm-aps",
-        feature = "tdm-springer"
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
     ))]
     pub api_key: secrecy::SecretString,
     /// Which env var the user used to acknowledge the publisher's ToS.
@@ -1048,7 +1049,8 @@ impl Default for TdmGrant {
             #[cfg(any(
                 feature = "tdm-elsevier",
                 feature = "tdm-aps",
-                feature = "tdm-springer"
+                feature = "tdm-springer",
+                feature = "tdm-ieee"
             ))]
             api_key: secrecy::SecretString::from(String::new()),
             agree_env_var: String::new(),
@@ -1358,7 +1360,8 @@ fn build_tdm_grant(agree_var: &str, key: String) -> TdmGrant {
     #[cfg(any(
         feature = "tdm-elsevier",
         feature = "tdm-aps",
-        feature = "tdm-springer"
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
     ))]
     {
         TdmGrant {
@@ -1370,7 +1373,8 @@ fn build_tdm_grant(agree_var: &str, key: String) -> TdmGrant {
     #[cfg(not(any(
         feature = "tdm-elsevier",
         feature = "tdm-aps",
-        feature = "tdm-springer"
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
     )))]
     {
         let _ = key;
@@ -1646,7 +1650,8 @@ mod tests {
             #[cfg(any(
                 feature = "tdm-elsevier",
                 feature = "tdm-aps",
-                feature = "tdm-springer"
+                feature = "tdm-springer",
+                feature = "tdm-ieee"
             ))]
             {
                 use secrecy::ExposeSecret as _;

--- a/crates/doiget-core/src/sources/tdm_ieee.rs
+++ b/crates/doiget-core/src/sources/tdm_ieee.rs
@@ -24,6 +24,27 @@
 //! - the key as an `apikey` **query parameter** (not a header)
 //! - a JSON envelope `{ total_records, total_searched, articles: [...] }`
 //!
+//! ### Observed on 2026-08-24 (#460), without a key
+//!
+//! One unauthenticated request confirmed the first bullet and corrected
+//! the third's failure path:
+//!
+//! ```text
+//! GET /api/v1/search/articles?doi=...&format=json
+//! HTTP=403  content-type=text/xml
+//! <h1>Developer Inactive</h1>
+//! ```
+//!
+//! So the **base and path are right** — the host resolves and the
+//! endpoint is served. But the failure body is **not JSON**, and
+//! `format=json` does not make it so. That also means a 403 is an
+//! `HttpError::HttpStatus` and never reaches the JSON parsing below:
+//! the branch a key-less or not-yet-activated user hits is the HTTP
+//! one, which is why
+//! `an_inactive_key_403_says_so_and_does_not_leak_the_key` exists.
+//!
+//! Still unverified: the 200-response envelope and the rate limits.
+//!
 //! Everything that could be wrong is wrong *loudly*: a response that is
 //! not that shape becomes [`FetchError::SourceSchema`] naming what was
 //! missing and quoting the body, so the first run against a real key
@@ -32,7 +53,7 @@
 //! recorded fixture without touching production.
 //!
 //! Do not promote the `docs/SOURCES.md` row out of its "unverified"
-//! marking until a fetch with a real key has been observed.
+//! marking until a **200** with a real key has been observed.
 //!
 //! ## Three-gate activation
 //!
@@ -364,10 +385,25 @@ mod tests {
         "articles": []
     }"#;
 
-    /// The failure this module is most likely to meet on its first run
-    /// against a real key: a well-formed JSON response in a shape the
-    /// inferred contract did not predict.
-    const SAMPLE_UNEXPECTED_SHAPE: &str = r#"{"error": "Developer Inactive"}"#;
+    /// A 200 whose body is not the inferred envelope. Kept generic — the
+    /// point is that an unrecognised *successful* response must be a
+    /// schema error that quotes what arrived, not a silent miss.
+    const SAMPLE_UNEXPECTED_SHAPE: &str = r#"{"totalfound": 1, "records": []}"#;
+
+    /// The real body IEEE serves an unauthorised caller, observed on
+    /// 2026-08-24 (#460):
+    ///
+    /// ```text
+    /// GET /api/v1/search/articles?doi=...&format=json
+    /// HTTP=403  content-type=text/xml
+    /// <h1>Developer Inactive</h1>
+    /// ```
+    ///
+    /// Note it is NOT JSON, and `format=json` does not change that — the
+    /// fixture this replaced was a JSON guess at it. It is also the
+    /// single most likely first-contact outcome, because a key pending
+    /// programme activation reads exactly like no key at all.
+    const SAMPLE_INACTIVE_KEY_BODY: &str = "<h1>Developer Inactive</h1>";
 
     fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
         let td = TempDir::new().expect("tempdir");
@@ -486,8 +522,61 @@ mod tests {
         };
         assert!(hint.contains("articles"), "name the missing field: {hint}");
         assert!(
-            hint.contains("Developer Inactive"),
+            hint.contains("totalfound"),
             "quote what actually arrived, or the real shape stays invisible: {hint}"
+        );
+    }
+
+    /// #460: the branch a real user hits first, and the one nothing
+    /// covered.
+    ///
+    /// A 403 is an `HttpError::HttpStatus`, so it never reaches the JSON
+    /// parsing above — the `SourceSchema` test is not this path. Two
+    /// things have to hold on it:
+    ///
+    /// 1. the surfaced text carries the status, so "not activated yet"
+    ///    is distinguishable from "wrong key"; and
+    /// 2. the key is gone. IEEE is query-param auth, so the URL inside
+    ///    `HttpStatus` carries `apikey=` and that string is
+    ///    `tracing`-logged. #457 taught `redact_api_key_query` the
+    ///    `apikey` spelling; this is the end-to-end proof, through the
+    ///    HTTP layer rather than the module-local redactor alone.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn an_inactive_key_403_says_so_and_does_not_leak_the_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/search/articles"))
+            .respond_with(
+                ResponseTemplate::new(403)
+                    .insert_header("content-type", "text/xml")
+                    .set_body_string(SAMPLE_INACTIVE_KEY_BODY),
+            )
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.uri());
+        let src = TdmIeeeSource::with_base(Url::parse(&server.uri()).expect("wiremock URI parses"));
+        let profile = profile_with_ieee_grant();
+        let ref_ = Ref::Doi(Doi::parse("10.1109/TSP.2018.2812747").expect("DOI parses"));
+
+        let err = src
+            .fetch(&ref_, &profile, &ctx)
+            .await
+            .expect_err("403 must not look like success");
+        let rendered = err.to_string();
+
+        assert!(
+            rendered.contains("403"),
+            "the status is the only thing telling an inactive key from a wrong one: {rendered}"
+        );
+        assert!(
+            !rendered.contains(TEST_KEY),
+            "the api key must never reach an error string: {rendered}"
+        );
+        assert!(
+            rendered.contains("REDACTED"),
+            "the redaction must be visible, not just absent: {rendered}"
         );
     }
 

--- a/docs/DECISIONS/0042-tdm-ieee-inferred-contract.md
+++ b/docs/DECISIONS/0042-tdm-ieee-inferred-contract.md
@@ -102,6 +102,37 @@ guess and not saying so would be the same defect with a new name.
   spelling that does not add it there leaks its key into `HttpError::HttpStatus`.
   This is a registry that must be maintained by hand, and the module docs say so.
 
+## Addendum, 2026-08-24 (#460) — first contact, without a key
+
+One unauthenticated request settled part of the above:
+
+```text
+GET https://ieeexploreapi.ieee.org/api/v1/search/articles?doi=...&format=json
+HTTP=403  content-type=text/xml
+<h1>Developer Inactive</h1>
+```
+
+**Confirmed:** the base and path. The host resolves and the endpoint is served, so
+the first of the three inferred facts is now an observed one.
+
+**Corrected:** the error body is not JSON, and `format=json` does not make it so.
+The decision above assumed the loud-failure path would be `SourceSchema`; for an
+unauthorised caller it is `HttpError::HttpStatus`, which never reaches the JSON
+parsing at all. The fixture that encoded the wrong assumption
+(`{"error": "Developer Inactive"}`) was a guess and has been replaced by the
+observed body, plus a test on the HTTP branch asserting the status is legible and
+the key is redacted out of it.
+
+**Still unverified:** the 200-response envelope and the rate limits. The
+`(unverified)` marking in `SOURCES.md` §1 stands and now means specifically those
+two, not the endpoint.
+
+Also found while doing this: `tdm-ieee` **did not compile on its own**.
+`TdmGrant::api_key` is gated on an `any(...)` that named the first three publishers
+and not the fourth, and the four-way CI job hid it because the others were always
+present. Fixed, with an `oa-only,tdm-ieee` singleton added to the clippy matrix —
+one singleton job is not enough; each publisher needs its own.
+
 **Revisit** when a run with a real programme key is observed: correct whatever it
 disagrees with, drop the `(unverified)` marking, and record the observed rate
 limits.

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -172,11 +172,17 @@ key as an `apikey` **query parameter**, as with Springer rather than the
 (`{ total_records, total_searched, articles: [...] }`) are taken from IEEE's
 public developer portal and SDKs.
 
-The failure mode is loud, not silent: a response in any other shape is a schema
-error naming the missing field and quoting the body, so the first run against a
-real key reports the actual contract. `DOIGET_IEEE_BASE` replays that response
-against a fixture. **Do not drop the "unverified" marking in §1 until such a run
-has been observed.**
+One unauthenticated request on 2026-08-24 (#460) **confirmed the endpoint** — the
+host resolves and `/api/v1/search/articles` is served — and corrected the assumed
+failure shape: an unauthorised caller gets `403` with `content-type: text/xml` and
+a body of `<h1>Developer Inactive</h1>`, not JSON. So `(unverified)` in §1 now means
+specifically **the 200-response envelope and the rate limits**.
+
+The failure mode is loud, not silent: a 403 surfaces with its status and the key
+redacted out of the URL, and a 200 in any other shape is a schema error naming the
+missing field and quoting the body — so the first run against a real key reports the
+actual contract. `DOIGET_IEEE_BASE` replays that response against a fixture. **Do not
+drop the "unverified" marking in §1 until a 200 with a real key has been observed.**
 
 Rate limits are likewise unknown; the source is subject to the same hard-coded
 limiter as every other, which may be more or less polite than IEEE requires.

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -178,11 +178,17 @@ key as an `apikey` **query parameter**, as with Springer rather than the
 (`{ total_records, total_searched, articles: [...] }`) are taken from IEEE's
 public developer portal and SDKs.
 
-The failure mode is loud, not silent: a response in any other shape is a schema
-error naming the missing field and quoting the body, so the first run against a
-real key reports the actual contract. `DOIGET_IEEE_BASE` replays that response
-against a fixture. **Do not drop the "unverified" marking in §1 until such a run
-has been observed.**
+One unauthenticated request on 2026-08-24 (#460) **confirmed the endpoint** — the
+host resolves and `/api/v1/search/articles` is served — and corrected the assumed
+failure shape: an unauthorised caller gets `403` with `content-type: text/xml` and
+a body of `<h1>Developer Inactive</h1>`, not JSON. So `(unverified)` in §1 now means
+specifically **the 200-response envelope and the rate limits**.
+
+The failure mode is loud, not silent: a 403 surfaces with its status and the key
+redacted out of the URL, and a 200 in any other shape is a schema error naming the
+missing field and quoting the body — so the first run against a real key reports the
+actual contract. `DOIGET_IEEE_BASE` replays that response against a fixture. **Do not
+drop the "unverified" marking in §1 until a 200 with a real key has been observed.**
 
 Rate limits are likewise unknown; the source is subject to the same hard-coded
 limiter as every other, which may be more or less polite than IEEE requires.


### PR DESCRIPTION
Closes #460.

## First contact, without a key

ADR-0042 shipped `tdm-ieee` against an inferred contract and said the first contact with the real endpoint should correct it. One unauthenticated request does part of that now:

```
GET https://ieeexploreapi.ieee.org/api/v1/search/articles?doi=...&format=json
HTTP=403  content-type=text/xml
<h1>Developer Inactive</h1>
```

| inferred fact | status |
|---|---|
| base + path | **confirmed** — host resolves, endpoint is served |
| `apikey` query parameter | still inferred |
| 200 envelope `{ total_records, total_searched, articles }` | still inferred |
| rate limits | still unknown |

`(unverified)` in `SOURCES.md` §1 now means specifically the last two, not the endpoint.

## The branch nothing covered

`SAMPLE_UNEXPECTED_SHAPE` was `{"error": "Developer Inactive"}` — a JSON guess at a `text/xml` response. Worse, a 403 is an `HttpError::HttpStatus` and never reaches the JSON parsing at all, so the `SourceSchema` test was not testing the path a real user hits first. **A key pending programme activation reads exactly like no key at all**, and nothing asserted that the difference survives to the user.

```rust
assert!(rendered.contains("403"),
        "the status is the only thing telling an inactive key from a wrong one");
assert!(!rendered.contains(TEST_KEY),
        "the api key must never reach an error string");
assert!(rendered.contains("REDACTED"),
        "the redaction must be visible, not just absent");
```

That last one matters more than it looks: IEEE is query-param auth, so the URL inside `HttpStatus` carries `apikey=`, and that string is `tracing`-logged. #457 taught `redact_api_key_query` the `apikey` spelling; this is the first proof of it **through the HTTP layer**, rather than the module-local redactor in isolation.

## `tdm-ieee` did not compile on its own

```
$ cargo build -p doiget-core --no-default-features --features oa-only,tdm-ieee
error[E0609]: no field `api_key` on type `&TdmGrant`
error[E0560]: struct `TdmGrant` has no field named `api_key`
```

`TdmGrant::api_key` and its three population sites are gated on

```rust
#[cfg(any(feature = "tdm-elsevier", feature = "tdm-aps", feature = "tdm-springer"))]
```

— the first three publishers, not the fourth. #457 updated `docs/CAPABILITY.md`'s rendering of that `cfg` and missed the code.

**Why CI could not see it.** The Tier-3 jobs are the four-way union, where the other three features are always present and the field always exists, plus an `oa-only,tdm-aps` singleton. The singleton exists for exactly this class of problem — its own comment says *"the singleton proves `tdm-*` does not secretly depend on `metadata`"*. So the lesson is that **one** singleton is not enough; the matrix now carries `oa-only,tdm-ieee` beside it, and the comment says why.

Five `any(...)` lists in `lib.rs` were updated, not one — the field, its `Default`, and `build_tdm_grant`'s three arms.

## Also

`http.rs` asserted *"No other source puts a secret in the query string"* directly above the redaction that has handled two spellings since #430.

## Checks

```
clippy  oa-only | oa-only,citation | oa-only,tdm-aps | oa-only,tdm-ieee | four-way union   GREEN
test    oa-only                                                     0 failures
test    oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee  0 failures
cargo metadata --locked                                             in sync
```

The `oa-only,tdm-ieee` line is the one that fails without this diff.