### PR TITLE
chore(deps): move doiget-mcp to rmcp 3.1.4 (#452)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -433,26 +433,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.2"
+version = "0.8.10-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.2"
+version = "0.8.10-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.2"
+version = "0.8.10-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1723,13 +1723,13 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
- "async-trait",
  "chrono",
  "futures",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
@@ -1741,19 +1741,20 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.2"
+version       = "0.8.10-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [
@@ -201,7 +201,7 @@ petgraph = "0.6"
 # `deny.toml` bans `axum` / `hyper::Server` / `openssl` / `native-tls`.
 # A `cargo tree -p doiget-mcp` after the edit must NOT show any of those
 # crates; `cargo deny check` enforces this in CI.
-rmcp = { version = "2.2", default-features = false, features = [
+rmcp = { version = "3.1", default-features = false, features = [
     "server", "macros", "transport-io", "schemars",
 ] }
 

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3953,8 +3953,8 @@ fn resolve_log_path() -> anyhow::Result<Utf8PathBuf> {
 impl ServerHandler for Server {
     fn get_info(&self) -> ServerInfo {
         // Both `ServerInfo` and `Implementation` are `#[non_exhaustive]`
-        // in rmcp 1.6, so we go through the public builders rather than
-        // struct-literal construction.
+        // (since rmcp 1.6, still so in 3.x), so we go through the public
+        // builders rather than struct-literal construction.
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_server_info(Implementation::new("doiget", VERSION))

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -56,9 +56,16 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
     let server_info = client
         .peer_info()
         .expect("server_info populated after initialize");
-    assert_eq!(server_info.server_info.name, "doiget");
+    // rmcp 3.x made `InitializeResult::server_info` an `Option<Implementation>`
+    // (2.x had it by value). A server that omits it still initializes, so the
+    // presence assertion has to be explicit or this check evaporates.
+    let implementation = server_info
+        .server_info
+        .as_ref()
+        .expect("server_info populated after initialize");
+    assert_eq!(implementation.name, "doiget");
     assert!(
-        !server_info.server_info.version.is_empty(),
+        !implementation.version.is_empty(),
         "server version must not be empty"
     );
     // `instructions` is set by `Server::get_info`. Assert it mentions
@@ -796,5 +803,90 @@ async fn doiget_metadata_only_network_failure_returns_network_error_envelope() -
     server_handle.await??;
     drop(env);
     drop(td);
+    Ok(())
+}
+
+/// The tool safety annotations shipped in 0.8.6 survive on the wire.
+///
+/// `#[tool(annotations(...))]` is consumed entirely by the rmcp macro and
+/// nothing in this crate reads it back, so a macro-syntax or model change in
+/// an rmcp major (2.x -> 3.x, #452) can drop every hint with the build still
+/// green and every other test still passing. An agent reading `tools/list`
+/// would then see 22 unannotated tools and have to assume the worst of each.
+///
+/// Asserted through `tools/list` over the real transport rather than by
+/// inspecting the router, because the serialised form is what a client sees.
+#[tokio::test]
+async fn tools_list_carries_the_safety_annotations() -> anyhow::Result<()> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+
+    let tools = client.peer().list_all_tools().await?;
+    assert!(!tools.is_empty(), "tools/list returned nothing");
+
+    let unannotated: Vec<&str> = tools
+        .iter()
+        .filter(|t| t.annotations.is_none())
+        .map(|t| t.name.as_ref())
+        .collect();
+    assert!(
+        unannotated.is_empty(),
+        "these tools reached the wire with no annotations: {unannotated:?}"
+    );
+
+    let hints = |name: &str| {
+        tools
+            .iter()
+            .find(|t| t.name.as_ref() == name)
+            .unwrap_or_else(|| panic!("tools/list is missing {name}"))
+            .annotations
+            .clone()
+            .unwrap_or_else(|| panic!("{name} has no annotations"))
+    };
+
+    // Reads local state only. Asserting the values, not just presence: an
+    // annotations struct that survived as all-`None` fields would pass the
+    // presence check above while telling a client nothing.
+    let health = hints("doiget_health");
+    assert_eq!(
+        health.read_only_hint,
+        Some(true),
+        "doiget_health is read-only (#406)"
+    );
+    assert_eq!(
+        health.open_world_hint,
+        Some(false),
+        "doiget_health touches no network"
+    );
+
+    // Writes into the store and talks to the open internet — the opposite
+    // corner of the same matrix.
+    let fetch = hints("doiget_fetch_paper");
+    assert_eq!(
+        fetch.read_only_hint,
+        Some(false),
+        "doiget_fetch_paper writes to the store"
+    );
+    assert_eq!(
+        fetch.open_world_hint,
+        Some(true),
+        "doiget_fetch_paper resolves against arbitrary publisher hosts"
+    );
+    assert_eq!(
+        fetch.destructive_hint,
+        Some(false),
+        "doiget_fetch_paper never removes stored data"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
     Ok(())
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -175,15 +175,15 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling]]
-version = "0.23.0"
+version = "0.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_core]]
-version = "0.23.0"
+version = "0.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_macro]]
-version = "0.23.0"
+version = "0.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.deadpool]]
@@ -567,7 +567,7 @@ version = "1.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rmcp]]
-version = "2.2.0"
+version = "3.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rmcp-macros]]
@@ -575,7 +575,7 @@ version = "1.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rmcp-macros]]
-version = "2.2.0"
+version = "3.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.roman-numerals-rs]]


### PR DESCRIPTION
Supersedes #452. Dependabot cannot land it: the major needs a source change, a beta bump and `supply-chain/config.toml` exemptions.

## The one breaking change that reaches this repo

`InitializeResult::server_info` is `Option<Implementation>` in 3.x, by value in 2.x. It is read in exactly one place — `tests/initialize_handshake.rs`:

```rust
let implementation = server_info
    .server_info
    .as_ref()
    .expect("server_info populated after initialize");
assert_eq!(implementation.name, "doiget");
```

Presence is asserted rather than unwrapped inline: a server that omits the field still initializes, so "the field vanished" should read as a stated expectation, not an incidental panic.

Nothing else needed touching. `#[tool_router]`, `#[tool]`, `#[tool_handler]`, `ToolRouter::remove_route` (#379's mechanism), the `ServerInfo` / `ServerCapabilities` builders and `ProtocolVersion::V_2024_11_05` all carry over.

## What was checked beyond "it compiles"

A semver-major that compiles clean on the first try is the suspicious case, so the checks were aimed at silent behaviour change rather than build breakage:

| risk | finding |
|---|---|
| tool input schemas move with a `schemars` major | `schemars` stays at **1.2.1**. The bump relocked five crates only: `rmcp`, `rmcp-macros`, `darling{,_core,_macro}`. Every generated input schema is byte-identical. |
| advertised protocol version drifts with the SDK | `get_info` pins `ProtocolVersion::V_2024_11_05` explicitly, so it does not. |
| ADR-0001 stdio-only invariant breached | No `axum`, `oauth2`, `jsonwebtoken` or streamable-http crate appears in `cargo tree -p doiget-mcp`. Enabled features are still exactly `server`, `macros`, `transport-io`, `schemars`, plus `client` in dev-dependencies. |
| new transitive deps unvetted | rmcp 3 drops `async-trait`, adds `indexmap` and `uuid`; both were already in the graph. `cargo vet --locked` succeeds after bumping the five exemptions. |
| **the 0.8.6 safety annotations silently dropped** | They are not — but nothing was checking. See below. |

## New test: `tools_list_carries_the_safety_annotations`

The 22 `#[tool(annotations(...))]` blocks shipped in 0.8.6 are consumed entirely by the rmcp macro and read back by nothing in this crate. A macro-syntax or model change in a major could have dropped every one of them with the build green and all 46 other tests passing — an agent would then see 22 unannotated tools and have to assume the worst of each.

The test drives `tools/list` over the real duplex transport (not the router in memory, because the serialised form is what a client sees) and asserts:

- no advertised tool reaches the wire with `annotations: None`;
- the concrete hint values at two opposite corners of the matrix — `doiget_health` is read-only and closed-world, `doiget_fetch_paper` writes, is open-world and non-destructive.

Values, not just presence: an annotations struct that survived with all-`None` fields would pass a presence check while telling a client nothing.

**Verified by mutation.** Deleting the `annotations(...)` block from `doiget_health` makes this test fail and only this test — the other eight in the same file, including the existing `tools/list` assertions, stay green. That is the gap it closes.

## Verification

Local, GNU toolchain:

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,citation`, `oa-only,tdm-ieee` and the full `oa-only,metadata,tdm-*` set — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features oa-only,citation` — clean.
- `cargo test --workspace --all-targets --no-default-features --features oa-only` — 47 binaries, 0 failures.
- `cargo vet --locked` — succeeds.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.3`.

Refs #452, #406, #379
