### PR TITLE
fix: #468 review findings, and cut 0.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,75 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.9] - 2026-08-25
+
+0.8.8 shipped five optional sources that were never called. 0.8.9 is what happened
+when the same question was asked of everything else: **is this code actually
+reached?** The answer was no, four more times.
+
+| | the component | its unit tests | actually reached |
+|---|---|---|---|
+| #442 | the three Tier-3 TDM sources | all passed | **no** — zero callers |
+| #454 | their transport allowlists | all passed | **no** — never registered in the production client |
+| #458 | the Tier-3 chain | all passed | **no** — skipped whenever Crossref answered |
+| #441 | `[store] root` in `config.toml` | all passed | **no** — the config rung did not exist |
+
+Every one was documented as working. `SOURCES.md` described the three gates that make
+a TDM source available; ADR-0036 stated the store-root resolution order; `config init`
+wrote `[store] root` into the template it generates and `config doctor` recommended it.
+All true on paper, all false in the binary.
+
+### Fixed
+
+- **[ci]** The Tier-3 surface is compiled and tested at all. No job built `tdm-*` — not
+  clippy, not test, not rustdoc — and `--all-features` appears in no workflow. Roughly
+  1100 lines, including the #146 credential-redaction regression, had never run once
+  (#440).
+- **[orchestrator]** The three Tier-3 TDM sources are reached by the production fetch
+  path, and scoped to the DOI prefixes their publisher registered, so enabling
+  `tdm-aps` does not disclose every lookup to APS (#442, ADR-0041).
+- **[transport]** Their allowlists are registered in the production client. A reached
+  source would otherwise have failed `UnknownSource`; the unit tests could not see it,
+  because the test client registers the key itself — the same trap DataCite nearly hit
+  in 0.8.8 (#454).
+- **[orchestrator]** The Tier-3 chain runs even when Crossref answers. A publisher's own
+  record is the entire point of holding its credentials, and Crossref resolves those
+  DOIs readily, so the chain never ran for the DOIs it exists to serve (#458).
+- **[config]** `[store] root` in `config.toml` is honoured, between the env var and the
+  cwd default (#441, ADR-0036 Amendment 1). `config doctor` now names which rung
+  answered: a setting that is present but unread resolves to the cwd default, and the
+  two coincide whenever you run from the directory you configured.
+- **[cli]** The `redirect_not_in_allowlist` help suggests the registrable domain and the
+  apex, not only the hop that was just refused. A publisher redirect chain used to cost
+  one edit-run cycle per hop (#443).
+- **[test]** 46 tests no longer read process-global environment. `from_env()` returns
+  `Err(KeyButNotAgreed)` while any other test holds `DOIGET_KEY_*` without its agreement
+  var, and `#[serial]` on that writer does nothing about unmarked readers — which is why
+  `coverage` failed on one commit and passed on a re-run of the same commit (#456).
+
+### Added
+
+- **[source]** **IEEE Xplore TDM**, opt-in behind the `tdm-ieee` Cargo feature plus a key
+  and a recorded agreement (#430, ADR-0042). Shipped against an inferred contract because
+  the programme gates the real one, and corrected from first contact (#460).
+- **[orchestrator]** When the publisher refuses the content leg, doiget asks the enabled
+  optional sources whether anyone else holds a copy (#445). The OA chain already advanced
+  past a 429 — what it could not do was look beyond Unpaywall's list, and with Crossref
+  having answered, that list was the whole candidate set.
+- **[cli]** The resolution trace is emitted when the content leg is blocked, not only on
+  `NOT_FOUND`. "Found nowhere" and "found at one host that refused me" raise the same
+  next question. A 429 is named as transient, because it is the one failure where
+  retrying the same host later is right and reconfiguring is wrong (#445).
+- **[errors]** The trace and its remediation are carried into the MCP envelope and
+  `batch --json`, so an agent can read them instead of scraping stderr (#459, ADR-0043).
+
+### Changed
+
+- **[core]** `CapabilityProfile` gains `for_tests()`, a `#[doc(hidden)]` constructor that
+  builds the clean-environment profile without reading the environment.
+- **[docs]** ADR-0041 (publisher prefix scoping), ADR-0042 (shipping against an inferred
+  contract), ADR-0043 (machine-readable diagnostics), and Amendment 1 to ADR-0036.
+
 ## [0.8.8] - 2026-08-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9-beta.12"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9-beta.12"
+version = "0.8.9"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9-beta.12"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9-beta.12"
+version       = "0.8.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9-beta.12" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9-beta.12" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9-beta.12" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.9" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -152,13 +152,36 @@ pub(crate) fn resolve_store_root_with_source() -> Result<(Utf8PathBuf, StoreRoot
 
 /// `[store] root` from the user's `config.toml`, if any.
 ///
-/// Deliberately silent on a malformed file: the store root is resolved by
-/// every subcommand, and a parse error surfaces with a proper diagnostic on
-/// the network path that owns this file. Failing every command here would
-/// turn one bad line into a total outage.
+/// Does not fail the command on a malformed file — the store root is
+/// resolved by every subcommand, and one bad line should not be a total
+/// outage — but it does NOT stay quiet about it.
+///
+/// The previous comment here justified silence by claiming "a parse error
+/// surfaces with a proper diagnostic on the network path that owns this
+/// file". The #468 review checked that claim and it is false for most
+/// callers: `list-recent`, `search`, `info`, `tag`, `bib` and `csl` never
+/// build an HTTP client, so that diagnostic never runs for them. TOML fails
+/// the whole document, so a typo anywhere — even under `[network]` — makes
+/// `[store] root` unreadable, and the command silently used `./papers`
+/// under the cwd as though nothing had been configured.
+///
+/// `search` then reports zero results, indistinguishable from an empty
+/// library. Worse, `tag` **writes** metadata into the wrong store and
+/// reports success. A warning is the minimum; the resolved source is also
+/// reported by `config doctor`.
 fn store_root_from_config() -> Option<Utf8PathBuf> {
     let path = user_config_path()?;
-    let cfg = doiget_core::user_extension::load(&path).ok()?;
+    let cfg = match doiget_core::user_extension::load(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "config.toml could not be read; [store] root ignored and the default store                  root used instead. Run `doiget config doctor` to see which root is in effect."
+            );
+            return None;
+        }
+    };
     let raw = cfg.store_root?;
     Some(doiget_core::user_extension::expand_store_root(&raw))
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1071,6 +1071,17 @@ impl Default for TdmGrant {
 /// rely on the resolution rules in `from_env`. `Default` is **not yet**
 /// implemented; Phase 1 will add it once the field set stabilizes.
 #[derive(Debug, Clone)]
+///
+/// **Correction (#468 review).** An earlier version of the note above said
+/// the type's safety guarantees "rely on the resolution rules in
+/// `from_env`", protected by `#[non_exhaustive]`. That overstates what the
+/// attribute does: it blocks struct-literal construction across a crate
+/// boundary, but every field here is `pub`, and `from_env` hands back an
+/// owned value — so a downstream caller has always been able to obtain a
+/// profile and then assign to `tdm_aps` directly. `#[non_exhaustive]` buys
+/// forward-compatibility for adding fields, not an authorization boundary.
+/// Whether one is wanted is tracked separately; it is not a property this
+/// type has today, and claiming it did was the problem.
 #[non_exhaustive]
 pub struct CapabilityProfile {
     /// Tier 1 OA sources are always permitted.
@@ -1131,9 +1142,18 @@ impl CapabilityProfile {
     /// Deliberately not `Default`: the type-level docs defer that to Phase 1
     /// "once the field set stabilizes", and a public `Default` would invite
     /// production code to skip the resolution rules.
-    #[doc(hidden)]
+    ///
+    /// `#[cfg(test)]`, not merely `#[doc(hidden)]`. The #468 review pointed
+    /// out that `#[doc(hidden)] pub` hides a function from rendered docs and
+    /// from nothing else — it would still be compiled into every published
+    /// build of this crate and callable by any downstream consumer, which is
+    /// exactly what the paragraph above says a public constructor must not
+    /// be. All 47 call sites are unit tests inside this crate (no
+    /// integration test, no fuzz target, no other crate), so the gate costs
+    /// nothing and the constructor does not exist in a release build.
+    #[cfg(test)]
     #[must_use]
-    pub fn for_tests() -> Self {
+    pub(crate) fn for_tests() -> Self {
         Self {
             oa: AlwaysOn,
             // Every `DOIGET_ENABLE_*` unset — the same all-false shape

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1178,8 +1178,12 @@ async fn fetch_paper_doi(
     )))]
     let tdm_meta: Option<Value> = None;
 
+    // The resolved pair is KEPT, not mapped away. When Crossref failed this
+    // pass ran for real, and the OA fallback below needs its payload — the
+    // old code discarded it and re-ran the whole chain to get it back,
+    // paying a second live round against five APIs (#468 review).
     #[cfg(feature = "metadata")]
-    let optional_meta = resolve_optional_chain(
+    let optional_resolved = resolve_optional_chain(
         ref_,
         profile,
         ctx,
@@ -1187,9 +1191,12 @@ async fn fetch_paper_doi(
         &mut extracted,
         &mut attempts,
     )
-    .await
-    .map(|(_, m)| m)
-    .or(tdm_meta);
+    .await;
+    #[cfg(feature = "metadata")]
+    let optional_meta = optional_resolved
+        .as_ref()
+        .map(|(_, m)| m.clone())
+        .or(tdm_meta);
     #[cfg(not(feature = "metadata"))]
     let optional_meta: Option<Value> = tdm_meta;
     let _ = &optional_meta;
@@ -1356,8 +1363,16 @@ async fn fetch_paper_doi(
     // #445: and if that did not help either, ask whoever else is switched
     // on. Additive by construction — see the fn docs.
     #[cfg(feature = "metadata")]
-    let (pdf_leg, pdf_bytes) =
-        try_optional_source_oa_fallback(doi, pdf_leg, pdf_bytes, profile, ctx, &mut attempts).await;
+    let (pdf_leg, pdf_bytes) = try_optional_source_oa_fallback(
+        doi,
+        pdf_leg,
+        pdf_bytes,
+        profile,
+        ctx,
+        &mut attempts,
+        optional_resolved.as_ref().map(|(n, m)| (*n, m)),
+    )
+    .await;
     if let Some(fl) = fallback_license {
         license = fl;
     }
@@ -1533,26 +1548,52 @@ async fn try_optional_source_oa_fallback(
     profile: &CapabilityProfile,
     ctx: &FetchContext,
     attempts: &mut Vec<SourceAttempt>,
+    already_resolved: Option<(&'static str, &Value)>,
 ) -> (PdfLegStatus, Option<Vec<u8>>) {
     if pdf_bytes.is_some() || !matches!(pdf_leg, PdfLegStatus::Blocked { .. }) {
         return (pdf_leg, pdf_bytes);
     }
 
-    // Reaching here means Crossref answered (a Crossref failure with no PDF
-    // returns NotFound further up), so `attempts` is a row of `NotNeeded`
-    // that carries no information. Running the chain for real replaces it
-    // with what actually happened.
-    let ref_ = Ref::Doi(doi.clone());
-    let mut discard = CrossrefFields::default();
-    let mut fresh: Vec<SourceAttempt> = Vec::new();
-    let resolved =
-        resolve_optional_chain(&ref_, profile, ctx, false, &mut discard, &mut fresh).await;
-    if !fresh.is_empty() {
-        *attempts = fresh;
-    }
-
-    let Some((name, meta)) = resolved else {
-        return (pdf_leg, pdf_bytes);
+    // Two cases, and conflating them was the bug the #468 review caught.
+    //
+    // An earlier comment here claimed "reaching this point means Crossref
+    // answered, because a Crossref failure returns NotFound further up".
+    // That is false: the NotFound short-circuit is further DOWN, after this
+    // call. `pdf_leg` comes from the Unpaywall-derived OA chain, which is
+    // independent of Crossref (#120 — Crossref is non-fatal), so this runs
+    // in both cases.
+    //
+    // Crossref FAILED: the chain at the top of `fetch_paper_doi` already ran
+    // for real and `attempts` holds its genuine outcomes. Re-running cost a
+    // second live round against five third-party APIs and then overwrote
+    // those outcomes with a second, possibly different answer. Reuse what it
+    // resolved instead.
+    //
+    // Crossref ANSWERED: the chain short-circuited, so every Tier-2 row is
+    // `NotNeeded` and carries nothing. Run it for real — but swap out only
+    // those rows. The old `*attempts = fresh` replaced the WHOLE vector,
+    // deleting the Tier-3 rows `resolve_tdm_chain` had recorded. In a
+    // `metadata` + `tdm-*` build that erased the answer to "was tdm-ieee
+    // consulted?" from the trace, from the MCP envelope and from
+    // `batch --json` — the exact question #413/#445 added the trace to
+    // answer.
+    let (name, meta) = match already_resolved {
+        Some((n, m)) => (n, m.clone()),
+        None => {
+            let ref_ = Ref::Doi(doi.clone());
+            let mut discard = CrossrefFields::default();
+            let mut fresh: Vec<SourceAttempt> = Vec::new();
+            let r =
+                resolve_optional_chain(&ref_, profile, ctx, false, &mut discard, &mut fresh).await;
+            if !fresh.is_empty() {
+                attempts.retain(|a| !fresh.iter().any(|f| f.source == a.source));
+                attempts.extend(fresh);
+            }
+            match r {
+                Some((n, m)) => (n, m),
+                None => return (pdf_leg, pdf_bytes),
+            }
+        }
     };
     let Some(raw) = optional_source_oa_url(name, &meta) else {
         tracing::debug!(
@@ -4966,6 +5007,42 @@ mod oa_fallthrough_tests {
             matches!(outcome.pdf_leg, PdfLegStatus::Blocked { .. }),
             "without a fallback source this must still be Blocked; got {:?}",
             outcome.pdf_leg
+        );
+    }
+    /// #468 review: the fall-through used to do `*attempts = fresh`, which
+    /// replaced the WHOLE trace and deleted the Tier-3 rows
+    /// `resolve_tdm_chain` had already recorded.
+    ///
+    /// The row's outcome does not matter here — what matters is that the
+    /// row still EXISTS. Its absence is what made "was tdm-ieee consulted?"
+    /// unanswerable from `attempts`, from the MCP envelope and from
+    /// `batch --json`, which is the question the trace was added to answer.
+    ///
+    /// Needs `metadata` AND a `tdm-*` feature, because the bug only appears
+    /// when both chains have written to the same vector. CI builds exactly
+    /// that combination.
+    #[cfg(feature = "tdm-ieee")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn the_fallback_preserves_the_tier_3_rows_it_used_to_delete() {
+        let server = server_with_a_rate_limited_publisher_and_a_repository_copy().await;
+        let (outcome, paths) = run_fetch(&server, true).await;
+
+        // The fall-through must actually have fired, or this proves nothing.
+        assert!(
+            paths.iter().any(|p| p == "/v3/search/works"),
+            "the fallback did not run, so this test cannot see the bug; paths were {paths:?}"
+        );
+
+        let sources: Vec<&str> = outcome.attempts.iter().map(|a| a.source).collect();
+        assert!(
+            sources.contains(&"tdm-ieee"),
+            "the Tier-3 row was dropped from the trace by the fallback; trace held {sources:?}"
+        );
+        // And the Tier-2 rows the fallback re-ran are still there too.
+        assert!(
+            sources.contains(&"core"),
+            "the refreshed Tier-2 rows are missing; trace held {sources:?}"
         );
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4021,12 +4021,32 @@ fn resolve_store_root() -> Option<Utf8PathBuf> {
 
 /// `[store] root` from the user's `config.toml`, if any (#441).
 ///
-/// Silent on a malformed file for the same reason as the CLI twin: the
-/// store root is resolved on nearly every tool call, and the parse error
-/// surfaces with a proper diagnostic on the path that owns the file.
+/// Warns on a malformed file rather than staying silent, for the reason the
+/// #468 review established against the CLI twin: only ONE function in this
+/// crate builds the HTTP client, so the "the parse error surfaces on the
+/// network path" justification does not hold for `doiget_info`,
+/// `doiget_search_local`, `doiget_list_recent` or `doiget_tag`.
+///
+/// The consequences are worse here than on the CLI, because an agent cannot
+/// see a shell. `doiget_info` returns `metadata: null` for a paper the user
+/// already has, which per this server's own tool description tells the agent
+/// to fetch it again; and `doiget_tag` writes into the wrong store and
+/// returns `ok: true`.
+///
+/// stdout stays clean either way (ADR-0001) — `tracing` is wired to stderr.
 fn store_root_from_config() -> Option<Utf8PathBuf> {
     let path = config_dir_utf8().ok()?.join("doiget").join("config.toml");
-    let cfg = doiget_core::user_extension::load(&path).ok()?;
+    let cfg = match doiget_core::user_extension::load(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "config.toml could not be read; [store] root ignored and the default store                  root used instead"
+            );
+            return None;
+        }
+    };
     let raw = cfg.store_root?;
     Some(doiget_core::user_extension::expand_store_root(&raw))
 }
@@ -4681,5 +4701,76 @@ mod tests {
                 None => std::env::remove_var(self.var),
             }
         }
+    }
+    /// #468 review: the CLI has three tests pinning the `[store] root`
+    /// resolution ORDER; this crate had none, even though it carries a
+    /// hand-duplicated copy of the resolver rather than calling the CLI's.
+    ///
+    /// That is the #454 shape — two independent copies of the same logic,
+    /// one of them unguarded — repeated one PR later, and it matters more
+    /// here: `doiget_tag` WRITES metadata into whatever root this returns,
+    /// and reports `ok: true` either way.
+    ///
+    /// The load-bearing assertion is the negative one. Comparing only
+    /// against the configured path would also pass if the config were
+    /// ignored and the test happened to run from that directory.
+    #[test]
+    #[serial_test::serial]
+    fn store_root_in_config_beats_the_cwd_default() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+
+        let lib = tempfile::TempDir::new().expect("tempdir");
+        let library = camino::Utf8Path::from_path(lib.path())
+            .expect("utf8 tempdir")
+            .as_str()
+            .replace('\u{5c}', "/");
+        std::fs::write(
+            doiget_dir.join("config.toml").as_std_path(),
+            format!("[store]\nroot = \"{library}\"\n"),
+        )
+        .expect("write config.toml");
+
+        let _guards = scoped_env_for_user_extension(cfg_root.as_str());
+        let _no_env_root = EnvGuard::unset("DOIGET_STORE_ROOT");
+
+        let got = resolve_store_root().expect("resolves on a normal host");
+
+        let cwd_default = camino::Utf8PathBuf::try_from(std::env::current_dir().expect("cwd"))
+            .expect("utf8 cwd")
+            .join("papers");
+        assert_ne!(
+            got, cwd_default,
+            "the config value was ignored and the cwd default answered instead"
+        );
+        assert_eq!(
+            got.as_str().replace('\u{5c}', "/"),
+            library,
+            "[store] root must win over the cwd default, as it does on the CLI"
+        );
+    }
+
+    /// The rung above it still wins, so adding the config rung did not
+    /// demote the env var.
+    #[test]
+    #[serial_test::serial]
+    fn env_beats_store_root_in_config_on_the_mcp_surface() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        std::fs::write(
+            doiget_dir.join("config.toml").as_std_path(),
+            "[store]\nroot = \"/from/config\"\n",
+        )
+        .expect("write config.toml");
+
+        let _guards = scoped_env_for_user_extension(cfg_root.as_str());
+        let _env_root = EnvGuard::set("DOIGET_STORE_ROOT", "/from/env");
+
+        let got = resolve_store_root().expect("resolves");
+        assert_eq!(got.as_str(), "/from/env");
     }
 }

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -187,6 +187,8 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_KEY_APS` | secret string | APS API key. |
 | `DOIGET_AGREE_TDM_SPRINGER` | `=1` | Acknowledges Springer Nature OA ToS. |
 | `DOIGET_KEY_SPRINGER` | secret string | Springer API key. |
+| `DOIGET_AGREE_TDM_IEEE` | `=1` | Acknowledges IEEE TDM ToS. |
+| `DOIGET_KEY_IEEE` | secret string | IEEE Xplore API key. |
 
 > **Note (ADR-0031):** `DOIGET_ENABLE_OPENALEX` gates the OpenAlex
 > *enrichment* / citation-graph source only (`/works/doi:…`,

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -55,7 +55,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 
 | Persona | Surface |
 |---|---|
-| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context?, remediation?, attempts? } }`. Never throws. |
+| Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
 | CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
@@ -147,8 +147,16 @@ The resolution trace introduced in #413/#438, previously CLI text only.
 every consumer has — *did anyone else look?* — and requiring them to memorise which of
 eight tokens implies it invites the confusion the trace exists to end.
 
-The field is **absent** when no trace is available, never `[]`. "We have no trace" and
-"the trace is empty" are different, and were the same observable before #413.
+"We have no trace" and "the trace is empty" are different, and were the same
+observable before #413. Both surfaces keep them apart, by different means — check
+the one you are parsing:
+
+| surface | no trace available | trace exists but empty |
+|---|---|---|
+| CLI `batch --json` | the `attempts` key is **absent** | `[]` |
+| MCP envelope | the `attempts` key is **present**, valued `null` | `[]` |
+
+Neither ever renders "no trace" as `[]`.
 
 ## 4. CLI exit codes
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -197,8 +197,8 @@ Every outcome, consulted or not, is recorded in the attempt trace attached to a
 failed fetch, so "asked and had nothing" is always distinguishable from "never
 asked" and from "wrong publisher".
 
-**Pointing them elsewhere.** `DOIGET_APS_BASE`, `DOIGET_ELSEVIER_BASE` and
-`DOIGET_SPRINGER_BASE` override the API base, mirroring `DOIGET_CROSSREF_BASE`.
+**Pointing them elsewhere.** `DOIGET_APS_BASE`, `DOIGET_ELSEVIER_BASE`,
+`DOIGET_SPRINGER_BASE` and `DOIGET_IEEE_BASE` override the API base, mirroring `DOIGET_CROSSREF_BASE`.
 Intended for tests and for institutional proxies.
 
 ### When the publisher refuses the content

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -193,6 +193,8 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_KEY_APS` | secret string | APS API key. |
 | `DOIGET_AGREE_TDM_SPRINGER` | `=1` | Acknowledges Springer Nature OA ToS. |
 | `DOIGET_KEY_SPRINGER` | secret string | Springer API key. |
+| `DOIGET_AGREE_TDM_IEEE` | `=1` | Acknowledges IEEE TDM ToS. |
+| `DOIGET_KEY_IEEE` | secret string | IEEE Xplore API key. |
 
 > **Note (ADR-0031):** `DOIGET_ENABLE_OPENALEX` gates the OpenAlex
 > *enrichment* / citation-graph source only (`/works/doi:…`,

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -61,7 +61,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 
 | Persona | Surface |
 |---|---|
-| Agent (MCP) | Structured `{ ok: false, error: { code, message, denial_context?, remediation?, attempts? } }`. Never throws. |
+| Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
 | CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
@@ -153,8 +153,16 @@ The resolution trace introduced in #413/#438, previously CLI text only.
 every consumer has — *did anyone else look?* — and requiring them to memorise which of
 eight tokens implies it invites the confusion the trace exists to end.
 
-The field is **absent** when no trace is available, never `[]`. "We have no trace" and
-"the trace is empty" are different, and were the same observable before #413.
+"We have no trace" and "the trace is empty" are different, and were the same
+observable before #413. Both surfaces keep them apart, by different means — check
+the one you are parsing:
+
+| surface | no trace available | trace exists but empty |
+|---|---|---|
+| CLI `batch --json` | the `attempts` key is **absent** | `[]` |
+| MCP envelope | the `attempts` key is **present**, valued `null` | `[]` |
+
+Neither ever renders "no trace" as `[]`.
 
 ## 4. CLI exit codes
 

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -203,8 +203,8 @@ Every outcome, consulted or not, is recorded in the attempt trace attached to a
 failed fetch, so "asked and had nothing" is always distinguishable from "never
 asked" and from "wrong publisher".
 
-**Pointing them elsewhere.** `DOIGET_APS_BASE`, `DOIGET_ELSEVIER_BASE` and
-`DOIGET_SPRINGER_BASE` override the API base, mirroring `DOIGET_CROSSREF_BASE`.
+**Pointing them elsewhere.** `DOIGET_APS_BASE`, `DOIGET_ELSEVIER_BASE`,
+`DOIGET_SPRINGER_BASE` and `DOIGET_IEEE_BASE` override the API base, mirroring `DOIGET_CROSSREF_BASE`.
 Intended for tests and for institutional proxies.
 
 ### When the publisher refuses the content


### PR DESCRIPTION
Six review passes over the promotion diff (#468). Two findings were the same shape as the four bugs this release exists to fix, and both were mine.

## 1. The fall-through deleted the trace it was supposed to complete

```rust
if !fresh.is_empty() {
    *attempts = fresh;      // replaces the WHOLE vector
}
```

`resolve_optional_chain` always pushes five rows, so the guard is always true. In a `metadata` + `tdm-*` build the Tier-3 rows `resolve_tdm_chain` had already recorded were erased — from `FetchPaperOutcome.attempts`, from the MCP envelope, and from `batch --json`. **"Was tdm-ieee consulted?" became unanswerable**, which is the exact question #413/#445 added the trace to answer.

The justifying comment was also false:

> Reaching here means Crossref answered (a Crossref failure with no PDF returns NotFound **further up**)

That short-circuit is at line 1369; this call is at line 1360 — **further down**. `pdf_leg` derives from the Unpaywall OA chain, which is independent of Crossref (#120), so the fallback ran in both cases. When Crossref had failed it re-ran the whole Tier-2 chain live — a second round against five third-party APIs — and then overwrote the first run's genuine results with the second run's.

Fixed by separating the two cases the old code conflated:

| | before | now |
|---|---|---|
| Crossref failed | re-run the chain, discard the first pass's real results | reuse the first pass's payload (now kept instead of mapped away); no second round |
| Crossref answered | replace the whole trace | swap out only the Tier-2 rows; Tier-3 rows survive |

Mutation-verified:

```
the_fallback_preserves_the_tier_3_rows_it_used_to_delete ... FAILED
  the Tier-3 row was dropped from the trace by the fallback;
  trace held ["datacite", "europe-pmc", "openaire", "hal", "core"]
```

## 2. A malformed `config.toml` was swallowed with no diagnostic at all

`store_root_from_config` justified `.ok()?` like this:

> Deliberately silent on a malformed file: ... a parse error surfaces with a proper diagnostic on the network path that owns this file.

The review checked the claim. It is false for most callers — `list-recent`, `search`, `info`, `tag`, `bib`, `csl`, and the MCP tools `doiget_info` / `doiget_search_local` / `doiget_list_recent` / `doiget_tag` never build an HTTP client. TOML fails the whole document, so a typo under `[network]` silently made `[store] root` unreadable and the command fell back to `./papers` under the cwd.

- `search` reports zero results — **indistinguishable from an empty library**
- `doiget_info` returns `metadata: null` for a paper the user has, which per the tool's own contract tells an agent to **re-fetch** it
- `doiget_tag` **writes** into the wrong store and returns `ok: true`

A read-path annoyance and a write-path correctness bug. Both twins now warn.

## The rest

| | finding |
|---|---|
| `for_tests()` | was `#[doc(hidden)] pub` — which hides a constructor from rendered docs and from nothing else, shipping it in every published build. Now `#[cfg(test)] pub(crate)`; all 47 call sites are in-crate unit tests, so the gate costs nothing. |
| `#[non_exhaustive]` note | claimed an authorization property `CapabilityProfile` does not have: every field is `pub` and `from_env` returns an owned value, so a caller could always assign to `tdm_aps`. Corrected rather than restated. |
| `CAPABILITY.md` §3 | the NORMATIVE env table never gained `DOIGET_AGREE_TDM_IEEE` / `DOIGET_KEY_IEEE` — the table a user reads to configure this release's headline source. |
| `ERRORS.md` | described an MCP failure envelope carrying `remediation`/`attempts`; the code puts both on `ok: true`. And "absent when no trace" holds for `batch --json` but not MCP, where the key is present and `null`. Both corrected, with a table since the two surfaces genuinely differ. |
| `SOURCES.md` | omitted `DOIGET_IEEE_BASE` four lines after naming it. |
| doiget-mcp `[store] root` | **zero tests**, despite carrying a hand-duplicated copy of the CLI resolver — the #454 shape again, one PR later. Two added; the positive one uses `assert_ne!` against the cwd default so it cannot pass by coincidence. Mutation-verified. |

## Also: the 0.8.9 cut

Version stripped to a clean `0.8.9` and the curated `## [0.8.9]` CHANGELOG section added, so #468 carries a stable version.

```
version gate PASSED for v0.8.9 (lane: stable)     ← all eight gates
```

## Deliberately not in this PR

Filed separately rather than rushed in: `classify_attempt` discarding the structured `DenialContext` (so per-source rows cannot carry remediation while the blocked leg can), `AttemptOutcome::Disabled`'s `env` holding two variables joined with `" + "`, and the untested wiring points for `batch --json` / MCP `attempts`.

## Verification

```
clippy   oa-only / citation / tdm-ieee / all-tdm     GREEN
rustdoc  oa-only,citation                            GREEN
test     oa-only                       821 passed, 0 failed
mutation  3 fixes, each verified to fail without it
```