### PR TITLE
fix(tdm-aps): request the URL APS documents, and pin the test to it (#484)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.3"
+version       = "0.8.10-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4786,9 +4786,14 @@ mod tdm_chain_tests {
             .iter()
             .map(|r| r.url.path().to_string())
             .collect();
+        // The prefix APS publishes, not the one this repo happens to
+        // build. #484 shipped `/v2/article/` past every test in the tree
+        // precisely because each of them was written from the
+        // implementation's output.
+        const APS_DOCUMENTED_PREFIX: &str = "/v2/journals/articles/";
         assert!(
-            paths.iter().any(|p| p.contains("/v2/article/")),
-            "fetch_paper never reached tdm-aps; paths were {paths:?}"
+            paths.iter().any(|p| p.contains(APS_DOCUMENTED_PREFIX)),
+            "fetch_paper never reached tdm-aps at its documented endpoint; paths were {paths:?}"
         );
 
         // Evidence 2: and the trace says so, in terms an operator can act

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -1,5 +1,5 @@
 //! APS Harvest TDM source — DOI metadata via the
-//! `/v2/article/<DOI>` endpoint (Phase 5b / Tier 3).
+//! `/v2/journals/articles/<DOI>` endpoint (Phase 5b / Tier 3).
 //!
 //! Spec: `docs/SOURCES.md` §1 Tier 3 row + §4 "TDM sources (Phase 5)",
 //! `docs/CAPABILITY.md` §2, ADR-0002 (per-publisher Cargo features),
@@ -72,7 +72,7 @@ const DEFAULT_BASE: &str = "https://harvest.aps.org";
 /// from the error message rather than looking like a lookup failure.
 pub(crate) const PUBLISHER_PREFIXES: &[&str] = &["10.1103"];
 
-/// APS Harvest [`Source`] impl — DOI → `/v2/article/<DOI>` JSON
+/// APS Harvest [`Source`] impl — DOI → `/v2/journals/articles/<DOI>` JSON
 /// record.
 #[derive(Clone, Debug)]
 pub struct TdmApsSource {
@@ -97,12 +97,27 @@ impl TdmApsSource {
         Self { base }
     }
 
-    /// Build the `/v2/article/<doi>` URL.
+    /// Build the `/v2/journals/articles/<doi>` URL.
     ///
-    /// APS encodes the DOI directly in the path; the `/` separator
-    /// in the DOI suffix must be percent-encoded.
+    /// The DOI goes into the path with its `/` separators intact. APS
+    /// publishes the shape verbatim:
+    ///
+    /// ```text
+    /// curl -H 'Accept: application/pdf'     ///   http://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001
+    /// ```
+    ///
+    /// Every other byte outside the RFC 3986 unreserved set is still
+    /// percent-encoded, because a DOI suffix may legally contain
+    /// characters (`;`, `<`, spaces) that are not safe in a path even
+    /// though `/` is.
+    ///
+    /// #484: this used to be `/v2/article/<percent-encoded DOI>`, which
+    /// is not an endpoint APS serves — `%2F` and the missing `journals/`
+    /// segment would each have produced a 404 on their own. Nothing
+    /// caught it because the wiremock stubs asserted the path this
+    /// function built rather than the one APS documents.
     fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
-        let path = format!("/v2/article/{}", percent_encode_path_segment(doi.as_str()));
+        let path = format!("/v2/journals/articles/{}", encode_doi_path(doi.as_str()));
         self.base.join(&path).map_err(|e| FetchError::SourceSchema {
             hint: format!("tdm-aps URL construction failed: {e}"),
         })
@@ -226,13 +241,13 @@ impl Source for TdmApsSource {
 
 /// Percent-encode a path segment, preserving the RFC 3986 unreserved
 /// set. `/` and other reserved characters are percent-encoded.
-fn percent_encode_path_segment(segment: &str) -> String {
-    let mut out = String::with_capacity(segment.len());
-    for b in segment.bytes() {
-        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+fn encode_doi_path(doi: &str) -> String {
+    let mut out = String::with_capacity(doi.len());
+    for b in doi.bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~' | b'/') {
             out.push(b as char);
         } else {
-            out.push_str(&format!("%{:02X}", b));
+            out.push_str(&format!("%{b:02X}"));
         }
     }
     out
@@ -305,6 +320,12 @@ mod tests {
 
     const TEST_KEY: &str = "aps-test-key-xyz";
 
+    /// The path the stubs match, spelled the way APS documents it rather
+    /// than the way `request_url` happens to build it. See
+    /// [`request_url_matches_the_published_aps_example`] for why the
+    /// distinction is load-bearing (#484).
+    const APS_ARTICLE_PATH: &str = "/v2/journals/articles/10.1103/PhysRevX.10.011001";
+
     fn profile_with_aps_grant() -> CapabilityProfile {
         let mut p = CapabilityProfile::for_tests();
         p.tdm_aps = Some(TdmGrant {
@@ -321,8 +342,7 @@ mod tests {
     async fn fetch_doi_returns_article_object() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            // APS path with percent-encoded DOI (`/` → `%2F`).
-            .and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
+            .and(path(APS_ARTICLE_PATH))
             // Slice 20: X-API-Key header MUST be present on the wire.
             .and(header("x-api-key", TEST_KEY))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ARTICLE_HIT))
@@ -367,7 +387,7 @@ mod tests {
     async fn fetch_non_object_returns_source_schema() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
+            .and(path(APS_ARTICLE_PATH))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_BAD_SHAPE))
             .mount(&server)
             .await;
@@ -411,5 +431,49 @@ mod tests {
                 "declared prefix {p} must be served"
             );
         }
+    }
+
+    /// The request URL is what APS publishes, byte for byte.
+    ///
+    /// This is the check the two wiremock tests below cannot make. A stub
+    /// written from `request_url`'s output asserts only that the
+    /// implementation agrees with itself — it stays green for any path, as
+    /// long as both sides move together. That is how `/v2/article/<DOI>`
+    /// survived to be shipped (#484).
+    ///
+    /// So the expectation here is a constant transcribed from the vendor's
+    /// own example, and it is deliberately not built from anything in this
+    /// module.
+    #[test]
+    fn request_url_matches_the_published_aps_example() {
+        // Verbatim from <https://harvest.aps.org/docs/harvest-api>:
+        //
+        //   curl -D - -H 'Accept: application/pdf'         //     http://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001
+        //
+        // Transcribed to https because `DEFAULT_BASE` pins TLS; the path
+        // and the DOI encoding are unchanged.
+        const PUBLISHED: &str =
+            "https://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001";
+
+        let src = TdmApsSource::new();
+        let doi = Doi::parse("10.1103/PhysRevX.5.021001").expect("DOI parses");
+
+        assert_eq!(
+            src.request_url(&doi).expect("URL builds").as_str(),
+            PUBLISHED,
+            "the URL must match APS's published example, not this module's idea of it"
+        );
+    }
+
+    /// A DOI suffix may carry characters that are not path-safe. `/` stays,
+    /// everything outside the RFC 3986 unreserved set does not.
+    #[test]
+    fn encode_doi_path_keeps_slashes_and_escapes_the_rest() {
+        assert_eq!(
+            encode_doi_path("10.1103/PhysRevX.5.021001"),
+            "10.1103/PhysRevX.5.021001"
+        );
+        assert_eq!(encode_doi_path("10.1103/a b"), "10.1103/a%20b");
+        assert_eq!(encode_doi_path("10.1103/x;y"), "10.1103/x%3By");
     }
 }


### PR DESCRIPTION
`TdmApsSource` asked for an endpoint APS does not serve. Found while designing the #458 fix, which makes these sources reachable for the first time — at which point this becomes a live 404.

## The mismatch

`crates/doiget-core/src/sources/tdm_aps.rs` built:

```rust
format!("/v2/article/{}", percent_encode_path_segment(doi.as_str()))
```

[APS Harvest](https://harvest.aps.org/docs/harvest-api) documents exactly three endpoints, and that is not one of them:

```
GET /v2/journals/articles
GET /v2/journals/articles/{id}
GET /v2/journals/articles/{id}/accepted_fulltext
```

with the DOI carried raw — the vendor's own example:

```
curl -D - -H 'Accept: application/pdf' \
  http://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001
```

| | was | now |
|---|---|---|
| path | `/v2/article/<DOI>` | `/v2/journals/articles/<DOI>` |
| DOI | `/` percent-encoded to `%2F` | raw `/`, other unsafe bytes still escaped |

Two independent defects, each fatal on its own. No user is affected: `tdm-aps` is never reached by the production fetch path today, which is exactly what #458 is about.

`percent_encode_path_segment` becomes `encode_doi_path`. `/` is a separator here rather than data, but everything outside the RFC 3986 unreserved set is still escaped, because a DOI suffix may legally contain `;`, `<` or a space.

## Why nothing caught it

```rust
.and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
```

The stub was transcribed from `request_url`'s output. That makes the test a restatement of the implementation: it asserts that the code agrees with itself, and would have stayed green for any path — `/banana` included — as long as both sides moved together.

So the fix is not just the string. Both stubs now match a named constant spelled the way APS documents it, and a new test pins the built URL against a constant transcribed verbatim from the vendor curl example, derived from nothing in this module:

```rust
const PUBLISHED: &str =
    "https://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001";
```

(https rather than the doc's http, because `DEFAULT_BASE` pins TLS; the path and DOI encoding are untouched.)

**Verified by mutation.** Restoring `/v2/article/` fails three tests — the new pin *and both* wiremock tests. Under the old arrangement the identical mutation kept all three green:

```
request_url_matches_the_published_aps_example ... FAILED
fetch_doi_returns_article_object ............... FAILED
fetch_non_object_returns_source_schema ......... FAILED
```

## Where this sits

Same shape as #442 (no caller), #454 (allowlist absent from the production client) and #458 (chain short-circuited), one level further out. Those were wiring defects — the component was right and unreachable. Here the component is wired correctly and disagrees with the vendor, which is a class a stub-based test cannot close on its own: a stub asserts what its author believed the contract was.

`tdm-elsevier`'s `/content/article/doi/<DOI>` does match Elsevier's published WADL. `tdm-springer` and `tdm-ieee` are unchecked — worth a pass, noted on #484.

`docs/SOURCES.md` lists only the base URL for APS, so no doc or `site/content/` regeneration is needed.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,tdm-aps`, and the full `oa-only,metadata,tdm-*` set — clean.
- `cargo test --workspace --all-targets --no-default-features --features oa-only` — 0 failures.
- `cargo test -p doiget-core --features oa-only,tdm-aps tdm_aps` — 6 passed.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.4`.

Closes #484
Refs #458, #442, #454
