### PR TITLE
docs: retract the 0.8.9 claim that #458 was fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Retracted
+
+- **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers. It
+  does not. `resolve_tdm_chain` still short-circuits every entry to `NotNeeded` the moment
+  `crossref_answered` is true, so a configured TDM key still yields byte-identical output
+  for the DOIs the chain exists to serve, and #458 is open. The bullet is struck from
+  `## [0.8.9]` below and the GitHub Release body carries a correction; the `v0.8.9` tag
+  annotation is immutable and still states it. The notes were assembled by grepping
+  `main..next` for `Closes` and `Refs` and reading both as "fixed" — PR #466 wrote
+  `Refs #458` about an adjacent `cfg`-gate fix, deliberately and correctly. The two
+  keywords are not interchangeable when assembling release notes (#472).
+
 ## [0.8.9] - 2026-08-25
 
 0.8.8 shipped five optional sources that were never called. 0.8.9 is what happened
@@ -22,6 +34,9 @@ reached?** The answer was no, four more times.
 | #454 | their transport allowlists | all passed | **no** — never registered in the production client |
 | #458 | the Tier-3 chain | all passed | **no** — skipped whenever Crossref answered |
 | #441 | `[store] root` in `config.toml` | all passed | **no** — the config rung did not exist |
+
+Three of the four are fixed below. **#458 is diagnosed but not fixed** and remains open;
+this release originally claimed otherwise — see the retraction under `## [Unreleased]`.
 
 Every one was documented as working. `SOURCES.md` described the three gates that make
 a TDM source available; ADR-0036 stated the store-root resolution order; `config init`
@@ -41,9 +56,6 @@ All true on paper, all false in the binary.
   source would otherwise have failed `UnknownSource`; the unit tests could not see it,
   because the test client registers the key itself — the same trap DataCite nearly hit
   in 0.8.8 (#454).
-- **[orchestrator]** The Tier-3 chain runs even when Crossref answers. A publisher's own
-  record is the entire point of holding its credentials, and Crossref resolves those
-  DOIs readily, so the chain never ran for the DOIs it exists to serve (#458).
 - **[config]** `[store] root` in `config.toml` is honoured, between the env var and the
   cwd default (#441, ADR-0036 Amendment 1). `config doctor` now names which rung
   answered: a setting that is present but unread resolves to the cwd default, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9"
+version = "0.8.10-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9"
+version = "0.8.10-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9"
+version = "0.8.10-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9"
+version       = "0.8.10-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
0.8.9's `### Fixed` list says the Tier-3 chain runs even when Crossref answers. It does not, so the claim is struck and the retraction recorded.

## What the code actually does

`resolve_tdm_chain` is entered unconditionally (behind the `tdm-*` feature gate). Inside, the per-entry loop opens with

```rust
if crossref_answered || resolved.is_some() {
    attempts.push(SourceAttempt::new(e.name, AttemptOutcome::NotNeeded));
    continue;
}
```

so with Crossref answering — which it does for the publisher-registered DOIs these sources exist to serve — every entry is skipped. `DOIGET_KEY_IEEE` + `DOIGET_AGREE_TDM_IEEE` changes nothing observable. That is #458, still open.

## Changes

| surface | this PR |
|---|---|
| `CHANGELOG.md` `## [0.8.9]` `### Fixed` | the `#458` bullet is removed |
| `CHANGELOG.md` `## [0.8.9]` intro table | annotated — it diagnoses four unreached components, the release fixed three |
| `CHANGELOG.md` `## [Unreleased]` | `### Retracted` entry, so the correction ships in the next release notes rather than being a silent edit |
| GitHub Release `v0.8.9` body | already corrected, before this PR |
| `v0.8.9` tag annotation | immutable; it still carries the claim, and that is the cost of having shipped it |

## Why a retraction and not a quiet edit

The claim is functional. A reader concludes that obtaining an IEEE TDM credential and configuring it makes IEEE DOIs resolve through IEEE. It does not, and the reader gets byte-identical output — which is the report in #458 verbatim.

It is also the exact failure mode 0.8.9 was about. A release whose theme was "documented as working, false in the binary" shipped release notes that were documented as working and false in the binary.

## Root cause

The notes were assembled by grepping `main..next` for `Closes` and `Refs` and treating both as "fixed". PR #466 wrote `Refs #458` about an adjacent `cfg`-gate bug found while investigating #458 — deliberate and correct. `Refs` is not `Closes`, and an assembly step that collapses them will ship this class of claim again.

Version: `0.8.9` → `0.8.10-beta.1` (lane retarget, counter reset per ADR-0033). `version-bump-gate.sh` passes locally.

Closes #472
Refs #458, #468
