### PR TITLE
chore(deps): roll up the three routine dependabot bumps (#450, #451, #453)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad  # v2.85.10
+      - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
           tool: cargo-llvm-cov
       - name: Generate workspace coverage (lcov)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.1"
+version = "0.8.10-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.1"
+version = "0.8.10-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.1"
+version = "0.8.10-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -631,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1781,7 +1781,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1838,7 +1838,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2030,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -2044,13 +2044,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2235,7 +2235,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2246,18 +2246,18 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,9 +2623,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2844,7 +2844,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.1"
+version       = "0.8.10-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [
@@ -180,7 +180,7 @@ proptest    = "1"
 # DOIGET_STORE_ROOT, etc.) within a single test binary. Lifted to
 # workspace deps in #228 review pass A6 so the three member crates
 # (core / cli / mcp) cannot drift on the major version.
-serial_test = "3"
+serial_test = "4"
 
 # Phase 4 (citation graph)
 petgraph = "0.6"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -71,7 +71,7 @@ version = "0.4.42"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-trait]]
-version = "0.1.91"
+version = "0.1.92"
 criteria = "safe-to-deploy"
 
 [[exemptions.aws-lc-rs]]
@@ -119,11 +119,11 @@ version = "0.4.45"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
-version = "4.6.5"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.5"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
@@ -675,11 +675,11 @@ version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.serial_test_derive]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.sha2]]
@@ -743,11 +743,11 @@ version = "3.27.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinystr]]
@@ -875,7 +875,7 @@ version = "2.5.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.24.0"
+version = "1.25.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]


### PR DESCRIPTION
Supersedes #450, #451 and #453. Stacked on #475 — **merge that first**; until it lands, `version-bump` is red here (this branch carries `0.8.10-beta.2` while `origin/next` is still `0.8.9`) and the diff shows #475's commit.

## Why one PR instead of three

Dependabot cannot land any of these on its own:

- it does not advance the beta counter, so `version-bump` is red on all three;
- it does not touch `supply-chain/config.toml`, so `cargo vet` is red on the two cargo ones;
- each cargo bump rewrites `Cargo.lock`, so #450 and #451 conflict pairwise — only the first could merge, and the second would need a rebase that discards whatever version-bump commit was pushed onto it.

## Contents

| | from | to |
|---|---|---|
| `async-trait` | 0.1.91 | 0.1.92 |
| `clap` (+ `clap_builder`) | 4.6.5 | 4.6.6 |
| `thiserror` (+ `thiserror-impl`) | 2.0.19 | 2.0.20 |
| `uuid` | 1.24.0 | 1.25.0 |
| `serial_test` (+ `serial_test_derive`) | 3.5.0 | **4.0.1** |
| `github/codeql-action/{init,autobuild,analyze}` | v4.37.6 | v4.37.8 |
| `taiki-e/install-action` | v2.85.10 | v2.86.5 |

## The one non-routine item: `serial_test` 4.0

It is a semver-major. Two things changed that could plausibly bite:

**Its MSRV rises to 1.93.1**, and doiget declares 1.86. This does not reach either MSRV job, because both run `cargo build --workspace --no-default-features --features oa-only` *without* `--all-targets` — dev-dependencies are never compiled at 1.86. Checked in `ci.yml::msrv` (line 154) and `msrv-drift.yml` (line 51). If either job ever gains `--all-targets`, this pin becomes a real MSRV constraint.

**Its derive moves to `syn` 3.** `syn` 3.0.3 now sits in the lock alongside 2.0.117; it is already covered by an imported audit, so it needed no new exemption.

No call-site changes: `#[serial]` compiles unchanged across all 46 env-mutating tests.

## Verification

Locally, on the GNU toolchain:

- `cargo clippy --workspace --all-targets -- -D warnings` across the four feature sets (`oa-only`, `oa-only,citation`, `oa-only,tdm-ieee`, and the full `oa-only,metadata,tdm-*` set) — clean.
- `cargo test --workspace --all-targets --no-default-features --features oa-only` — 40 binaries, all green, 0 failures.
- `cargo vet --locked` — succeeds.

## What is deliberately not here

`supply-chain/imports.lock` was left untouched. Running `cargo vet regenerate exemptions` refreshes it as a side effect (+520 lines of new third-party audit data) and also prunes ~40 stale exemptions while narrowing three criteria from `safe-to-deploy` to `safe-to-run`. Importing new peer-audit data and re-deriving criteria from a Windows-resolved lock are both supply-chain decisions; they do not belong in a dep bump. Exemptions here are edited in place for the eight crates that actually moved.

That stale-exemption backlog is worth its own pass — filed separately if wanted.

Refs #450, #451, #453
