### PR TITLE
feat(errors): carry the resolution trace and the remediation into MCP and batch --json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.9"
+version = "0.8.9-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.9"
+version = "0.8.9-beta.10"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.9"
+version = "0.8.9-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.9"
+version       = "0.8.9-beta.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -526,13 +526,13 @@ fn classify_joined(
                 } = &outcome.pdf_leg
                 {
                     let effective = effective_blocked_code(*code, denial.as_ref());
-                    let denial_value = denial.as_ref().and_then(denial_context_to_value);
                     let record = json_mode.then(|| {
                         build_jsonl_failure(
                             Some(&input),
                             effective.as_wire(),
                             message,
-                            denial_value,
+                            denial.as_ref(),
+                            &outcome.attempts,
                         )
                     });
                     let error_dbg =
@@ -558,11 +558,18 @@ fn classify_joined(
                 let error_dbg = format!("{e:?}");
                 let json_msg = format!("{e}");
                 let code: ErrorCode = (&e).into();
-                let denial_value = Option::<DenialContext>::from(&e)
-                    .as_ref()
-                    .and_then(denial_context_to_value);
+                let denial = Option::<DenialContext>::from(&e);
                 let record = json_mode.then(|| {
-                    build_jsonl_failure(Some(&input), code.as_wire(), &json_msg, denial_value)
+                    build_jsonl_failure(
+                        Some(&input),
+                        code.as_wire(),
+                        &json_msg,
+                        denial.as_ref(),
+                        // A typed `FetchError` carries no trace — the
+                        // orchestrator's `attempts` live on the outcome,
+                        // which this arm never got.
+                        &[],
+                    )
                 });
                 let failure = Some((input.clone(), code.as_wire()));
                 JoinedOutcome {
@@ -582,7 +589,7 @@ fn classify_joined(
             // would mishandle. Self-review for #209 §1.
             let json_msg = format!("batch task panicked: {join_err}");
             let record =
-                json_mode.then(|| build_jsonl_failure(None, "FETCH_ERROR", &json_msg, None));
+                json_mode.then(|| build_jsonl_failure(None, "FETCH_ERROR", &json_msg, None, &[]));
             JoinedOutcome {
                 is_error: true,
                 json_record: record,
@@ -655,12 +662,34 @@ fn build_jsonl_failure(
     ref_input: Option<&str>,
     code: &str,
     message: &str,
-    denial_context: Option<serde_json::Value>,
+    denial: Option<&DenialContext>,
+    attempts: &[doiget_core::orchestrator::SourceAttempt],
 ) -> serde_json::Value {
     let mut error = serde_json::json!({ "code": code, "message": message });
-    if let Some(dc) = denial_context {
-        if let Some(obj) = error.as_object_mut() {
-            obj.insert("denial_context".to_string(), dc);
+    if let Some(obj) = error.as_object_mut() {
+        if let Some(dc) = denial {
+            // Route through the logged helper (#154): a bare `json!` would
+            // coerce a future serialization failure to `null` with no trace.
+            if let Some(v) = denial_context_to_value(dc) {
+                obj.insert("denial_context".to_string(), v);
+            }
+            // #459: `denial_context` says what was refused; this says what
+            // to do. A CI consumer reading only the first can report a
+            // recoverable failure as a permanent one.
+            let r = doiget_core::remediation::for_denial(dc);
+            if !r.is_empty() {
+                obj.insert("remediation".to_string(), serde_json::json!(r));
+            }
+        }
+        // #459: the #438 resolution trace, which until now existed only as
+        // CLI text. Omitted entirely when empty rather than emitted as
+        // `[]`, so "no trace available" and "the trace is empty" stay
+        // distinguishable.
+        if !attempts.is_empty() {
+            obj.insert(
+                "attempts".to_string(),
+                doiget_core::orchestrator::attempts_to_value(attempts),
+            );
         }
     }
     serde_json::json!({
@@ -679,7 +708,10 @@ fn build_jsonl_failure(
 /// a policy denial (`docs/ERRORS.md` §3.1).
 #[allow(clippy::print_stdout)]
 fn emit_jsonl_failure(ref_input: Option<&str>, code: &str, message: &str) {
-    println!("{}", build_jsonl_failure(ref_input, code, message, None));
+    println!(
+        "{}",
+        build_jsonl_failure(ref_input, code, message, None, &[])
+    );
 }
 
 /// Emit a JSON-Lines record for a ref skipped because its PDF already exists
@@ -748,7 +780,7 @@ mod tests {
 
     #[test]
     fn jsonl_failure_shape_invalid_ref() {
-        let v = build_jsonl_failure(Some("not-a-doi"), "INVALID_REF", "bad ref", None);
+        let v = build_jsonl_failure(Some("not-a-doi"), "INVALID_REF", "bad ref", None, &[]);
         assert_eq!(v["ok"], false);
         assert_eq!(v["ref"], "not-a-doi");
         assert_eq!(v["error"]["code"], "INVALID_REF");
@@ -761,7 +793,7 @@ mod tests {
 
     #[test]
     fn jsonl_failure_shape_fetch_error() {
-        let v = build_jsonl_failure(Some("arxiv:2401.12345"), "NETWORK_ERROR", "boom", None);
+        let v = build_jsonl_failure(Some("arxiv:2401.12345"), "NETWORK_ERROR", "boom", None, &[]);
         assert_eq!(v["ok"], false);
         assert_eq!(v["ref"], "arxiv:2401.12345");
         assert_eq!(v["error"]["code"], "NETWORK_ERROR");
@@ -772,19 +804,25 @@ mod tests {
     fn jsonl_failure_shape_with_denial_context() {
         // #210: the structured `denial_context` carries the closed-enum
         // `reason` + per-source detail when a CAPABILITY_DENIED failure
-        // surfaces. Hand-craft the value to pin the wire shape — the
-        // serializer is `DenialContext`'s own `Serialize` impl (ADR-0023).
-        let dc = serde_json::json!({
-            "reason":    "redirect_not_in_allowlist",
-            "source":    "oa-publisher",
-            "attempted": "evil.example.com",
-            "expected":  ["good-publisher.example.org"],
-        });
+        // surfaces. Since #459 the builder takes the typed `DenialContext`
+        // rather than a pre-serialised value, so this now exercises
+        // `DenialContext`'s own `Serialize` impl (ADR-0023) end to end
+        // instead of a hand-written stand-in for it.
+        let dc = DenialContext {
+            reason: doiget_core::DenialReason::RedirectNotInAllowlist,
+            source: Some("oa-publisher".to_string()),
+            attempted: Some("strathprints.strath.ac.uk".to_string()),
+            expected: Some(vec!["good-publisher.example.org".to_string()]),
+            hop_index: None,
+            cap: None,
+            actual: None,
+        };
         let v = build_jsonl_failure(
             Some("10.1234/foo"),
             "CAPABILITY_DENIED",
             "redirect not in allowlist",
-            Some(dc),
+            Some(&dc),
+            &[],
         );
         assert_eq!(v["error"]["code"], "CAPABILITY_DENIED");
         assert_eq!(
@@ -794,7 +832,58 @@ mod tests {
         assert_eq!(v["error"]["denial_context"]["source"], "oa-publisher");
         assert_eq!(
             v["error"]["denial_context"]["attempted"],
-            "evil.example.com"
+            "strathprints.strath.ac.uk"
+        );
+
+        // #459: and the record now says what to DO. A CI consumer reading
+        // only `denial_context` reports a recoverable failure as a
+        // permanent one.
+        let rem = v["error"]["remediation"]
+            .as_array()
+            .expect("a redirect denial must carry remediation");
+        let values: Vec<&str> = rem.iter().filter_map(|x| x["value"].as_str()).collect();
+        assert!(
+            values.contains(&"*.strath.ac.uk"),
+            "the registrable-domain widening must be offered: {values:?}"
+        );
+        assert!(
+            rem.iter()
+                .any(|x| x["kind"] == "trust_flag" && x["value"] == "trust_academic_repos"),
+            "an *.ac.uk host must surface the curated flag: {values:?}"
+        );
+    }
+
+    /// #459: the trace an agent needs to tell "we asked and it had
+    /// nothing" from "we never asked". Absent entirely when there is no
+    /// trace, so the two are not conflated with an empty array.
+    #[test]
+    fn jsonl_failure_carries_the_resolution_trace() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+
+        let attempts = vec![
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: "DOIGET_ENABLE_HAL",
+                },
+            ),
+            SourceAttempt::new("core", AttemptOutcome::NoRecord),
+        ];
+        let v = build_jsonl_failure(Some("10.1/x"), "NOT_FOUND", "nope", None, &attempts);
+        let a = v["error"]["attempts"]
+            .as_array()
+            .expect("attempts must be present when the trace is non-empty");
+        assert_eq!(a[0]["source"], "hal");
+        assert_eq!(a[0]["outcome"], "not_consulted_disabled");
+        assert_eq!(a[0]["detail"], "DOIGET_ENABLE_HAL");
+        assert_eq!(a[0]["consulted"], false);
+        assert_eq!(a[1]["outcome"], "consulted_no_record");
+        assert_eq!(a[1]["consulted"], true);
+
+        let empty = build_jsonl_failure(Some("10.1/x"), "NOT_FOUND", "nope", None, &[]);
+        assert!(
+            empty["error"].get("attempts").is_none(),
+            "no trace must be absent, not an empty array: {empty}"
         );
     }
 
@@ -803,7 +892,7 @@ mod tests {
         // Self-review for #209 §1: a JoinSet panic loses the input, so
         // the record carries `ref: null` rather than a sentinel string
         // that a consumer doing `retry(rec["ref"])` would mishandle.
-        let v = build_jsonl_failure(None, "FETCH_ERROR", "batch task panicked: ...", None);
+        let v = build_jsonl_failure(None, "FETCH_ERROR", "batch task panicked: ...", None, &[]);
         assert_eq!(v["ok"], false);
         assert!(v["ref"].is_null(), "panic record's ref MUST be null: {v}");
         assert_eq!(v["error"]["code"], "FETCH_ERROR");
@@ -1003,12 +1092,12 @@ mod tests {
             !s.contains('\n'),
             "JSONL success must be single-line: {s:?}"
         );
-        let s2 = build_jsonl_failure(Some("10.1/x"), "FETCH_ERROR", "msg", None).to_string();
+        let s2 = build_jsonl_failure(Some("10.1/x"), "FETCH_ERROR", "msg", None, &[]).to_string();
         assert!(
             !s2.contains('\n'),
             "JSONL failure must be single-line: {s2:?}"
         );
-        let s3 = build_jsonl_failure(None, "FETCH_ERROR", "msg", None).to_string();
+        let s3 = build_jsonl_failure(None, "FETCH_ERROR", "msg", None, &[]).to_string();
         assert!(
             !s3.contains('\n'),
             "null-ref JSONL must be single-line: {s3:?}"

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1042,84 +1042,11 @@ pub(crate) fn cli_exit_code(code: ErrorCode) -> i32 {
     }
 }
 
-/// Widening suggestions for a refused host, most specific first (#443).
-///
-/// The `= help:` block used to name only the hop that was just refused, so
-/// a publisher whose PDF sits behind `www.x.org -> pubs.x.org` cost the
-/// user one edit-run cycle per hop. Naming the registrable domain too ends
-/// it in one.
-///
-/// It is also the policy-consistent suggestion. The built-in allowlist is
-/// written almost entirely as registrable-domain wildcards
-/// (`*.springer.com`, `*.wiley.com`, `*.aps.org`), and ADR-0027's stated
-/// mitigation for widening the trusted surface is exactly that they are
-/// "bounded registrable-domain wildcards". Suggesting a bare FQDN was both
-/// more work for the user and narrower than the convention the project
-/// applies to itself. The apex is offered alongside the wildcard because a
-/// single-suffix wildcard does not match it — the reason the built-in list
-/// already carries both forms for `doaj.org`, `arxiv.org` and friends.
-///
-/// Conservative by construction: a suggestion is emitted only when the
-/// derived parent is clearly registrable. Getting this exactly right needs
-/// the public suffix list, and a wrong guess here is not cosmetic — it
-/// would invite the user to trust `*.co.uk`.
-fn widening_suggestions(host: &str) -> Vec<(String, &'static str)> {
-    let mut out = vec![(host.to_string(), "this hop only")];
-    let labels: Vec<&str> = host.split('.').filter(|l| !l.is_empty()).collect();
-    if labels.len() < 2 || looks_like_public_suffix(&labels) {
-        return out;
-    }
-    if labels.len() == 2 {
-        // Already the apex: the useful widening is its subdomains.
-        out.push((format!("*.{host}"), "and its subdomains"));
-        return out;
-    }
-    let parent_labels = &labels[1..];
-    if looks_like_public_suffix(parent_labels) {
-        return out;
-    }
-    let parent = parent_labels.join(".");
-    out.push((format!("*.{parent}"), "the whole publisher"));
-    out.push((parent, "apex too (a wildcard does not match it)"));
-    out
-}
-
-/// Whether `labels` looks like a public suffix rather than something a
-/// single organisation registered.
-///
-/// Deliberately crude and deliberately over-cautious: the cost of a false
-/// positive is one missing suggestion, and the cost of a false negative is
-/// telling a user to trust every domain under `co.uk`.
-fn looks_like_public_suffix(labels: &[&str]) -> bool {
-    match labels {
-        // A bare TLD.
-        [_] => true,
-        // `co.uk`, `ac.jp`, `com.au`, … — a known second level under a
-        // two-letter ccTLD. `example.co.uk` has three labels and is NOT
-        // caught here, which is correct.
-        [sld, tld] => {
-            tld.len() == 2
-                && matches!(
-                    *sld,
-                    "co" | "com"
-                        | "ne"
-                        | "net"
-                        | "or"
-                        | "org"
-                        | "ac"
-                        | "edu"
-                        | "gov"
-                        | "go"
-                        | "gr"
-                        | "lg"
-                        | "mil"
-                        | "id"
-                        | "in"
-                )
-        }
-        _ => false,
-    }
-}
+// `widening_suggestions` / `looks_like_public_suffix` moved to
+// `doiget_core::remediation` in #459 so the MCP and `batch --json`
+// surfaces render the same suggestions this block does, rather than a
+// second implementation of them. #454 is the recent lesson about two
+// surfaces each keeping their own copy of a rule.
 
 /// Build the ADR-0023 `denial_context` advisory lines shared by
 /// [`render_fetch_error`] and [`render_blocked_error`]: the `= note:`
@@ -1168,7 +1095,7 @@ fn denial_note_lines(dc: &DenialContext, config_path: Option<&camino::Utf8Path>)
             .to_string(),
     );
     if dc.attempted.is_some() {
-        for (pattern, why) in widening_suggestions(attempted) {
+        for (pattern, why) in doiget_core::remediation::widening_suggestions(attempted) {
             out.push(format!(
                 "          [[network.additional_hosts]] host = \"{pattern}\"   # {why}"
             ));
@@ -2012,7 +1939,7 @@ host = "*.uj.edu.pl"
             "repository.ruj.uj.edu.pl",
             "link.springer.com",
         ] {
-            for (pattern, _) in widening_suggestions(host) {
+            for (pattern, _) in doiget_core::remediation::widening_suggestions(host) {
                 doiget_core::user_extension::validate_pattern(&pattern).unwrap_or_else(|e| {
                     panic!("suggested `{pattern}` for `{host}`, which the validator rejects: {e:?}")
                 });
@@ -2032,7 +1959,7 @@ host = "*.uj.edu.pl"
             ("foo.com.au", "com.au"),
             ("example.org", "org"),
         ] {
-            let joined: String = widening_suggestions(host)
+            let joined: String = doiget_core::remediation::widening_suggestions(host)
                 .into_iter()
                 .map(|(p, _)| p)
                 .collect::<Vec<_>>()
@@ -2050,10 +1977,11 @@ host = "*.uj.edu.pl"
     /// `strath.ac.uk` is a real registration, not a public suffix.
     #[test]
     fn a_four_label_academic_host_still_gets_its_institution_wildcard() {
-        let got: Vec<String> = widening_suggestions("strathprints.strath.ac.uk")
-            .into_iter()
-            .map(|(p, _)| p)
-            .collect();
+        let got: Vec<String> =
+            doiget_core::remediation::widening_suggestions("strathprints.strath.ac.uk")
+                .into_iter()
+                .map(|(p, _)| p)
+                .collect();
         assert!(
             got.iter().any(|p| p == "*.strath.ac.uk"),
             "expected the institution wildcard; got {got:?}"
@@ -2064,7 +1992,7 @@ host = "*.uj.edu.pl"
     /// downward.
     #[test]
     fn an_apex_host_offers_its_subdomains() {
-        let got: Vec<String> = widening_suggestions("ams.org")
+        let got: Vec<String> = doiget_core::remediation::widening_suggestions("ams.org")
             .into_iter()
             .map(|(p, _)| p)
             .collect();

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod paper_text;
 pub mod provenance;
 pub mod rate_limiter;
 pub mod refs;
+pub mod remediation;
 pub mod resolver_cache;
 pub mod source;
 pub mod sources;

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -3453,6 +3453,46 @@ impl AttemptOutcome {
         )
     }
 
+    /// Stable machine token for this outcome (#459).
+    ///
+    /// [`Self::render`] is prose and may be reworded; this is the thing a
+    /// consumer branches on. Kept separate for that reason — the CLI has
+    /// already reworded the trace twice (#413, #438) and a caller keying
+    /// off the sentence would have broken both times.
+    ///
+    /// The two halves of the vocabulary mirror [`Self::was_consulted`]:
+    /// `not_consulted_*` means no request went out, `consulted_*` means one
+    /// did. That distinction is the entire reason this type exists.
+    #[must_use]
+    pub fn wire(&self) -> &'static str {
+        match self {
+            Self::Disabled { .. } => "not_consulted_disabled",
+            Self::NotApplicable => "not_consulted_not_applicable",
+            Self::WrongPublisher { .. } => "not_consulted_wrong_publisher",
+            Self::NotNeeded => "not_consulted_not_needed",
+            Self::NoRecord => "consulted_no_record",
+            Self::NotOpenAccess { .. } => "consulted_not_open_access",
+            Self::Failed { .. } => "consulted_failed",
+            Self::Resolved => "consulted_resolved",
+        }
+    }
+
+    /// The variant's free-text payload, when it has one.
+    ///
+    /// Carried separately from [`Self::wire`] so a consumer gets the
+    /// actionable specifics — which env var, which prefix, which error —
+    /// without parsing them back out of the rendered sentence.
+    #[must_use]
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            Self::Disabled { env } => Some(env),
+            Self::WrongPublisher { detail }
+            | Self::NotOpenAccess { detail }
+            | Self::Failed { detail } => Some(detail),
+            _ => None,
+        }
+    }
+
     /// One-line rendering, phrased so consulted and not-consulted cannot
     /// be misread for one another.
     #[must_use]
@@ -3488,6 +3528,40 @@ impl SourceAttempt {
     pub fn new(source: &'static str, outcome: AttemptOutcome) -> Self {
         Self { source, outcome }
     }
+}
+
+/// The trace as JSON, for the machine-readable surfaces (#459).
+///
+/// One object per source: `{ source, outcome, detail?, consulted }`.
+///
+/// `consulted` is redundant with `outcome` and present anyway. It is the
+/// single question every consumer of this array actually has — "did anyone
+/// else look?" — and making them memorise which of eight tokens implies it
+/// invites the exact confusion the type was introduced to end.
+///
+/// Built here rather than by `#[derive(Serialize)]` on the types: both are
+/// `#[non_exhaustive]` public API, and deriving would make every future
+/// variant a wire change by default instead of by decision.
+#[must_use]
+pub fn attempts_to_value(attempts: &[SourceAttempt]) -> serde_json::Value {
+    serde_json::Value::Array(
+        attempts
+            .iter()
+            .map(|a| {
+                let mut o = serde_json::Map::new();
+                o.insert("source".into(), serde_json::json!(a.source));
+                o.insert("outcome".into(), serde_json::json!(a.outcome.wire()));
+                if let Some(d) = a.outcome.detail() {
+                    o.insert("detail".into(), serde_json::json!(d));
+                }
+                o.insert(
+                    "consulted".into(),
+                    serde_json::json!(a.outcome.was_consulted()),
+                );
+                serde_json::Value::Object(o)
+            })
+            .collect(),
+    )
 }
 
 /// Render a whole trace as an `= note:`-style block.

--- a/crates/doiget-core/src/remediation.rs
+++ b/crates/doiget-core/src/remediation.rs
@@ -1,0 +1,320 @@
+//! Machine-readable remediation hints for a denial (#459).
+//!
+//! [`DenialContext`] (ADR-0023) says what was refused. It does not say what
+//! to do about it, and until now the only place that did was CLI text —
+//! the `= help:` block from #443. An agent driving doiget over MCP, or a
+//! CI job reading `batch --json`, got the refusal and nothing else.
+//!
+//! That gap has a concrete cost. A hybrid-OA paper whose only free copy
+//! sits in a university repository is refused with
+//! `redirect_not_in_allowlist`, and is fetchable after **one line** of
+//! config — either the host, or the `trust_academic_repos` flag that
+//! already knows about `*.ac.uk`. An agent that cannot find that line
+//! reports "this paper is not available", which is false.
+//!
+//! So the hints live here, in core, computed once and rendered by every
+//! surface. The CLI's `= help:` block, the MCP envelope and the
+//! `batch --json` record all read the same [`Remediation`] list; #454 is
+//! the recent lesson about what happens when two surfaces each keep their
+//! own copy of a rule.
+
+use serde::Serialize;
+
+use crate::user_extension::{academic_repo_hosts, oa_registry_hosts};
+use crate::{DenialContext, DenialReason};
+
+/// What kind of change would lift this denial.
+///
+/// Deliberately a closed set, and deliberately **not** collapsed into one
+/// "here is a string to paste": the two kinds do different things to the
+/// trusted surface, and a caller has to be able to tell them apart. Adding
+/// a host trusts one publisher. Setting a trust flag trusts a curated
+/// class of hosts (ADR-0028). An agent choosing between them is making a
+/// policy decision on the user's behalf and should be able to see that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RemediationKind {
+    /// Add a host pattern under `[[network.additional_hosts]]`.
+    AdditionalHost,
+    /// Set a `[network]` boolean that trusts a curated host class.
+    TrustFlag,
+}
+
+/// One suggested change, with the reason it is being suggested.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct Remediation {
+    /// Which kind of change this is.
+    pub kind: RemediationKind,
+    /// The host pattern to add, or the flag name to set.
+    pub value: String,
+    /// Why this entry is offered, phrased for a human reading a log.
+    pub note: String,
+}
+
+/// Suggestions that would lift `denial`, most specific first.
+///
+/// Empty for reasons with no configuration channel — a size cap or a
+/// capability gate is not fixed by editing the allowlist, and offering a
+/// host to add there would be actively misleading.
+#[must_use]
+pub fn for_denial(denial: &DenialContext) -> Vec<Remediation> {
+    let mut out = Vec::new();
+    // Only the host-allowlist reasons have a config channel.
+    // `InsecureScheme` is deliberately excluded: the fix for an `http://`
+    // redirect is not to trust the host, and ADR-0027 offers no opt-out.
+    if !matches!(
+        denial.reason,
+        DenialReason::RedirectNotInAllowlist | DenialReason::HostInBlockList
+    ) {
+        return out;
+    }
+    let Some(host) = denial.attempted.as_deref() else {
+        return out;
+    };
+
+    for (pattern, why) in widening_suggestions(host) {
+        out.push(Remediation {
+            kind: RemediationKind::AdditionalHost,
+            value: pattern,
+            note: why.to_string(),
+        });
+    }
+
+    // The flag comes last but is usually the better answer when it
+    // applies: it is one line, it is curated, and it covers the next
+    // repository as well as this one.
+    if let Some((flag, pattern, why)) = trust_flag_for_host(host) {
+        out.push(Remediation {
+            kind: RemediationKind::TrustFlag,
+            value: flag.to_string(),
+            note: format!("{host} matches {pattern} — {why}"),
+        });
+    }
+    out
+}
+
+/// The `[network]` trust flag that already covers `host`, if any.
+///
+/// Returns the flag name, the curated pattern that matched, and that
+/// pattern's own note, so the caller can say *why* the flag applies rather
+/// than asserting that it does.
+#[must_use]
+pub fn trust_flag_for_host(host: &str) -> Option<(&'static str, String, String)> {
+    let host_lc = host.to_ascii_lowercase();
+    for (flag, hosts) in [
+        ("trust_academic_repos", academic_repo_hosts()),
+        ("trust_oa_registries", oa_registry_hosts()),
+    ] {
+        for h in hosts {
+            if pattern_matches(&host_lc, h.host.as_str()) {
+                return Some((
+                    flag,
+                    h.host.as_str().to_string(),
+                    h.note.unwrap_or_else(|| "a curated host class".to_string()),
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// `docs/REDIRECT_ALLOWLIST.md` §2.2 matching, against an already-lowercased
+/// host.
+///
+/// The same rule `http::SourceAllowlist::matches` applies, kept local
+/// rather than building a throwaway `SourceAllowlist` per call. Both are
+/// three lines and neither is likely to change — but if §2.2 ever does,
+/// this must change with it.
+fn pattern_matches(host_lc: &str, pattern: &str) -> bool {
+    let pat_lc = pattern.to_ascii_lowercase();
+    match pat_lc.strip_prefix("*.") {
+        Some(suffix) => host_lc == suffix || host_lc.ends_with(&format!(".{suffix}")),
+        None => host_lc == pat_lc,
+    }
+}
+
+/// Widening suggestions for a refused host, most specific first (#443).
+///
+/// The `= help:` block used to name only the hop that was just refused, so
+/// a publisher whose PDF sits behind `www.x.org -> pubs.x.org` cost the
+/// user one edit-run cycle per hop. Naming the registrable domain too ends
+/// it in one.
+///
+/// It is also the policy-consistent suggestion. The built-in allowlist is
+/// written almost entirely as registrable-domain wildcards
+/// (`*.springer.com`, `*.wiley.com`, `*.aps.org`), and ADR-0027's stated
+/// mitigation for widening the trusted surface is exactly that they are
+/// "bounded registrable-domain wildcards". Suggesting a bare FQDN was both
+/// more work for the user and narrower than the convention the project
+/// applies to itself. The apex is offered alongside the wildcard because a
+/// single-suffix wildcard does not match it — the reason the built-in list
+/// already carries both forms for `doaj.org`, `arxiv.org` and friends.
+///
+/// Conservative by construction: a suggestion is emitted only when the
+/// derived parent is clearly registrable. Getting this exactly right needs
+/// the public suffix list, and a wrong guess here is not cosmetic — it
+/// would invite the user to trust `*.co.uk`.
+///
+/// Moved here from `doiget-cli` in #459 so the MCP and `batch --json`
+/// surfaces get the same suggestions as the CLI rather than a second
+/// implementation of them.
+#[must_use]
+pub fn widening_suggestions(host: &str) -> Vec<(String, &'static str)> {
+    let mut out = vec![(host.to_string(), "this hop only")];
+    let labels: Vec<&str> = host.split('.').filter(|l| !l.is_empty()).collect();
+    if labels.len() < 2 || looks_like_public_suffix(&labels) {
+        return out;
+    }
+    if labels.len() == 2 {
+        // Already the apex: the useful widening is its subdomains.
+        out.push((format!("*.{host}"), "and its subdomains"));
+        return out;
+    }
+    let parent_labels = &labels[1..];
+    if looks_like_public_suffix(parent_labels) {
+        return out;
+    }
+    let parent = parent_labels.join(".");
+    out.push((format!("*.{parent}"), "the whole publisher"));
+    out.push((parent, "apex too (a wildcard does not match it)"));
+    out
+}
+
+/// Whether `labels` looks like a public suffix rather than something a
+/// single organisation registered.
+///
+/// Deliberately crude and deliberately over-cautious: the cost of a false
+/// positive is one missing suggestion, and the cost of a false negative is
+/// telling a user to trust every domain under `co.uk`.
+fn looks_like_public_suffix(labels: &[&str]) -> bool {
+    match labels {
+        // A bare TLD.
+        [_] => true,
+        // `co.uk`, `ac.jp`, `com.au`, … — a known second level under a
+        // two-letter ccTLD. `example.co.uk` has three labels and is NOT
+        // caught here, which is correct.
+        [sld, tld] => {
+            tld.len() == 2
+                && matches!(
+                    *sld,
+                    "co" | "com"
+                        | "ne"
+                        | "net"
+                        | "or"
+                        | "org"
+                        | "ac"
+                        | "edu"
+                        | "gov"
+                        | "go"
+                        | "gr"
+                        | "lg"
+                        | "mil"
+                        | "id"
+                        | "in"
+                )
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn denial(host: &str) -> DenialContext {
+        DenialContext {
+            reason: DenialReason::RedirectNotInAllowlist,
+            source: Some("oa-publisher".to_string()),
+            attempted: Some(host.to_string()),
+            expected: Some(vec!["*.arxiv.org".to_string()]),
+            hop_index: None,
+            cap: None,
+            actual: None,
+        }
+    }
+
+    /// The exact case that motivated #459: a real fetch, refused, that
+    /// `trust_academic_repos` fixes in one line. The flag has to be in the
+    /// output or an agent cannot find it.
+    #[test]
+    fn a_university_repository_offers_the_trust_flag_as_well_as_the_host() {
+        let r = for_denial(&denial("strathprints.strath.ac.uk"));
+        let hosts: Vec<&str> = r
+            .iter()
+            .filter(|x| x.kind == RemediationKind::AdditionalHost)
+            .map(|x| x.value.as_str())
+            .collect();
+        assert_eq!(
+            hosts,
+            vec![
+                "strathprints.strath.ac.uk",
+                "*.strath.ac.uk",
+                "strath.ac.uk"
+            ],
+            "the #443 widening set, unchanged by the move"
+        );
+
+        let flag = r
+            .iter()
+            .find(|x| x.kind == RemediationKind::TrustFlag)
+            .expect("an *.ac.uk host must surface trust_academic_repos");
+        assert_eq!(flag.value, "trust_academic_repos");
+        assert!(
+            flag.note.contains("*.ac.uk"),
+            "say WHICH curated pattern matched, or the flag looks like a guess: {}",
+            flag.note
+        );
+    }
+
+    /// A publisher host has no curated class, so only the host route is
+    /// offered. Suggesting a trust flag that would not have helped is the
+    /// same failure as #442's "go find an API key" — it sends the user
+    /// after the wrong fix.
+    #[test]
+    fn a_publisher_host_offers_no_trust_flag() {
+        let r = for_denial(&denial("pubs.ams.org"));
+        assert!(
+            r.iter().all(|x| x.kind == RemediationKind::AdditionalHost),
+            "no curated class covers ams.org: {r:?}"
+        );
+        assert_eq!(
+            r.iter().map(|x| x.value.as_str()).collect::<Vec<_>>(),
+            vec!["pubs.ams.org", "*.ams.org", "ams.org"]
+        );
+    }
+
+    /// Reasons with no configuration channel must offer nothing. An
+    /// oversized body is not fixed by trusting the host, and saying so
+    /// would be worse than silence.
+    #[test]
+    fn a_reason_with_no_config_channel_suggests_nothing() {
+        for reason in [
+            DenialReason::SizeCapExceeded,
+            DenialReason::InsecureScheme,
+            DenialReason::CapabilityNotGranted,
+        ] {
+            let mut d = denial("example.org");
+            d.reason = reason;
+            assert!(
+                for_denial(&d).is_empty(),
+                "{reason:?} has no allowlist channel, so it must suggest nothing"
+            );
+        }
+    }
+
+    /// Guarding the one mistake that is not cosmetic.
+    #[test]
+    fn a_public_suffix_is_never_offered_for_trust() {
+        for host in ["example.co.uk", "example.ac.jp", "foo.com", "localhost"] {
+            for (pattern, _) in widening_suggestions(host) {
+                assert!(
+                    !matches!(pattern.as_str(), "*.co.uk" | "co.uk" | "*.ac.jp" | "ac.jp"),
+                    "{host} must never suggest trusting a public suffix, got {pattern}"
+                );
+            }
+        }
+    }
+}

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -548,7 +548,10 @@ impl Server {
     #[tool(
         description = "WHEN TO USE: User wants to download a paper PDF given a DOI or arXiv id.\n\
                        INPUTS: ref (DOI or arXiv id), dry_run (optional bool).\n\
-                       OUTPUTS: { ok: true, ref, source, path, license, size_bytes, schema_version } OR { ok: true, dry_run: true, ref, plan, rate_limit_budget } OR { ok:false, ref, error }.\n\
+                       OUTPUTS: { ok: true, ref, source, path, license, size_bytes, schema_version, pdf, attempts } OR { ok: true, dry_run: true, ref, plan, rate_limit_budget } OR { ok:false, ref, error }.\n\
+                       READ `pdf.status` — `ok: true` does NOT mean a PDF landed. `fetched` = PDF on disk; `no_oa_url` = metadata only, no free copy exists; `blocked` = a free copy EXISTS but was refused.\n\
+                       ON `blocked`: do not report the paper as unavailable. `pdf.remediation` lists the config changes that would lift it, narrowest first — `additional_host` entries go under [[network.additional_hosts]] in the config file, a `trust_flag` is a [network] boolean. Show them to the user and let them choose; both widen the trusted download surface.\n\
+                       `attempts` says which other sources were consulted and which were never asked (`consulted: false` + `detail` naming the env var to set). Use it before concluding a paper is not indexed anywhere.\n\
                        COSTS: 1-3 s network call (or 0 when dry_run). May fail if not Open Access.\n\
                        SIDE EFFECTS: Writes PDF (or metadata-only TOML) to the store. Appends a row to the provenance log (unless dry_run).\n\
                        LIMITS: Max 5 fetches/sec (global). Use doiget_batch_fetch for >5 refs.",
@@ -3262,6 +3265,17 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
                     "denial_context".into(),
                     denial_context_to_value(dc, "fetch_paper_pdf_leg"),
                 );
+                // #459: `denial_context` says what was refused. This says
+                // what to do about it — the same suggestions the CLI's
+                // `= help:` block prints, from the same core function.
+                //
+                // Without it an agent sees a refusal and 24 patterns that
+                // are not the host, and reports "not available" for a
+                // paper that one line of config would have fetched.
+                let r = doiget_core::remediation::for_denial(dc);
+                if !r.is_empty() {
+                    o.insert("remediation".into(), json!(r));
+                }
             }
             if let Some(arxiv_id) = suggested_arxiv_id {
                 o.insert("suggested_arxiv_id".into(), json!(arxiv_id));
@@ -3309,7 +3323,22 @@ fn fetch_paper_success_envelope(outcome: &FetchPaperOutcome, ref_str: &str) -> V
         "year": outcome.year,
         // Issue #118: never a silent metadata-only success.
         "pdf": pdf_leg_json(&outcome.pdf_leg),
+        // #459: the #438 resolution trace. "We asked and it had nothing"
+        // and "we never asked" need different actions, and until now only
+        // the CLI was told which had happened. `null` rather than `[]`
+        // when there is no trace, so "unavailable" stays distinguishable
+        // from "empty".
+        "attempts": attempts_json(&outcome.attempts),
     })
+}
+
+/// Serialise the resolution trace, or `null` when there is none.
+fn attempts_json(attempts: &[doiget_core::orchestrator::SourceAttempt]) -> Value {
+    if attempts.is_empty() {
+        Value::Null
+    } else {
+        doiget_core::orchestrator::attempts_to_value(attempts)
+    }
 }
 
 /// Build the `{ok:false, ref, error:{code, message}}` envelope for
@@ -4435,6 +4464,121 @@ mod tests {
             "user-extension host must appear in the oa-publisher allowlist; \
              got: {:?}",
             oa.redirect_hosts
+        );
+    }
+
+    /// #459: a blocked PDF leg must say what would lift it.
+    ///
+    /// Before this the envelope carried `denial_context` — the host and
+    /// the 24 patterns that are not it — and nothing else. An agent that
+    /// cannot find the one-line fix reports "this paper is not
+    /// available", which for the DOI in ADR-0043 is false: it fetches
+    /// after `trust_academic_repos = true`.
+    #[test]
+    fn a_blocked_leg_carries_the_remediation_that_would_lift_it() {
+        use doiget_core::{DenialContext, DenialReason};
+
+        let leg = PdfLegStatus::Blocked {
+            code: ErrorCode::NetworkError,
+            message: "redirect target strathprints.strath.ac.uk not in allowlist".to_string(),
+            denial: Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: Some("oa-publisher".to_string()),
+                attempted: Some("strathprints.strath.ac.uk".to_string()),
+                expected: Some(vec!["*.arxiv.org".to_string()]),
+                hop_index: None,
+                cap: None,
+                actual: None,
+            }),
+            suggested_arxiv_id: None,
+        };
+        let v = pdf_leg_json(&leg);
+        let rem = v["remediation"]
+            .as_array()
+            .expect("a redirect denial must carry remediation");
+
+        assert!(
+            rem.iter().any(|x| x["value"] == "*.strath.ac.uk"),
+            "the #443 registrable-domain widening must reach MCP too: {v}"
+        );
+        let flag = rem
+            .iter()
+            .find(|x| x["kind"] == "trust_flag")
+            .expect("an *.ac.uk host must surface the curated flag");
+        assert_eq!(flag["value"], "trust_academic_repos");
+        assert!(
+            flag["note"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("*.ac.uk"),
+            "name the pattern that matched, or the flag reads as a guess: {flag}"
+        );
+    }
+
+    /// The converse: a denial with no configuration channel must offer
+    /// nothing. Suggesting a host to trust for an oversized body sends
+    /// the caller after a fix that cannot work.
+    #[test]
+    fn a_denial_with_no_config_channel_carries_no_remediation() {
+        use doiget_core::{DenialContext, DenialReason};
+
+        let leg = PdfLegStatus::Blocked {
+            code: ErrorCode::NetworkError,
+            message: "body exceeded the size cap".to_string(),
+            denial: Some(DenialContext {
+                reason: DenialReason::SizeCapExceeded,
+                source: Some("oa-publisher".to_string()),
+                attempted: None,
+                expected: None,
+                hop_index: None,
+                cap: Some(104_857_600),
+                actual: Some(209_715_200),
+            }),
+            suggested_arxiv_id: None,
+        };
+        let v = pdf_leg_json(&leg);
+        assert!(
+            v.get("remediation").is_none(),
+            "a size cap is not fixed by trusting a host: {v}"
+        );
+        assert!(
+            v.get("denial_context").is_some(),
+            "the denial context itself must still be there: {v}"
+        );
+    }
+
+    /// #459: the trace, and the distinction it exists to make. Absent
+    /// rather than `[]` when unavailable — #413 was filed because those
+    /// two were the same observable.
+    #[test]
+    fn attempts_json_distinguishes_no_trace_from_an_empty_one() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+
+        assert!(
+            attempts_json(&[]).is_null(),
+            "no trace must be null, not an empty array"
+        );
+
+        let a = attempts_json(&[
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: "DOIGET_ENABLE_HAL",
+                },
+            ),
+            SourceAttempt::new("core", AttemptOutcome::NoRecord),
+        ]);
+        let rows = a.as_array().expect("array");
+        assert_eq!(rows[0]["outcome"], "not_consulted_disabled");
+        assert_eq!(
+            rows[0]["detail"], "DOIGET_ENABLE_HAL",
+            "name the var to set, or the agent cannot act on it"
+        );
+        assert_eq!(rows[0]["consulted"], false);
+        assert_eq!(rows[1]["outcome"], "consulted_no_record");
+        assert_eq!(
+            rows[1]["consulted"], true,
+            "asked-and-empty is not the same as never-asked"
         );
     }
 

--- a/docs/DECISIONS/0043-machine-readable-diagnostics.md
+++ b/docs/DECISIONS/0043-machine-readable-diagnostics.md
@@ -1,0 +1,116 @@
+# 0043 - The machine-readable surfaces carry the trace and the remediation
+
+- **Date:** 2026-08-24
+- **Status:** Accepted
+- **Supersedes:** - (extends [0023](0023-denial-context.md))
+- **Source:** #459, and the half of #445 that #448 left
+
+## Context
+
+Three issues this cycle made a blocked fetch actionable: #443 added the `= help:` block
+naming the registrable-domain widening, #448 attached the #438 resolution trace to
+blocked outcomes, and #449 made the content leg fall through. All three landed as **CLI
+text**. The MCP tool envelope and the `batch --json` record got none of it.
+
+Driving the real MCP server against the DOI #407 was written about shows what that costs.
+`doiget_fetch_paper` on `10.1109/TSP.2018.2812747` returns:
+
+```
+pdf: { status: "blocked",
+       code: "NETWORK_ERROR",
+       message: "redirect target strathprints.strath.ac.uk not in allowlist for source oa-publisher",
+       denial_context: { reason: "redirect_not_in_allowlist",
+                         attempted: "strathprints.strath.ac.uk",
+                         expected: [ 24 host patterns ] } }
+```
+
+An agent sees a refusal, the host, and 24 patterns that are not it. There is no
+`attempts`, and nothing says what to change.
+
+The same call, after adding **one line** of config:
+
+```
+ok: true    pdf: { status: "fetched" }    size_bytes: 880081
+```
+
+`strathprints.strath.ac.uk` is a university repository, `trust_academic_repos` exists for
+exactly that class, and `user_extension::academic_repo_hosts()` already knows the host.
+The information needed to get from the first output to the second was in the codebase and
+never reached the caller.
+
+An agent that cannot recover from a recoverable failure reports "this paper is not
+available". That is false, and it is false in a way the user cannot see.
+
+## Decision
+
+**Both surfaces carry both fields, additively, computed once in `doiget-core`.**
+
+`docs/ERRORS.md` §3.2 (`remediation`) and §3.3 (`attempts`) are the wire contract.
+Neither is required; §3.1's existing rule — consumers MUST tolerate presence and absence —
+extends to them unchanged, so no current consumer breaks.
+
+Four sub-decisions worth recording, because each had a cheaper alternative:
+
+**Computed in core, not per surface.** `widening_suggestions` moves out of `doiget-cli`
+into `doiget_core::remediation`, and the CLI's `= help:` block now renders the same list
+the MCP envelope serialises. The cheaper option was to copy it. #454 is the recent lesson
+about two surfaces each keeping their own copy of a rule: the Tier-3 allowlists had a
+guard asserting the list was right and no caller handing it to anyone, for three releases.
+
+**`kind` is a closed enum, not a pasteable string.** `additional_host` trusts one
+publisher; `trust_flag` trusts a curated class (ADR-0028). Collapsing them into one
+"here is what to paste" would hide a policy decision that an agent is making on the
+user's behalf.
+
+**`attempts.outcome` is a token, not the rendered sentence.** `AttemptOutcome::render`
+is prose and has already been reworded twice (#413, #438); a consumer keying off it would
+have broken both times. `wire()` is the stable half, `detail` carries the specifics —
+which env var, which prefix — so a consumer never has to parse them back out of a
+sentence.
+
+**`attempts` is absent when there is no trace, never `[]`.** "We have no trace" and "the
+trace ran and found nothing" are different, and #413 exists precisely because they used
+to be the same observable. Emitting `[]` for the first would reintroduce that.
+
+## Alternatives rejected
+
+**(a) Leave it; the CLI has the information.** Rejected because MCP is not a lesser
+surface. §3's persona table has always promised the agent a *structured* rendering of
+what the human is told — this is that promise going unkept, not a feature request.
+
+**(b) Fold the hints into `error.message`.** Cheapest, and it works for a human tailing
+a log. It makes an agent parse English to find a config key, which is the failure mode
+`denial_context` was introduced to end (ADR-0023). Doing it again one field over would be
+strange.
+
+**(c) Derive `Serialize` on `SourceAttempt` / `AttemptOutcome`.** Fewer lines. Both are
+`#[non_exhaustive]` public API, so deriving makes every future variant a wire change by
+default rather than by decision. `attempts_to_value` keeps the wire shape a thing someone
+chose.
+
+## Consequences
+
+**Positive.**
+
+- An agent can recover from an allowlist denial without a human, and can tell "we asked
+  and it had nothing" from "we never asked" — the #413 distinction, finally available to
+  the caller that most needs it.
+- One implementation of the widening rule, so the CLI and MCP cannot drift.
+- The `--mode json` half of #445 is closed, for all three surfaces rather than the one it
+  asked about.
+
+**Negative / accepted.**
+
+- Two more closed enums to version. Both are small and both are already the kind of thing
+  ADR-0023 versions.
+- `remediation` is advisory. It suggests widening the trusted surface, and a caller that
+  applies every suggestion without thought will trust more than it needed to. The `note`
+  field exists to make the trade visible, and the most-specific-first ordering means the
+  narrowest fix is read first. Not a substitute for the user's judgement, and
+  `docs/SECURITY.md`'s posture on the allowlist is unchanged: doiget suggests, the user
+  edits the file.
+- The trust flag is offered only when a curated pattern already matches, so it can never
+  invent a new class — but the curated lists are static data and will age.
+
+**Revisit** if a third machine-readable surface appears, or if `remediation` grows a kind
+that is not a config edit.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -59,6 +59,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0040 | Source expansion gated by the existing `metadata` feature, runtime-gated off | Accepted (0.8.8) | `feat/adr-source-and-allowlist-decisions` | #413 |
 | 0041 | Tier-3 TDM sources are scoped to their publisher's DOI prefixes | Accepted (0.8.9) | `fix/442-tier3-orchestrator-wiring` | #442 |
 | 0042 | `tdm-ieee` ships against an inferred contract, marked unverified | Accepted (0.8.9) | `feat/430-tdm-ieee` | #430 |
+| 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
 
 ## Conventions
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -55,9 +55,9 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 
 | Persona | Surface |
 |---|---|
-| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context? } }`. Never throws. |
+| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context?, remediation?, attempts? } }`. Never throws. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
-| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?}}`. Exit code = number of failures (capped at 255). |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
 
 ### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
@@ -97,6 +97,58 @@ renaming or repurposing one is a breaking change.
 
 `error.message` MUST continue to embed the same parameters in human-readable
 form — `denial_context` is a parallel channel, not a replacement.
+
+### 3.2 Structured `remediation` (NORMATIVE; ADR-0043)
+
+`denial_context` says what was refused. `remediation` says what would lift it.
+Both are **optional and additive**; consumers MUST tolerate presence and absence.
+
+```jsonc
+"remediation": [
+  { "kind": "additional_host", "value": "strathprints.strath.ac.uk", "note": "this hop only" },
+  { "kind": "additional_host", "value": "*.strath.ac.uk",            "note": "the whole publisher" },
+  { "kind": "additional_host", "value": "strath.ac.uk",              "note": "apex too (a wildcard does not match it)" },
+  { "kind": "trust_flag",      "value": "trust_academic_repos",
+    "note": "strathprints.strath.ac.uk matches *.ac.uk — UK academic institutions (Universities UK)" }
+]
+```
+
+`kind` is a **closed** enum: `additional_host` (a pattern for
+`[[network.additional_hosts]]`) and `trust_flag` (a `[network]` boolean). Adding a
+variant is a minor semver bump.
+
+The two kinds are deliberately not collapsed into one pasteable string: adding a host
+trusts one publisher, a trust flag trusts a curated class (ADR-0028), and a caller
+choosing between them is making a policy decision on the user's behalf.
+
+Emitted only for reasons with a configuration channel — `redirect_not_in_allowlist` and
+`host_in_block_list`. A `size_cap_exceeded` or `capability_not_granted` denial carries no
+`remediation`, because offering a host to trust would send the caller after a fix that
+cannot work.
+
+### 3.3 Structured `attempts` (NORMATIVE; ADR-0043)
+
+The resolution trace introduced in #413/#438, previously CLI text only.
+
+```jsonc
+"attempts": [
+  { "source": "hal",  "outcome": "not_consulted_disabled", "detail": "DOIGET_ENABLE_HAL", "consulted": false },
+  { "source": "core", "outcome": "consulted_no_record",                                   "consulted": true  }
+]
+```
+
+`outcome` is a **closed** enum:
+`not_consulted_disabled`, `not_consulted_not_applicable`,
+`not_consulted_wrong_publisher`, `not_consulted_not_needed`, `consulted_no_record`,
+`consulted_not_open_access`, `consulted_failed`, `consulted_resolved`.
+
+`detail` is present only for the variants carrying one, and is opaque text.
+`consulted` is redundant with `outcome` and present anyway: it is the single question
+every consumer has — *did anyone else look?* — and requiring them to memorise which of
+eight tokens implies it invites the confusion the trace exists to end.
+
+The field is **absent** when no trace is available, never `[]`. "We have no trace" and
+"the trace is empty" are different, and were the same observable before #413.
 
 ## 4. CLI exit codes
 

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -61,9 +61,9 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 
 | Persona | Surface |
 |---|---|
-| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context? } }`. Never throws. |
+| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context?, remediation?, attempts? } }`. Never throws. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
-| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?}}`. Exit code = number of failures (capped at 255). |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
 
 ### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
@@ -103,6 +103,58 @@ renaming or repurposing one is a breaking change.
 
 `error.message` MUST continue to embed the same parameters in human-readable
 form — `denial_context` is a parallel channel, not a replacement.
+
+### 3.2 Structured `remediation` (NORMATIVE; ADR-0043)
+
+`denial_context` says what was refused. `remediation` says what would lift it.
+Both are **optional and additive**; consumers MUST tolerate presence and absence.
+
+```jsonc
+"remediation": [
+  { "kind": "additional_host", "value": "strathprints.strath.ac.uk", "note": "this hop only" },
+  { "kind": "additional_host", "value": "*.strath.ac.uk",            "note": "the whole publisher" },
+  { "kind": "additional_host", "value": "strath.ac.uk",              "note": "apex too (a wildcard does not match it)" },
+  { "kind": "trust_flag",      "value": "trust_academic_repos",
+    "note": "strathprints.strath.ac.uk matches *.ac.uk — UK academic institutions (Universities UK)" }
+]
+```
+
+`kind` is a **closed** enum: `additional_host` (a pattern for
+`[[network.additional_hosts]]`) and `trust_flag` (a `[network]` boolean). Adding a
+variant is a minor semver bump.
+
+The two kinds are deliberately not collapsed into one pasteable string: adding a host
+trusts one publisher, a trust flag trusts a curated class (ADR-0028), and a caller
+choosing between them is making a policy decision on the user's behalf.
+
+Emitted only for reasons with a configuration channel — `redirect_not_in_allowlist` and
+`host_in_block_list`. A `size_cap_exceeded` or `capability_not_granted` denial carries no
+`remediation`, because offering a host to trust would send the caller after a fix that
+cannot work.
+
+### 3.3 Structured `attempts` (NORMATIVE; ADR-0043)
+
+The resolution trace introduced in #413/#438, previously CLI text only.
+
+```jsonc
+"attempts": [
+  { "source": "hal",  "outcome": "not_consulted_disabled", "detail": "DOIGET_ENABLE_HAL", "consulted": false },
+  { "source": "core", "outcome": "consulted_no_record",                                   "consulted": true  }
+]
+```
+
+`outcome` is a **closed** enum:
+`not_consulted_disabled`, `not_consulted_not_applicable`,
+`not_consulted_wrong_publisher`, `not_consulted_not_needed`, `consulted_no_record`,
+`consulted_not_open_access`, `consulted_failed`, `consulted_resolved`.
+
+`detail` is present only for the variants carrying one, and is opaque text.
+`consulted` is redundant with `outcome` and present anyway: it is the single question
+every consumer has — *did anyone else look?* — and requiring them to memorise which of
+eight tokens implies it invites the confusion the trace exists to end.
+
+The field is **absent** when no trace is available, never `[]`. "We have no trace" and
+"the trace is empty" are different, and were the same observable before #413.
 
 ## 4. CLI exit codes
 


### PR DESCRIPTION
Closes #459. Closes the `--mode json` half of #445, for all three surfaces rather than the one it asked about.

## The gap, measured

Everything #443, #448 and #449 added to make a blocked fetch *actionable* is CLI text. Driving the **real** MCP server against the DOI #407 was written about:

```
$ doiget serve  →  doiget_fetch_paper { ref: "10.1109/TSP.2018.2812747" }

KEYS        : [authors, license, oa_status, ok, path, pdf, ref, ...]
has attempts: False
pdf         : { status: "blocked",
                message: "redirect target strathprints.strath.ac.uk not in allowlist ...",
                denial_context: { reason, attempted, source, expected: [24 patterns] } }
```

A refusal, the host, and 24 patterns that are not it.

**The same call after one line of config** — `trust_academic_repos = true`:

```
ok: true    pdf: { status: "fetched" }    size_bytes: 880081
```

`strathprints.strath.ac.uk` is a university repository, that flag exists for exactly that class, and `user_extension::academic_repo_hosts()` already knew the host. The information needed to get from the first output to the second was in the codebase and never reached the caller.

An agent that cannot recover from a recoverable failure reports "this paper is not available." That is false, and false in a way the user cannot see.

## After, from the same real server

```
pdf.status  : blocked
remediation :
    additional_host  strathprints.strath.ac.uk   this hop only
    additional_host  *.strath.ac.uk              the whole publisher
    additional_host  strath.ac.uk                apex too (a wildcard does not match it)
    trust_flag       trust_academic_repos        strathprints.strath.ac.uk matches *.ac.uk — UK academic institutions
attempts    :
    datacite    not_consulted_disabled  consulted=False  DOIGET_ENABLE_DATACITE
    europe-pmc  not_consulted_disabled  consulted=False  DOIGET_ENABLE_EUROPE_PMC
    openaire    not_consulted_disabled  consulted=False  DOIGET_ENABLE_OPENAIRE
    hal         not_consulted_disabled  consulted=False  DOIGET_ENABLE_HAL
    core        not_consulted_disabled  consulted=False  DOIGET_ENABLE_CORE
```

## Computed once, in core

`widening_suggestions` moves out of `doiget-cli` into the new `doiget_core::remediation`, so the CLI's `= help:` block, the MCP envelope and the JSONL record render the **same list**. Copying it was cheaper — #454 is the recent lesson about two surfaces each keeping their own copy of a rule.

`trust_flag_for_host` is new: it matches the refused host against the curated `academic_repo_hosts()` / `oa_registry_hosts()` patterns and returns the flag **with the pattern that matched**, so the suggestion says *why* rather than asserting. A publisher host gets no flag at all — suggesting one that would not have helped is #442's "go find an API key" in a new place.

## Shape decisions (ADR-0043)

| decision | why not the cheaper thing |
|---|---|
| `kind` is a closed enum | adding a host trusts one publisher; a trust flag trusts a curated class (ADR-0028). Collapsing them hides a policy choice an agent makes for the user. |
| `attempts.outcome` is a token, not `render()` | that sentence has been reworded twice (#413, #438); a consumer keying off it would have broken twice. |
| `attempts` absent, never `[]` | #413 exists because "no trace" and "trace found nothing" were one observable. |
| hand-written `attempts_to_value`, not `derive(Serialize)` | both types are `#[non_exhaustive]`; deriving makes every future variant a wire change by default rather than by decision. |

## The tool description was the other half of the problem

`doiget_fetch_paper`'s `OUTPUTS` line did not mention `pdf` **at all**, so an agent had no way to know that `ok: true` does not mean a PDF landed. It now says to read `pdf.status`, that `blocked` means a copy **exists** and was refused, and to show `remediation` to the user rather than deciding for them.

## Contract

`docs/ERRORS.md` is NORMATIVE, hence ADR-0043 plus §3.2 / §3.3. Both fields are additive under §3.1's existing "consumers MUST tolerate presence and absence" rule, so no current consumer breaks.

One existing test improved rather than patched: `jsonl_failure_shape_with_denial_context` hand-crafted a JSON stand-in for `DenialContext`; the builder now takes the typed value, so it exercises the real `Serialize` impl end to end.

## Checks

```
clippy  oa-only | oa-only,citation | oa-only,tdm-aps | oa-only,tdm-ieee | four-way union   GREEN
test    oa-only                                                     0 failures
test    oa-only,metadata,tdm-aps,tdm-elsevier,tdm-springer,tdm-ieee  0 failures
cargo metadata --locked                                             in sync
```

Plus the real-server run above, which is the thing the unit tests cannot do.