### PR TITLE
fix(test): stop 46 tests reading process-global env, and guard it

### DIFF
--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -64,6 +64,31 @@ jobs:
             exit 1
           fi
 
+      - name: CapabilityProfile::from_env in tests must be serialised (#456)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `from_env()` reads process-global env. A test that calls it races
+          # any `#[serial]` test holding `DOIGET_KEY_*` without its agreement
+          # var, and loses with `KeyButNotAgreed` — `#[serial]` on the WRITER
+          # serialises marked tests against each other and does nothing about
+          # unmarked readers. It also makes the suite fail on a developer
+          # machine that exports `DOIGET_KEY_ELSEVIER`.
+          #
+          # So outside `lib.rs` (which owns the env-resolution tests), a file
+          # that calls `from_env()` must also carry `serial`. Tests that only
+          # want a default profile use `CapabilityProfile::for_tests()`, which
+          # reads no environment at all.
+          bad=0
+          while IFS= read -r f; do
+            [ "$f" = "crates/doiget-core/src/lib.rs" ] && continue
+            if ! grep -q 'serial' "$f"; then
+              echo "::error file=$f::posture-lint: calls CapabilityProfile::from_env() with no #[serial] in the file; use CapabilityProfile::for_tests() for a default profile (#456)"
+              bad=1
+            fi
+          done < <(grep -rl 'CapabilityProfile::from_env()' --include='*.rs' crates/doiget-core/src || true)
+          [ "$bad" -eq 0 ]
+
       - name: LICENSE is verbatim SPDX MIT (no trailing prose)
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.11"
+version = "0.8.9-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.11"
+version = "0.8.9-beta.12"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.11"
+version = "0.8.9-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.11"
+version       = "0.8.9-beta.12"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.6" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.6" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.6" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.12" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.12" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.12" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/citation_graph.rs
+++ b/crates/doiget-core/src/citation_graph.rs
@@ -442,7 +442,7 @@ mod tests {
     }
 
     fn profile_with_openalex_enabled() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: true,
             semantic_scholar: false,
@@ -539,7 +539,7 @@ mod tests {
             Url::parse("http://127.0.0.1:1").expect("URI parses"),
             "doiget@localhost".to_string(),
         );
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let seed = Doi::parse("10.1234/seed").expect("DOI parses");
 
         let err = expand(&seed, GraphCaps::default(), &src, &profile, &ctx)

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1109,6 +1109,44 @@ pub enum CapabilityError {
 }
 
 impl CapabilityProfile {
+    /// The profile a clean environment produces, built WITHOUT reading the
+    /// environment (#456).
+    ///
+    /// Most tests want "a default profile", not "whatever the environment
+    /// says". Calling [`Self::from_env`] for that couples them to a
+    /// process-global they do not control, and the coupling is not
+    /// hypothetical: `from_env` returns `Err(KeyButNotAgreed)` while any
+    /// other test holds `DOIGET_KEY_*` set without its agreement var, so a
+    /// reader that lands inside that window panics on `.expect("profile")`.
+    /// `#[serial]` on the writer cannot help — it serialises marked tests
+    /// against each other, and the readers were unmarked.
+    ///
+    /// It also makes the tests deterministic on a developer machine that
+    /// happens to export `DOIGET_KEY_ELSEVIER`, which `#[serial]` cannot fix
+    /// at all.
+    ///
+    /// Tests that genuinely exercise env resolution must keep
+    /// [`Self::from_env`] **and** carry `#[serial_test::serial]`.
+    ///
+    /// Deliberately not `Default`: the type-level docs defer that to Phase 1
+    /// "once the field set stabilizes", and a public `Default` would invite
+    /// production code to skip the resolution rules.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn for_tests() -> Self {
+        Self {
+            oa: AlwaysOn,
+            // Every `DOIGET_ENABLE_*` unset — the same all-false shape
+            // `from_env` produces with a clean environment.
+            metadata: MetadataAccess::default(),
+            tdm_elsevier: None,
+            tdm_aps: None,
+            tdm_springer: None,
+            tdm_ieee: None,
+            rate_limits: RateLimits::HARD_CODED,
+        }
+    }
+
     /// Read the runtime profile from environment variables.
     ///
     /// Implements the resolution algorithm specified in

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -2786,7 +2786,7 @@ mod tests {
             session_id: "01J0000000000000000000TEST".into(),
             cache_root: None,
         };
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let store = FsStore::new(store_root.clone()).expect("fs store");
 
         let n = MAX_BATCH_REFS + 1;
@@ -4039,7 +4039,7 @@ mod chain_tests {
     }
 
     fn all_off() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: false,
@@ -4398,7 +4398,7 @@ mod tdm_singleton_reach_tests {
         assert!(!cases.is_empty(), "the guard must have checked something");
 
         let (_td, c) = ctx();
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
 
         for (name, doi) in cases {
             let ref_ = Ref::Doi(Doi::parse(doi).expect("doi"));
@@ -4537,7 +4537,7 @@ mod tdm_chain_tests {
     }
 
     fn all_gates_open() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_aps = Some(grant("DOIGET_AGREE_TDM_APS"));
         p.tdm_elsevier = Some(grant("DOIGET_AGREE_TDM_ELSEVIER"));
         p.tdm_springer = Some(grant("DOIGET_AGREE_TDM_SPRINGER"));
@@ -4546,7 +4546,7 @@ mod tdm_chain_tests {
     }
 
     fn all_gates_closed() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_aps = None;
         p.tdm_elsevier = None;
         p.tdm_springer = None;

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -414,7 +414,7 @@ mod tests {
         // Trait-shape pin: a `Source` impl is dyn-safe and can be boxed.
         let s: Box<dyn Source> = Box::new(MockSource);
         assert_eq!(s.name(), "mock");
-        let profile = CapabilityProfile::from_env().expect("Phase 0 stub");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi("10.1234/example".to_string()));
         assert!(s.can_serve(&profile, &r));
 
@@ -428,7 +428,7 @@ mod tests {
         // Direct dispatch (not through `dyn`) to exercise the async fn
         // body and assert the populated FetchResult fields.
         let s = MockSource;
-        let profile = CapabilityProfile::from_env().expect("Phase 0 stub");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi("10.1234/example".to_string()));
         let (_td, ctx) = build_test_context();
 

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -682,7 +682,7 @@ mod tests {
     }
 
     fn profile() -> CapabilityProfile {
-        CapabilityProfile::from_env().expect("Phase 0 stub profile")
+        CapabilityProfile::for_tests()
     }
 
     // -----------------------------------------------------------------

--- a/crates/doiget-core/src/sources/core_oa.rs
+++ b/crates/doiget-core/src/sources/core_oa.rs
@@ -363,7 +363,7 @@ mod tests {
     }
 
     fn profile(core: bool) -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: false,

--- a/crates/doiget-core/src/sources/crossref.rs
+++ b/crates/doiget-core/src/sources/crossref.rs
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn crossref_can_serve_returns_true_for_doi() {
         let s = CrossrefSource::new("test@example.org".into());
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
         assert!(s.can_serve(&profile, &r));
     }
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn crossref_can_serve_returns_false_for_arxiv() {
         let s = CrossrefSource::new("test@example.org".into());
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Arxiv(ArxivId::parse("2401.12345").unwrap());
         assert!(!s.can_serve(&profile, &r));
     }
@@ -401,7 +401,7 @@ mod tests {
         let host = server_host(&server);
         let s = crossref_for(&server);
         let (_td, ctx) = build_test_context(&host);
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
 
         let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
@@ -424,7 +424,7 @@ mod tests {
             "test@example.org".into(),
         );
         let (_td, ctx) = build_test_context("127.0.0.1");
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Arxiv(ArxivId::parse("2401.12345").unwrap());
 
         let err = s.fetch(&r, &profile, &ctx).await.expect_err("not eligible");
@@ -451,7 +451,7 @@ mod tests {
         let host = server_host(&server);
         let s = crossref_for(&server);
         let (_td, ctx) = build_test_context(&host);
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
 
         let _res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
@@ -482,7 +482,7 @@ mod tests {
         let host = server_host(&server);
         let s = crossref_for(&server);
         let (_td, ctx) = build_test_context(&host);
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
 
         let err = s.fetch(&r, &profile, &ctx).await.expect_err("404 errors");
@@ -506,7 +506,7 @@ mod tests {
         let host = server_host(&server);
         let s = crossref_for(&server);
         let (_td, ctx) = build_test_context(&host);
-        let profile = CapabilityProfile::from_env().expect("clean env");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi::parse("10.1234/example").unwrap());
 
         let err = s

--- a/crates/doiget-core/src/sources/datacite.rs
+++ b/crates/doiget-core/src/sources/datacite.rs
@@ -300,7 +300,7 @@ mod tests {
     }
 
     fn profile(datacite: bool) -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: false,

--- a/crates/doiget-core/src/sources/doaj.rs
+++ b/crates/doiget-core/src/sources/doaj.rs
@@ -263,7 +263,7 @@ mod tests {
     }
 
     fn profile_with_doaj_enabled() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: false,
@@ -325,7 +325,7 @@ mod tests {
     async fn fetch_without_capability_flag_is_not_eligible() {
         let (_td, ctx) = build_test_context("http://127.0.0.1:1");
         let src = DoajSource::with_base(Url::parse("http://127.0.0.1:1").expect("URI parses"));
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
 
         assert!(

--- a/crates/doiget-core/src/sources/europepmc.rs
+++ b/crates/doiget-core/src/sources/europepmc.rs
@@ -348,7 +348,7 @@ mod tests {
     }
 
     fn profile(europe_pmc: bool) -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: false,

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -346,7 +346,7 @@ mod tests {
     }
 
     fn profile(hal: bool) -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: false,

--- a/crates/doiget-core/src/sources/openaire.rs
+++ b/crates/doiget-core/src/sources/openaire.rs
@@ -343,7 +343,7 @@ mod tests {
     }
 
     fn profile(openaire: bool) -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: false,

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -287,7 +287,7 @@ mod tests {
         // Build a clean profile, then flip the openalex flag. We avoid
         // touching the real env vars so the test runs single-threaded
         // without `serial_test`.
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: true,
             semantic_scholar: false,
@@ -355,7 +355,7 @@ mod tests {
             "doiget@localhost".to_string(),
         );
         // Profile with metadata.openalex == false (default).
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
 
         assert!(

--- a/crates/doiget-core/src/sources/s2.rs
+++ b/crates/doiget-core/src/sources/s2.rs
@@ -277,7 +277,7 @@ mod tests {
     }
 
     fn profile_with_s2_enabled() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.metadata = MetadataAccess {
             openalex: false,
             semantic_scholar: true,
@@ -347,7 +347,7 @@ mod tests {
     async fn fetch_without_capability_flag_is_not_eligible() {
         let (_td, ctx) = build_test_context("http://127.0.0.1:1");
         let src = S2Source::with_base(Url::parse("http://127.0.0.1:1").expect("URI parses"), None);
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let ref_ = Ref::Doi(Doi::parse("10.1234/example").expect("DOI parses"));
 
         assert!(

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -306,7 +306,7 @@ mod tests {
     const TEST_KEY: &str = "aps-test-key-xyz";
 
     fn profile_with_aps_grant() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_aps = Some(TdmGrant {
             // Issue #153: key flows through the grant, not the env var.
             api_key: secrecy::SecretString::from(TEST_KEY.to_string()),
@@ -348,7 +348,7 @@ mod tests {
     async fn fetch_without_grant_is_not_eligible() {
         let (_td, ctx) = build_test_context("http://127.0.0.1:1");
         let src = TdmApsSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("DOI parses"));
 
         assert!(

--- a/crates/doiget-core/src/sources/tdm_elsevier.rs
+++ b/crates/doiget-core/src/sources/tdm_elsevier.rs
@@ -322,7 +322,7 @@ mod tests {
     const TEST_KEY: &str = "els-test-key-xyz";
 
     fn profile_with_elsevier_grant() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_elsevier = Some(TdmGrant {
             // Issue #153: key flows through the grant, not the env var.
             api_key: secrecy::SecretString::from(TEST_KEY.to_string()),
@@ -366,7 +366,7 @@ mod tests {
     async fn fetch_without_grant_is_not_eligible() {
         let (_td, ctx) = build_test_context("http://127.0.0.1:1");
         let src = TdmElsevierSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let ref_ = Ref::Doi(Doi::parse("10.1016/j.example.2024.001").expect("DOI parses"));
 
         assert!(

--- a/crates/doiget-core/src/sources/tdm_ieee.rs
+++ b/crates/doiget-core/src/sources/tdm_ieee.rs
@@ -434,7 +434,7 @@ mod tests {
     const TEST_KEY: &str = "test-key-xyz";
 
     fn profile_with_ieee_grant() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_ieee = Some(TdmGrant {
             // Issue #153: the key flows through the grant, not the env
             // var, so the fixture seeds it directly.
@@ -447,7 +447,7 @@ mod tests {
 
     /// Grant whose key is empty — exercises the fail-closed branch.
     fn profile_with_empty_key_grant() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_ieee = Some(TdmGrant {
             api_key: secrecy::SecretString::from(String::new()),
             agree_env_var: "DOIGET_AGREE_TDM_IEEE".to_string(),
@@ -622,7 +622,7 @@ mod tests {
     async fn fetch_without_grant_is_not_eligible() {
         let (_td, ctx) = build_test_context("http://127.0.0.1:1");
         let src = TdmIeeeSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let ref_ = Ref::Doi(Doi::parse("10.1109/example").expect("DOI parses"));
 
         let err = src

--- a/crates/doiget-core/src/sources/tdm_springer.rs
+++ b/crates/doiget-core/src/sources/tdm_springer.rs
@@ -364,7 +364,7 @@ mod tests {
     const TEST_KEY: &str = "test-key-xyz";
 
     fn profile_with_springer_grant() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_springer = Some(TdmGrant {
             // Issue #153: the key now flows through the grant, not the
             // env var, so the fixture seeds it directly.
@@ -377,7 +377,7 @@ mod tests {
 
     /// Grant whose key is empty — exercises the fail-closed branch.
     fn profile_with_empty_key_grant() -> CapabilityProfile {
-        let mut p = CapabilityProfile::from_env().expect("clean env never errors");
+        let mut p = CapabilityProfile::for_tests();
         p.tdm_springer = Some(TdmGrant {
             api_key: secrecy::SecretString::from(String::new()),
             agree_env_var: "DOIGET_AGREE_TDM_SPRINGER".to_string(),
@@ -466,7 +466,7 @@ mod tests {
     async fn fetch_without_grant_is_not_eligible() {
         let (_td, ctx) = build_test_context("http://127.0.0.1:1");
         let src = TdmSpringerSource::with_base(Url::parse("http://127.0.0.1:1").expect("parses"));
-        let profile = CapabilityProfile::from_env().expect("clean env never errors");
+        let profile = CapabilityProfile::for_tests();
         let ref_ = Ref::Doi(Doi::parse("10.1007/example").expect("DOI parses"));
 
         assert!(

--- a/crates/doiget-core/src/sources/unpaywall.rs
+++ b/crates/doiget-core/src/sources/unpaywall.rs
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn unpaywall_can_serve_returns_true_for_doi() {
         let s = UnpaywallSource::new(TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi(TEST_DOI.to_string()));
         assert!(s.can_serve(&profile, &r));
     }
@@ -273,7 +273,7 @@ mod tests {
     #[test]
     fn unpaywall_can_serve_returns_false_for_arxiv() {
         let s = UnpaywallSource::new(TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Arxiv(ArxivId("2401.12345".to_string()));
         assert!(!s.can_serve(&profile, &r));
     }
@@ -291,7 +291,7 @@ mod tests {
         let host = host_of(&server.uri());
         let (_td, ctx) = build_test_context(&host);
         let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi(TEST_DOI.to_string()));
 
         let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
@@ -316,7 +316,7 @@ mod tests {
         let host = host_of(&server.uri());
         let (_td, ctx) = build_test_context(&host);
         let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi(TEST_DOI.to_string()));
 
         let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
@@ -344,7 +344,7 @@ mod tests {
         let host = host_of(&server.uri());
         let (_td, ctx) = build_test_context(&host);
         let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi(TEST_DOI.to_string()));
 
         let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
@@ -373,7 +373,7 @@ mod tests {
         let host = host_of(&server.uri());
         let (_td, ctx) = build_test_context(&host);
         let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi(TEST_DOI.to_string()));
 
         let res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
@@ -386,7 +386,7 @@ mod tests {
         // gate fires first.
         let (_td, ctx) = build_test_context("127.0.0.1");
         let s = UnpaywallSource::new(TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Arxiv(ArxivId("2401.12345".to_string()));
 
         let err = s
@@ -414,7 +414,7 @@ mod tests {
         let host = host_of(&server.uri());
         let (td, ctx) = build_test_context(&host);
         let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi(TEST_DOI.to_string()));
 
         let _res = s.fetch(&r, &profile, &ctx).await.expect("fetch ok");
@@ -475,7 +475,7 @@ mod tests {
         let host = host_of(&server.uri());
         let (_td, ctx) = build_test_context(&host);
         let s = UnpaywallSource::with_base(base_of(&server.uri()), TEST_EMAIL.to_string());
-        let profile = CapabilityProfile::from_env().expect("profile");
+        let profile = CapabilityProfile::for_tests();
         let r = Ref::Doi(Doi(TEST_DOI.to_string()));
 
         let err = s


### PR DESCRIPTION
Closes #456.

## The race

`coverage` failed on an unrelated PR and passed on a re-run of **the same commit**. `from_env()` had returned `Err(KeyButNotAgreed)` — which, with a clean environment, happens for exactly one reason: another test was holding `DOIGET_KEY_ELSEVIER` set without its agreement var.

`#[serial]` on that writer cannot help. It serialises marked tests **against each other**; the readers were plain `#[test]` and kept running in parallel on other threads. The reader was the unguarded half, and no amount of marking the writer fixes that.

## The fix, and why not `#[serial]` everywhere

`CapabilityProfile::for_tests()` builds the clean-environment profile **without reading the environment**. 46 call sites that only wanted "a default profile" now use it.

Marking 46 readers `#[serial]` would also have worked, and would have been the worse fix: it serialises the largest test binary for a coupling problem, and the next test someone writes forgets the attribute. Removing the dependency cannot be forgotten.

It also fixes something `#[serial]` could not touch at all — the suite now passes on a developer machine that happens to export `DOIGET_KEY_ELSEVIER`.

## Classification, and a trap I walked into

The 14 sites that genuinely exercise env resolution keep `from_env()`. My first pass classified them by "does the enclosing fn mention `DOIGET_`" and kept 14. Spot-checking two of them:

```rust
fn profile_with_aps_grant() -> CapabilityProfile {
    let mut p = CapabilityProfile::from_env()...;
    p.tdm_aps = Some(TdmGrant {
        agree_env_var: "DOIGET_AGREE_TDM_APS".to_string(),   // a string literal
```

```rust
    "can_serve must be false without DOIGET_ENABLE_DOAJ"     // an assert message
```

Neither reads the environment. The rule became "does the fn call `set_var` / `remove_var` / `EnvGuard`", which cut the kept set from 14 to 4 — all in `orchestrator.rs`, all verified to carry `#[serial]`.

Worth stating because the loose rule would have *passed CI*: those ten tests would have stayed coupled to a global they do not control, for no reason, and nothing would have said so.

## The guard

`posture-lint` now fails if a file outside `lib.rs` calls `from_env()` without carrying `serial`.

Mutation-verified:

```
$ # reintroduce one call in datacite.rs (no #[serial] in that file)
  GUARD CAUGHT: crates/doiget-core/src/sources/datacite.rs
```

Final distribution:

| file | `from_env()` | why |
|---|---|---|
| `lib.rs` | 10 | owns the env-resolution tests; all `#[serial]` |
| `orchestrator.rs` | 4 | genuinely set env before reading; all `#[serial]` |
| everything else | 0 | `for_tests()` |

## Unrelated drift, fixed here

`[workspace.dependencies]` had the three crates pinned at **`0.8.9-beta.6`** while `[workspace.package].version` had reached **`beta.11`**. Betas 7–11 bumped only the latter.

Nothing caught it: `version-bump-gate.sh` reads `[workspace.package]` alone, and `cargo metadata --locked` stays happy because a caret requirement on a pre-release matches later pre-releases of the same version.

Harmless today, but these pins are what a published manifest carries, so they should not be allowed to drift silently. **Worth a follow-up to teach the gate about them** — say the word and I will file it.

## Verification

```
clippy  oa-only / oa-only,citation      GREEN
rustdoc oa-only / oa-only,citation      GREEN
test    oa-only                         819 passed, 0 failed
test    full tdm (lib)                  530 passed, 0 failed
posture-lint guard (local + mutation)   passes / catches
```