### PR TITLE
feat(tdm): consult Tier 3 when the content leg is blocked (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[orchestrator]** A Tier-3 TDM source is consulted when the **content leg** is
+  blocked, not only when Crossref missed. It was asked the metadata question all
+  along, and Crossref answers that question readily for a publisher's own DOIs — so
+  for exactly the DOIs these sources exist to serve, the chain recorded `NotNeeded`
+  and no request ever went out. Signing an agreement, obtaining a key and building
+  with the feature produced byte-identical output (#458, ADR-0044).
+
+### Added
+
+- **[source]** `tdm-aps` returns the article PDF. APS documents single-request
+  retrieval with `Accept: application/pdf`, which makes it the only Tier-3
+  publisher whose full-text contract is both public and PDF-shaped — Elsevier does
+  not permit non-open-access PDF retrieval through its APIs at all (#458, ADR-0044).
+- **[core]** `Source::fetch_content`, defaulted to `Ok(None)`. "Metadata-only" was
+  previously expressed by setting `pdf_bytes: None` and saying so in a doc-comment,
+  which the orchestrator could not read — so it could not tell a source with nothing
+  to offer from one it had never asked.
+- **[transport]** `HttpClient::fetch_pdf_with_headers`. The magic-byte check is not
+  optional on a credentialed endpoint: publisher error pages and WAF holding
+  responses are 200s with a body.
+
+### Changed
+
+- **[errors]** `PdfLegStatus::TdmFetched` is distinct from `Fetched`, and the stored
+  source label names the publisher rather than `oa-publisher`. A TDM copy did not
+  come from an OA host and carries an agreement's terms.
+- **[core]** A TDM-retrieved artifact reports `license = "unknown"`. Unpaywall's
+  licence describes an OA location that was never reached; carrying it forward would
+  put an open-licence claim on a file obtained by a route it does not describe.
+- **[docs]** ADR-0044, which also records that ADR-0041's rejection of
+  Crossref-based publisher routing rested on a premise this change removes.
+
 ### Retracted
 
 - **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers. It

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.4"
+version = "0.8.10-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.4"
+version = "0.8.10-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.4"
+version = "0.8.10-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.4"
+version       = "0.8.10-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -597,6 +597,18 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
                 label, outcome.size_bytes, arxiv_id, outcome.path
             ));
         }
+        // #458: the publisher served its own copy under the user's TDM
+        // agreement. Named explicitly rather than left to the `_` arm
+        // below, which would have printed the same line as a plain OA
+        // fetch -- the user needs to know the open route failed and which
+        // agreement was drawn on, because that is the one with terms
+        // attached.
+        PdfLegStatus::TdmFetched { source, .. } => {
+            print_success(format_args!(
+                "fetched {} ({} bytes) via {} under your TDM agreement (no open copy available) -> {}",
+                label, outcome.size_bytes, source, outcome.path
+            ));
+        }
         // Issue #145: `Blocked` is NO LONGER a success outcome. It is
         // intercepted in `fetch_one` BEFORE `emit_success_line` is
         // called and rendered via `render_blocked_error` with a
@@ -814,7 +826,9 @@ fn emit_link_result(ref_: &Ref, outcome: &FetchPaperOutcome, dir: &Utf8Path) {
     };
     if !matches!(
         outcome.pdf_leg,
-        PdfLegStatus::Fetched | PdfLegStatus::PreprintFallback { .. }
+        PdfLegStatus::Fetched
+            | PdfLegStatus::PreprintFallback { .. }
+            | PdfLegStatus::TdmFetched { .. }
     ) {
         print_success(format_args!(
             "note: --link skipped for {label} (no PDF — metadata-only fetch)"

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -883,6 +883,31 @@ impl HttpClient {
         self.fetch_inner(source, url, &[], true).await
     }
 
+    /// [`Self::fetch_pdf`] with request headers, for sources that
+    /// authenticate by header rather than by query parameter.
+    ///
+    /// This is the pairing the Tier-3 content leg needs (#458): APS Harvest
+    /// wants `X-API-Key` *and* `Accept: application/pdf` on the same request
+    /// that must be magic-byte checked. `fetch_bytes_with_headers` would
+    /// send the headers and skip the check, which is exactly how a
+    /// publisher error page or a WAF holding response — both 200s with a
+    /// body — would end up written to `<safekey>.pdf`.
+    ///
+    /// Header values are sent on the wire only; they are never logged and
+    /// never echoed into an error message (#146).
+    ///
+    /// # Errors
+    ///
+    /// Any [`HttpError`] variant including [`HttpError::NotAPdf`].
+    pub async fn fetch_pdf_with_headers(
+        &self,
+        source: &str,
+        url: Url,
+        headers: &[(&str, &str)],
+    ) -> Result<(Bytes, Url), HttpError> {
+        self.fetch_inner(source, url, headers, true).await
+    }
+
     /// Single diagnostic request against `url`, reporting what came back
     /// instead of turning it into an error.
     ///

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -770,6 +770,23 @@ pub enum PdfLegStatus {
         /// and audit trail context).
         original_block: String,
     },
+    /// The OA chain was blocked and a Tier-3 TDM source served the
+    /// publisher's own copy under the user's TDM agreement (#458).
+    ///
+    /// Distinct from [`Self::Fetched`] on purpose. The bytes did not come
+    /// from an OA host, they are not necessarily openly licensed, and the
+    /// user obtained them under an agreement they signed — provenance
+    /// that says `oa-publisher` here would be wrong in all three
+    /// respects.
+    TdmFetched {
+        /// The Tier-3 source that served it (`"tdm-aps"`, ...). Matches
+        /// [`crate::source::Source::name`].
+        source: String,
+        /// The OA-chain error that triggered the fallback, kept for the
+        /// audit trail — the user still needs to know the open route
+        /// failed even though the fetch succeeded.
+        original_block: String,
+    },
 }
 
 /// What `fetch_paper` wrote to disk and how.
@@ -1373,6 +1390,23 @@ async fn fetch_paper_doi(
         optional_resolved.as_ref().map(|(n, m)| (*n, m)),
     )
     .await;
+
+    // #458: and if even that found nothing, ask the publisher itself.
+    //
+    // This is the second Tier-3 consultation point, and the one that
+    // matters. `resolve_tdm_chain` above runs when *Crossref* missed,
+    // which is a question about metadata. The gap a TDM agreement is
+    // obtained to close is about bytes, and it opens here -- after
+    // Crossref answered perfectly well and the content leg still failed.
+    #[cfg(any(
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
+    ))]
+    let (pdf_leg, pdf_bytes) =
+        try_tdm_content_fallback(doi, pdf_leg, pdf_bytes, profile, ctx, &mut attempts).await;
+
     if let Some(fl) = fallback_license {
         license = fl;
     }
@@ -1407,14 +1441,17 @@ async fn fetch_paper_doi(
         }
     }
 
-    let is_preprint_fallback = matches!(pdf_leg, PdfLegStatus::PreprintFallback { .. });
     let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_bytes {
         Some(bytes) => {
             let staged = stage_pdf_to_tempfile(bytes)?;
-            let label = if is_preprint_fallback {
-                "arxiv".to_string()
-            } else {
-                "oa-publisher".to_string()
+            // Derived from the leg rather than from a boolean: #458 added a
+            // third way to end up holding bytes, and a two-valued flag
+            // would have quietly labelled the publisher's TDM copy
+            // `oa-publisher`.
+            let label = match &pdf_leg {
+                PdfLegStatus::PreprintFallback { .. } => "arxiv".to_string(),
+                PdfLegStatus::TdmFetched { source, .. } => source.clone(),
+                _ => "oa-publisher".to_string(),
             };
             (
                 label,
@@ -1631,6 +1668,193 @@ async fn try_optional_source_oa_fallback(
             (pdf_leg, pdf_bytes)
         }
     }
+}
+
+/// #458: the publisher's own copy, once the open routes are exhausted.
+///
+/// Triggered by a blocked *content* leg -- the trigger #445 already built
+/// for the optional OA chain, and the one Tier 3 always needed.
+/// `resolve_tdm_chain` fires on a Crossref miss instead, so for the DOIs
+/// these sources exist to serve -- ones Crossref resolves readily -- it
+/// recorded `NotNeeded` for every entry and no request ever went out.
+///
+/// Additive, like its two siblings: on any failure the ORIGINAL block is
+/// kept. The publisher's refusal on the open route is what the user has to
+/// act on; burying it under a second failure from the TDM endpoint would
+/// answer a question they did not ask.
+///
+/// Disclosure stays bounded exactly as ADR-0041 bounds it -- a source is
+/// only ever told about DOIs its own publisher registered. What rises is
+/// the frequency of consultation, not its scope.
+#[cfg(any(
+    feature = "tdm-elsevier",
+    feature = "tdm-aps",
+    feature = "tdm-springer",
+    feature = "tdm-ieee"
+))]
+#[allow(clippy::vec_init_then_push)]
+async fn try_tdm_content_fallback(
+    doi: &Doi,
+    pdf_leg: PdfLegStatus,
+    pdf_bytes: Option<Vec<u8>>,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    attempts: &mut Vec<SourceAttempt>,
+) -> (PdfLegStatus, Option<Vec<u8>>) {
+    struct ContentEntry<'a> {
+        name: &'static str,
+        /// What the user must set, rendered verbatim into the trace.
+        enable_hint: &'static str,
+        /// DOI prefixes this publisher registered (ADR-0041).
+        prefixes: &'static [&'static str],
+        /// Human name, for the wrong-publisher message.
+        publisher: &'static str,
+        src: &'a dyn crate::source::Source,
+    }
+
+    if pdf_bytes.is_some() {
+        return (pdf_leg, pdf_bytes);
+    }
+    let PdfLegStatus::Blocked {
+        message: ref blocked_message,
+        ..
+    } = pdf_leg
+    else {
+        return (pdf_leg, pdf_bytes);
+    };
+    let original_block = blocked_message.clone();
+
+    let ref_ = Ref::Doi(doi.clone());
+
+    #[cfg(feature = "tdm-aps")]
+    let aps = optional_base("DOIGET_APS_BASE").map_or_else(
+        crate::sources::tdm_aps::TdmApsSource::new,
+        crate::sources::tdm_aps::TdmApsSource::with_base,
+    );
+    #[cfg(feature = "tdm-elsevier")]
+    let elsevier = optional_base("DOIGET_ELSEVIER_BASE").map_or_else(
+        crate::sources::tdm_elsevier::TdmElsevierSource::new,
+        crate::sources::tdm_elsevier::TdmElsevierSource::with_base,
+    );
+    #[cfg(feature = "tdm-springer")]
+    let springer = optional_base("DOIGET_SPRINGER_BASE").map_or_else(
+        crate::sources::tdm_springer::TdmSpringerSource::new,
+        crate::sources::tdm_springer::TdmSpringerSource::with_base,
+    );
+    #[cfg(feature = "tdm-ieee")]
+    let ieee = optional_base("DOIGET_IEEE_BASE").map_or_else(
+        crate::sources::tdm_ieee::TdmIeeeSource::new,
+        crate::sources::tdm_ieee::TdmIeeeSource::with_base,
+    );
+
+    // Not a `vec![]` literal: each entry is `#[cfg]`-gated on its own
+    // publisher feature, and attribute-per-element inside a vec literal is
+    // not expressible. Same shape as `resolve_tdm_chain`; the
+    // `vec_init_then_push` allow is on the fn because the lint's span runs
+    // from the `let` across every push, so a statement-level attribute does
+    // not cover it.
+    #[allow(unused_mut)]
+    let mut chain: Vec<ContentEntry<'_>> = Vec::new();
+    #[cfg(feature = "tdm-aps")]
+    chain.push(ContentEntry {
+        name: "tdm-aps",
+        enable_hint: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+        prefixes: crate::sources::tdm_aps::PUBLISHER_PREFIXES,
+        publisher: "American Physical Society (APS)",
+        src: &aps,
+    });
+    #[cfg(feature = "tdm-elsevier")]
+    chain.push(ContentEntry {
+        name: "tdm-elsevier",
+        enable_hint: "DOIGET_KEY_ELSEVIER + DOIGET_AGREE_TDM_ELSEVIER",
+        prefixes: crate::sources::tdm_elsevier::PUBLISHER_PREFIXES,
+        publisher: "Elsevier BV",
+        src: &elsevier,
+    });
+    #[cfg(feature = "tdm-springer")]
+    chain.push(ContentEntry {
+        name: "tdm-springer",
+        enable_hint: "DOIGET_KEY_SPRINGER + DOIGET_AGREE_TDM_SPRINGER",
+        prefixes: crate::sources::tdm_springer::PUBLISHER_PREFIXES,
+        publisher: "Springer Nature",
+        src: &springer,
+    });
+    #[cfg(feature = "tdm-ieee")]
+    chain.push(ContentEntry {
+        name: "tdm-ieee",
+        enable_hint: "DOIGET_KEY_IEEE + DOIGET_AGREE_TDM_IEEE",
+        prefixes: crate::sources::tdm_ieee::PUBLISHER_PREFIXES,
+        publisher: "IEEE",
+        src: &ieee,
+    });
+
+    // Replace the metadata-stage row rather than appending a second one.
+    // That row says `NotNeeded`, which was true of the metadata question
+    // and is now false of the one being asked.
+    fn record(attempts: &mut Vec<SourceAttempt>, name: &'static str, outcome: AttemptOutcome) {
+        attempts.retain(|a| a.source != name);
+        attempts.push(SourceAttempt::new(name, outcome));
+    }
+
+    for e in chain {
+        debug_assert_eq!(e.name, e.src.name(), "chain name must match Source::name");
+
+        // Prefix BEFORE credentials, per ADR-0041: a DOI this publisher
+        // never registered is not a configuration problem, and reporting
+        // it as one would send the user after an API key that would not
+        // have helped.
+        if !e.prefixes.contains(&doi.prefix()) {
+            record(
+                attempts,
+                e.name,
+                AttemptOutcome::WrongPublisher {
+                    detail: format!("DOI prefix {} is not {}", doi.prefix(), e.publisher),
+                },
+            );
+            continue;
+        }
+        if !e.src.can_serve(profile, &ref_) {
+            record(
+                attempts,
+                e.name,
+                AttemptOutcome::Disabled { env: e.enable_hint },
+            );
+            continue;
+        }
+
+        match e.src.fetch_content(&ref_, profile, ctx).await {
+            // A metadata-only source. It has nothing to say about the
+            // content question, so its metadata-stage row is left alone
+            // rather than overwritten with a verdict it never gave.
+            Ok(None) => {}
+            Ok(Some(bytes)) => {
+                tracing::info!(
+                    source = e.name,
+                    doi = %doi.as_str(),
+                    size = bytes.len(),
+                    "OA routes exhausted; the publisher served its own copy under the user's TDM agreement (#458)"
+                );
+                record(attempts, e.name, AttemptOutcome::Resolved);
+                return (
+                    PdfLegStatus::TdmFetched {
+                        source: e.name.to_string(),
+                        original_block,
+                    },
+                    Some(bytes.to_vec()),
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    source = e.name,
+                    error = %err,
+                    "TDM content leg failed; keeping the original block"
+                );
+                record(attempts, e.name, classify_attempt(&err));
+            }
+        }
+    }
+
+    (pdf_leg, pdf_bytes)
 }
 
 /// Auto preprint fallback (issue #325). Called after the DOI OA PDF chain

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1411,6 +1411,27 @@ async fn fetch_paper_doi(
         license = fl;
     }
 
+    // #458: the licence tracks the artifact that actually landed, not the
+    // work. That is already how the arXiv fallback behaves -- it overwrites
+    // `license` with the preprint's, because a CC-BY record about the
+    // published version says nothing about the file on disk.
+    //
+    // A TDM copy came from the publisher under an agreement the user
+    // signed, by a route the OA licence does not describe; carrying
+    // Unpaywall's `cc-by` forward would put an open-licence claim on it.
+    // doiget does not guess licences (`docs/SOURCES.md` -- Tier-2 sources
+    // report `unknown` rather than infer), and the APS record's licence
+    // field describes the article, not this retrieval. So: `unknown`.
+    #[cfg(any(
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
+    ))]
+    if matches!(pdf_leg, PdfLegStatus::TdmFetched { .. }) {
+        license = "unknown".to_string();
+    }
+
     // Issue #120: Crossref is non-fatal, but if it failed AND the OA
     // PDF leg produced nothing, writing a DOI-only stub entry would
     // mask a total failure and violate the "explain why" promise.
@@ -4693,7 +4714,7 @@ mod tdm_chain_tests {
 
     use camino::Utf8PathBuf;
     use tempfile::TempDir;
-    use wiremock::matchers::method;
+    use wiremock::matchers::{header, method, path, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::http::HttpClient;
@@ -5030,6 +5051,315 @@ mod tdm_chain_tests {
             "the trace must record tdm-aps as consulted; got:
 {hint}"
         );
+    }
+    // -----------------------------------------------------------------
+    // #458 — the CONTENT leg. Everything above this line drives the
+    // metadata stage (Crossref missed); these drive the state #458 was
+    // actually reported in: Crossref answered fine, and the PDF is what
+    // could not be had.
+    // -----------------------------------------------------------------
+
+    /// The mock has to serve Crossref, Unpaywall, the OA host AND the TDM
+    /// endpoint, so every one of those source keys needs an allowlist
+    /// entry. `ctx_for` above registers only the `tdm-*` keys, which is
+    /// why its tests can only ever 404 their way to the chain.
+    fn ctx_for_content(host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let dir = Utf8PathBuf::try_from(td.path().to_path_buf()).expect("utf-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http_multi(&[
+            ("crossref", host),
+            ("unpaywall", host),
+            ("oa-publisher", host),
+            ("tdm-aps", host),
+            ("tdm-elsevier", host),
+            ("tdm-springer", host),
+            ("tdm-ieee", host),
+        ]));
+        let session_id = "01J0000000000000000000CNT".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(dir.join("t.jsonl"), session_id.clone()).expect("log opens"),
+        );
+        (
+            td,
+            FetchContext {
+                http,
+                rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+                log,
+                session_id,
+                cache_root: None,
+            },
+        )
+    }
+
+    /// Minimal Crossref envelope. Its job here is simply to SUCCEED, which
+    /// is what makes `resolve_tdm_chain` record `NotNeeded` for every
+    /// Tier-3 entry — the short circuit #458 is about.
+    fn crossref_body() -> serde_json::Value {
+        serde_json::json!({
+            "status": "ok",
+            "message": {
+                "title": ["A paper APS published"],
+                "author": [{ "family": "Doe", "given": "Jane" }],
+                "issued": { "date-parts": [[2026, 1, 1]] },
+                "container-title": ["Physical Review X"],
+                "type": "journal-article"
+            }
+        })
+    }
+
+    /// Unpaywall reports an OA copy that will turn out to be unreachable.
+    /// `license` is deliberately `cc-by`: if the TDM copy inherited it,
+    /// the store would carry an open-licence claim about a file obtained
+    /// under a signed agreement.
+    fn unpaywall_body(oa_url: &str) -> serde_json::Value {
+        serde_json::json!({
+            "doi": "10.1103/PhysRevX.10.011001",
+            "is_oa": true,
+            "title": "A paper APS published",
+            "best_oa_location": {
+                "url": oa_url,
+                "url_for_pdf": oa_url,
+                "license": "cc-by"
+            }
+        })
+    }
+
+    const PDF_BYTES: &[u8] = b"%PDF-1.7\nthe publisher's own copy\n%%EOF\n";
+
+    /// Mount Crossref (answers), Unpaywall (points at a dead OA URL), the
+    /// dead OA URL itself, and whatever APS should reply with.
+    ///
+    /// Registration order matters: wiremock takes the first mock that
+    /// matches, so the Unpaywall catch-all goes last.
+    async fn mount_oa_blocked(server: &MockServer, aps: ResponseTemplate) {
+        let oa_url = format!("{}/oa/file.pdf", server.uri());
+        Mock::given(method("GET"))
+            .and(path_regex("^/works/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(crossref_body()))
+            .mount(server)
+            .await;
+        // The PDF representation of the APS article endpoint. Matched on
+        // `Accept` so it cannot be confused with the metadata-stage call
+        // to the same path — if the two were conflated this test would
+        // pass without the content leg existing at all.
+        Mock::given(method("GET"))
+            .and(path_regex("^/v2/journals/articles/"))
+            .and(header("accept", "application/pdf"))
+            .respond_with(aps)
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/oa/file.pdf"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(unpaywall_body(&oa_url)))
+            .mount(server)
+            .await;
+    }
+
+    fn aps_pdf_requests(reqs: &[wiremock::Request]) -> usize {
+        reqs.iter()
+            .filter(|r| {
+                r.url.path().starts_with("/v2/journals/articles/")
+                    && r.headers
+                        .get("accept")
+                        .and_then(|v| v.to_str().ok())
+                        .is_some_and(|v| v.contains("application/pdf"))
+            })
+            .count()
+    }
+
+    /// THE regression for #458.
+    ///
+    /// Crossref answers, so the metadata-stage chain records `NotNeeded`
+    /// for every Tier-3 source exactly as it always did. The OA copy is
+    /// refused. Before this change that was the end of it — byte-identical
+    /// output with the TDM gates open and closed, which is the report.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn tdm_content_leg_serves_the_pdf_when_the_oa_route_is_blocked() {
+        let server = MockServer::start().await;
+        mount_oa_blocked(
+            &server,
+            ResponseTemplate::new(200).set_body_bytes(PDF_BYTES),
+        )
+        .await;
+
+        let _bases = BaseGuard::to(&server.uri());
+        let _oa = OaBaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let store_td = TempDir::new().expect("tempdir");
+        let root = Utf8PathBuf::try_from(store_td.path().to_path_buf()).expect("utf-8");
+        let store = crate::store::FsStore::new(root.clone()).expect("store");
+
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("doi"));
+        let outcome = fetch_paper(&ref_, &all_gates_open(), &ctx, &store, &root)
+            .await
+            .expect("the TDM content leg should have supplied the PDF");
+
+        // Evidence 1: a PDF request actually went out to APS. Asserted on
+        // the mock's record rather than on the return value, because
+        // "reached" is the whole question (#442).
+        let reqs = server.received_requests().await.expect("recorded");
+        assert_eq!(
+            aps_pdf_requests(&reqs),
+            1,
+            "expected exactly one Accept: application/pdf request to the APS article endpoint; \
+             paths were {:?}",
+            reqs.iter().map(|r| r.url.path()).collect::<Vec<_>>()
+        );
+
+        // Evidence 2: the leg says where the bytes came from.
+        match &outcome.pdf_leg {
+            PdfLegStatus::TdmFetched {
+                source,
+                original_block,
+            } => {
+                assert_eq!(source, "tdm-aps");
+                assert!(
+                    !original_block.is_empty(),
+                    "the OA refusal must be carried forward, not discarded"
+                );
+            }
+            other => panic!("expected TdmFetched, got {other:?}"),
+        }
+
+        // Evidence 3: provenance names the publisher, not `oa-publisher`.
+        assert_eq!(outcome.source, "tdm-aps");
+        assert_eq!(outcome.size_bytes, PDF_BYTES.len() as u64);
+
+        // Evidence 4: and it does not claim the file is CC-BY. Unpaywall
+        // said `cc-by` about the OA location we never got; this file came
+        // from the publisher under an agreement, by a route that licence
+        // does not describe.
+        assert_eq!(
+            outcome.license, "unknown",
+            "a TDM-retrieved copy must not inherit the OA location's licence"
+        );
+    }
+
+    /// Prefix scoping still holds on the new path (ADR-0041). An Elsevier
+    /// DOI must not cause a request to APS — the disclosure argument for
+    /// the whole feature depends on it, and the new consultation point
+    /// fires far more often than the old one.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn tdm_content_leg_is_not_consulted_for_another_publishers_doi() {
+        let server = MockServer::start().await;
+        mount_oa_blocked(
+            &server,
+            ResponseTemplate::new(200).set_body_bytes(PDF_BYTES),
+        )
+        .await;
+
+        let _bases = BaseGuard::to(&server.uri());
+        let _oa = OaBaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let store_td = TempDir::new().expect("tempdir");
+        let root = Utf8PathBuf::try_from(store_td.path().to_path_buf()).expect("utf-8");
+        let store = crate::store::FsStore::new(root.clone()).expect("store");
+
+        // An Elsevier prefix, with the APS gate wide open.
+        let ref_ = Ref::Doi(Doi::parse("10.1016/j.physrep.2020.01.001").expect("doi"));
+        let _ = fetch_paper(&ref_, &all_gates_open(), &ctx, &store, &root).await;
+
+        let reqs = server.received_requests().await.expect("recorded");
+        assert_eq!(
+            aps_pdf_requests(&reqs),
+            0,
+            "an Elsevier DOI reached the APS content endpoint; paths were {:?}",
+            reqs.iter().map(|r| r.url.path()).collect::<Vec<_>>()
+        );
+    }
+
+    /// The zero-request test above proves nothing reached APS. It cannot
+    /// prove WHICH gate stopped it: `Source::can_serve` checks the prefix
+    /// too, so deleting the orchestrator check leaves that test green.
+    ///
+    /// What only the orchestrator produces is the DISTINCTION. ADR-0041
+    /// checks the prefix before credentials precisely so a foreign DOI
+    /// reads as `WrongPublisher` rather than `Disabled` -- otherwise the
+    /// trace tells the user to go and find an API key that would not have
+    /// helped, which is the failure #438 added the trace to prevent.
+    ///
+    /// Mirrors `a_foreign_doi_is_wrong_publisher_not_disabled`, which
+    /// makes the same assertion about the metadata chain.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn content_leg_reports_a_foreign_doi_as_wrong_publisher_not_disabled() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let doi = Doi::parse("10.1016/j.physrep.2020.01.001").expect("doi");
+        let blocked = PdfLegStatus::Blocked {
+            code: crate::ErrorCode::NetworkError,
+            message: "the open route refused us".to_string(),
+            denial: None,
+            suggested_arxiv_id: None,
+        };
+        let mut attempts: Vec<SourceAttempt> = Vec::new();
+
+        let (leg, bytes) =
+            try_tdm_content_fallback(&doi, blocked, None, &all_gates_open(), &ctx, &mut attempts)
+                .await;
+
+        assert!(bytes.is_none(), "no publisher owns this DOI here");
+        assert!(matches!(leg, PdfLegStatus::Blocked { .. }));
+        assert!(
+            matches!(outcome(&attempts, "tdm-aps"), AttemptOutcome::WrongPublisher { .. }),
+            "an Elsevier DOI must read as WrongPublisher for tdm-aps, not Disabled; got {attempts:?}"
+        );
+    }
+
+    /// A 200 that is not a PDF must not become `<safekey>.pdf`, and must
+    /// not displace the OA refusal the user has to act on.
+    ///
+    /// This is the case `fetch_bytes_with_headers` would have gotten
+    /// wrong: publisher error pages and WAF holding responses are 200s
+    /// with a body.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn tdm_content_leg_rejects_a_non_pdf_body_and_keeps_the_original_block() {
+        let server = MockServer::start().await;
+        mount_oa_blocked(
+            &server,
+            ResponseTemplate::new(200).set_body_string("<html>Access denied</html>"),
+        )
+        .await;
+
+        let _bases = BaseGuard::to(&server.uri());
+        let _oa = OaBaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let store_td = TempDir::new().expect("tempdir");
+        let root = Utf8PathBuf::try_from(store_td.path().to_path_buf()).expect("utf-8");
+        let store = crate::store::FsStore::new(root.clone()).expect("store");
+
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("doi"));
+        let outcome = fetch_paper(&ref_, &all_gates_open(), &ctx, &store, &root)
+            .await
+            .expect("a metadata-only outcome is still an outcome");
+
+        // The request went out...
+        let reqs = server.received_requests().await.expect("recorded");
+        assert_eq!(aps_pdf_requests(&reqs), 1);
+
+        // ...and the HTML did not become a PDF.
+        match &outcome.pdf_leg {
+            PdfLegStatus::Blocked { message, .. } => {
+                assert!(
+                    !message.is_empty(),
+                    "the ORIGINAL OA refusal must survive, not the TDM failure"
+                );
+            }
+            other => panic!("expected the original Blocked leg to survive, got {other:?}"),
+        }
+        assert_eq!(outcome.size_bytes, 0, "nothing should have been stored");
     }
 }
 

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -329,6 +329,47 @@ pub trait Source: Send + Sync {
         profile: &CapabilityProfile,
         ctx: &FetchContext,
     ) -> Result<FetchResult, FetchError>;
+
+    /// Fetch the publisher's own copy of the document itself, when this
+    /// source holds one.
+    ///
+    /// Distinct from [`Self::fetch`], which resolves a *record*. A Tier-3
+    /// TDM source is consulted for two different reasons at two different
+    /// points in the fetch, and conflating them is what #458 was:
+    ///
+    /// - [`fetch`](Self::fetch) answers "who can tell me about this DOI?"
+    ///   and runs when Crossref could not;
+    /// - `fetch_content` answers "who will give me the bytes?" and runs
+    ///   when the content leg was blocked — which is usually *after*
+    ///   Crossref answered perfectly well.
+    ///
+    /// The default is `Ok(None)`: "this source is metadata-only". Stating
+    /// it is the point. Before #458 the same fact was expressed by every
+    /// Tier-3 impl setting `FetchResult.pdf_bytes` to `None` and saying so
+    /// in a doc-comment, which the orchestrator could neither read nor act
+    /// on — so it could not tell a source that had nothing to offer from
+    /// one it had simply never asked.
+    ///
+    /// Implementations that override it MUST use a PDF-validating fetch
+    /// ([`HttpClient::fetch_pdf`] or
+    /// [`HttpClient::fetch_pdf_with_headers`]). A publisher error page or
+    /// a WAF holding response is a 200 with a body, and storing one under
+    /// `<safekey>.pdf` would be worse than returning nothing.
+    ///
+    /// # Errors
+    ///
+    /// Any [`FetchError`]. `Ok(None)` means "not me"; `Err` means "me, and
+    /// it went wrong". The orchestrator keeps the original content-leg
+    /// block either way, but records the two as different attempt
+    /// outcomes.
+    async fn fetch_content(
+        &self,
+        _ref_: &Ref,
+        _profile: &CapabilityProfile,
+        _ctx: &FetchContext,
+    ) -> Result<Option<Bytes>, FetchError> {
+        Ok(None)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -44,6 +44,8 @@ use secrecy::ExposeSecret;
 use url::Url;
 
 use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use bytes::Bytes;
+
 use crate::source::{FetchContext, FetchError, FetchResult, Source};
 use crate::{CapabilityProfile, Ref};
 
@@ -237,10 +239,74 @@ impl Source for TdmApsSource {
             metadata_json: Some(envelope),
         })
     }
+
+    /// APS serves the article PDF from the same endpoint as the JSON
+    /// record; `Accept` selects the representation. Both are documented
+    /// against `/v2/journals/articles/{id}` (#484).
+    ///
+    /// Returns `Ok(None)` — "not me" — rather than an error whenever a
+    /// gate is shut, so the orchestrator can tell "APS declined" apart
+    /// from "APS was never eligible". The gates are re-checked here even
+    /// though the caller checks them: a source that trusts its caller is
+    /// one refactor away from not being checked at all, which is the
+    /// double-gate pattern the other Tier-3 entry points already use.
+    async fn fetch_content(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<Option<Bytes>, FetchError> {
+        let Ref::Doi(doi) = ref_ else {
+            return Ok(None);
+        };
+        // Grant present AND the DOI is one APS registered (ADR-0041).
+        if !self.can_serve(profile, ref_) {
+            return Ok(None);
+        }
+        let Some(grant) = profile.tdm_aps.as_ref() else {
+            return Ok(None);
+        };
+        let api_key = grant.api_key.expose_secret();
+        if api_key.is_empty() {
+            return Ok(None);
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        // `fetch_pdf_with_headers`, not `fetch_bytes_with_headers`: the
+        // magic-byte check is the only thing standing between an APS
+        // error page and a file called `<safekey>.pdf`.
+        let (bytes, _final_url) = ctx
+            .http
+            .fetch_pdf_with_headers(
+                self.name(),
+                url,
+                &[("X-API-Key", api_key), ("Accept", "application/pdf")],
+            )
+            .await?;
+
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::TdmAps,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(bytes.len() as u64),
+            license: None,
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(Some(bytes))
+    }
 }
 
-/// Percent-encode a path segment, preserving the RFC 3986 unreserved
-/// set. `/` and other reserved characters are percent-encoded.
+/// Percent-encode a DOI for use as a URL path, preserving the RFC 3986
+/// unreserved set **and** `/`, which APS carries raw (#484). Every other
+/// reserved or non-ASCII byte is escaped.
 fn encode_doi_path(doi: &str) -> String {
     let mut out = String::with_capacity(doi.len());
     for b in doi.bytes() {

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3242,6 +3242,18 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
     match leg {
         PdfLegStatus::Fetched => json!({ "status": "fetched" }),
         PdfLegStatus::NoOaUrl => json!({ "status": "no_oa_url" }),
+        // #458. Explicit, because the `_` arm at the bottom renders
+        // `{"status": "unknown"}` -- an agent would be told nothing about
+        // a PDF that exists, came from the publisher rather than an open
+        // host, and carries the terms of a TDM agreement.
+        PdfLegStatus::TdmFetched {
+            source,
+            original_block,
+        } => json!({
+            "status": "tdm_fetched",
+            "source": source,
+            "original_block": original_block,
+        }),
         PdfLegStatus::Blocked {
             code,
             message,

--- a/docs/DECISIONS/0044-tier-3-consulted-on-a-blocked-content-leg.md
+++ b/docs/DECISIONS/0044-tier-3-consulted-on-a-blocked-content-leg.md
@@ -1,0 +1,163 @@
+# 0044 - Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss
+
+- **Date:** 2026-08-25
+- **Status:** Accepted
+- **Supersedes:** -
+- **Amends:** [0041](0041-tdm-sources-scoped-to-publisher-prefixes.md) — its option-(c) rejection rests on a premise this decision removes
+- **Source:** #458 (the chain never ran), #445 (the trigger it should have had), #484 (the endpoint it should have asked)
+
+## Context
+
+Tier 3 was consulted from one place: `resolve_tdm_chain`, which records `NotNeeded`
+for every entry when Crossref answered.
+
+That is the correct trigger for Tier 2. Those sources are *resolution* fallbacks —
+they exist because Crossref sometimes has nothing, and once it has something they
+are genuinely not needed.
+
+Tier 3 was added for a different reason. #407 measured the corpus that motivated it
+as **metadata-resolvable but not fetchable**. The metadata was never the problem.
+So the two conditions were backwards:
+
+| | what it needs | what it got |
+|---|---|---|
+| Tier 2 | run when Crossref found nothing | run when Crossref found nothing |
+| Tier 3 | run when the **content leg** failed | run when Crossref found nothing |
+
+Crossref resolves publisher-registered DOIs readily, so for exactly the DOIs these
+sources exist to serve, the chain was skipped. A user could sign a publisher's TDM
+agreement, obtain a key, build with the feature, and get output byte-identical to
+having done none of it. That is #458, and it is the #442 defect class one level up
+from wiring: every documented gate satisfied, nothing changed.
+
+A second problem sat behind it. Even reached, all four Tier-3 sources were
+metadata-only by construction (`FetchResult.pdf_bytes` is always `None`), and a
+source that cannot return bytes cannot close a gap that is about bytes. #458 was
+explicit that the two halves land together or not at all: half 1 alone buys a
+duplicate metadata record, half 2 alone is unreachable code.
+
+## Decision
+
+**D1 — Tier 3 gains a second consultation point, triggered by a blocked content
+leg.** It is not moved. `resolve_tdm_chain` still answers "who can tell me about
+this DOI?" when Crossref could not; the new `try_tdm_content_fallback` answers "who
+will give me the bytes?" after the open routes are exhausted:
+
+```
+OA PDF chain
+  Blocked -> try_arxiv_preprint_fallback          (#325)
+    Blocked -> try_optional_source_oa_fallback    (#445)
+      Blocked -> try_tdm_content_fallback         (this ADR)
+```
+
+It is additive on the same terms as its two siblings: on any failure the **original**
+block survives. The publisher's refusal on the open route is what the user has to
+act on, and burying it under a second failure from the TDM endpoint would answer a
+question they did not ask.
+
+**D2 — `Source::fetch_content`, defaulted to `Ok(None)`.** The metadata-only
+contract used to be expressed by each impl setting `pdf_bytes: None` and saying so
+in a doc-comment. The orchestrator cannot read a doc-comment, so it could not
+distinguish a source with nothing to offer from one it had never asked. The default
+makes "metadata-only" a stated fact rather than an emergent one, and leaves the
+other sources untouched.
+
+Overriding implementations MUST use a PDF-validating fetch. `HttpClient` gains
+`fetch_pdf_with_headers` for this: publisher error pages and WAF holding responses
+are 200s with a body, and `fetch_bytes_with_headers` would write one to
+`<safekey>.pdf`.
+
+**D3 — APS first.** It is the only Tier-3 publisher whose full-text contract is
+both public and PDF-shaped:
+
+| publisher | what its API grants |
+|---|---|
+| **APS Harvest** | `GET /v2/journals/articles/{doi}` with `Accept: application/pdf`, one request, `X-API-Key`. Published example in the vendor's own documentation. |
+| Elsevier | **Non-OA PDF retrieval via the APIs is not permitted**; a non-OA article yields a first-page *preview*. What an entitlement grants for subscription content is full-text XML. |
+| IEEE | Contract not public — shipped against an inferred one ([ADR-0042](0042-tdm-ieee-inferred-contract.md)). |
+| Springer | Unverified. |
+
+Elsevier was the first choice and was rejected on that evidence. Storing a
+first-page preview as `<safekey>.pdf` and reporting it as fetched would be a worse
+version of the defect this ADR exists to close: not an absent feature, but wrong
+data presented as right. Elsevier remains a good candidate for a later XML-shaped
+instalment under [ADR-0032](0032-fulltext-html-extraction.md); it is the wrong
+publisher for closing a gap about bytes.
+
+**D4 — `PdfLegStatus::TdmFetched { source, original_block }`, distinct from
+`Fetched`.** The bytes did not come from an OA host, are not necessarily openly
+licensed, and were obtained under an agreement the user signed. Provenance reading
+`oa-publisher` would be wrong in all three respects. The stored source label is
+derived from the leg rather than from a two-valued "was this a preprint fallback"
+flag, which would have labelled the publisher's copy `oa-publisher` by default.
+
+**D5 — a TDM-retrieved artifact reports `license = "unknown"`.** The licence tracks
+the artifact that landed, not the work — that is already how the arXiv fallback
+behaves, overwriting the licence with the preprint's. Unpaywall's `cc-by` describes
+an OA location that was never reached; carrying it forward would put an
+open-licence claim on a file obtained under a signed agreement, by a route that
+licence does not describe. doiget does not guess licences, so the honest answer is
+`unknown`.
+
+**D6 — prefix scoping is kept, and is now a choice rather than a forced move.**
+
+ADR-0041 rejected option (c), routing by the publisher named in Crossref metadata,
+because *"it only works when Crossref answered — and the TDM chain runs precisely
+when Crossref did not, so the routing information would be missing exactly when it
+is needed."*
+
+**D1 removes that premise.** The new consultation point runs *after* Crossref
+answered, so (c) is available here in a way it was not in ADR-0041.
+
+It is still not taken. A constant is testable and does not make the publisher
+contacted depend on a prior network response — the second half of ADR-0041's
+reasoning, which survives intact. This is recorded explicitly so the next reader
+does not re-derive the rejection from an argument that no longer holds.
+
+The prefix is checked in the orchestrator **before** credentials, exactly as in
+ADR-0041, so `WrongPublisher` and `Disabled` stay distinguishable in the trace.
+`Source::can_serve` checks it too; the redundancy is the deliberate double gate, and
+only the orchestrator check produces the distinction.
+
+## Consequences
+
+**Positive.**
+
+- A TDM agreement now changes what the user gets. The three gates lead somewhere.
+- The trace distinguishes "consulted for metadata and not needed" from "consulted
+  for content and refused", which are different problems with different fixes.
+- `fetch_content` gives future publishers a defined place to land, and its default
+  states the metadata-only contract for the three that have not.
+
+**Negative, and the one that needs stating plainly.**
+
+**Disclosure scope is unchanged; frequency rises.** ADR-0041's argument was that a
+publisher is only ever told about DOIs it registered, so the disclosure is nil —
+resolving such a DOI goes through them anyway. That still holds exactly: prefix
+scoping is enforced on the new path too.
+
+What changes is how often. The old trigger was "Crossref missed", which for a
+publisher-registered DOI is rare. The new trigger is "the content leg was blocked
+for a DOI this publisher registered", which is common — it is the case the feature
+exists for. A user with `tdm-aps` enabled will contact APS about a meaningful
+fraction of the APS DOIs they fetch, rather than almost never.
+
+That is the cost of the feature working at all, and it is bounded by the same
+prefix rule. It is recorded here rather than left for someone to discover in a
+packet capture.
+
+**Also negative.** The one-shot content attempt has no retry and no caching, so a
+transient failure at the TDM endpoint costs the fetch. Consistent with the OA chain,
+which does the same, and preferable to retry loops against a credentialed endpoint.
+
+## Alternatives rejected
+
+- **Move the trigger instead of adding one.** Tier 3 would stop answering the
+  metadata question it currently answers when Crossref is down, for no gain.
+- **Half 1 alone** (reach Tier 3 on a blocked content leg, stay metadata-only). #458
+  rejected it in advance: it buys a duplicate metadata record for a DOI Crossref
+  already resolved.
+- **Elsevier first.** See D3. Rejected on the vendor's own documented policy, not on
+  preference.
+- **Infer a licence for the TDM copy** from the publisher record. That is a guess
+  about *this retrieval*, and the repo's standing rule is not to guess licences.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -60,6 +60,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0041 | Tier-3 TDM sources are scoped to their publisher's DOI prefixes | Accepted (0.8.9) | `fix/442-tier3-orchestrator-wiring` | #442 |
 | 0042 | `tdm-ieee` ships against an inferred contract, marked unverified | Accepted (0.8.9) | `feat/430-tdm-ieee` | #430 |
 | 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
+| 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
 
 ## Conventions
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -24,9 +24,38 @@
 | CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
-| APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
+| APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
+
+### 1.1 When Tier 3 is consulted (ADR-0044)
+
+Tier-3 sources are asked two different questions at two different points, and the
+distinction is what #458 was about:
+
+| point | question | trigger |
+|---|---|---|
+| metadata stage | "who can tell me about this DOI?" | Crossref found nothing |
+| **content stage** | "who will give me the bytes?" | the OA content leg was **blocked** |
+
+The second is the one a TDM agreement is obtained for. Until ADR-0044 it did not
+exist, so for a publisher-registered DOI — which Crossref resolves readily — an
+enabled TDM source was never consulted at all and enabling it changed nothing
+observable.
+
+**`tdm-aps` returns PDF bytes** at the content stage; APS documents single-request
+retrieval with `Accept: application/pdf`. The stored file reports
+`license = "unknown"`: it came from the publisher under your agreement, not from the
+OA location whose licence Unpaywall reported, and doiget does not guess licences.
+
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
+that is its own policy — retrieval of non-open-access article PDFs through the
+ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
+preview rather than the article.
+
+Disclosure is bounded exactly as before: a source is only ever told about DOIs its
+own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
+asked, not what it is told.
 
 ## 2. User responsibility
 

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -30,9 +30,38 @@ weight = 200
 | CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
-| APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
+| APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
+
+### 1.1 When Tier 3 is consulted (ADR-0044)
+
+Tier-3 sources are asked two different questions at two different points, and the
+distinction is what #458 was about:
+
+| point | question | trigger |
+|---|---|---|
+| metadata stage | "who can tell me about this DOI?" | Crossref found nothing |
+| **content stage** | "who will give me the bytes?" | the OA content leg was **blocked** |
+
+The second is the one a TDM agreement is obtained for. Until ADR-0044 it did not
+exist, so for a publisher-registered DOI — which Crossref resolves readily — an
+enabled TDM source was never consulted at all and enabling it changed nothing
+observable.
+
+**`tdm-aps` returns PDF bytes** at the content stage; APS documents single-request
+retrieval with `Accept: application/pdf`. The stored file reports
+`license = "unknown"`: it came from the publisher under your agreement, not from the
+OA location whose licence Unpaywall reported, and doiget does not guess licences.
+
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
+that is its own policy — retrieval of non-open-access article PDFs through the
+ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
+preview rather than the article.
+
+Disclosure is bounded exactly as before: a source is only ever told about DOIs its
+own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
+asked, not what it is told.
 
 ## 2. User responsibility
 


### PR DESCRIPTION
> [!WARNING]
> **Draft. Do not merge.** The mechanism is complete and the build is green across every feature set, but the reachability tests are not written. Merging a Tier-3 content path on a green build with nothing proving it is reached would be precisely the defect #442 / #454 / #458 are about, so this says so instead.

#458, both halves, for APS.

## Why a second consultation point rather than moving the first

`resolve_tdm_chain` fires on a Crossref **miss**. That is a question about metadata. The gap a TDM agreement is obtained to close is about **bytes**, and it opens after Crossref answered perfectly well and the content leg still failed — which is exactly the state #458 reproduced.

So Tier 3 gains a second entry point beside the one #445 already built:

```
OA PDF chain
  └─ Blocked ─→ try_arxiv_preprint_fallback        (#325)
                  └─ Blocked ─→ try_optional_source_oa_fallback   (#445)
                                  └─ Blocked ─→ try_tdm_content_fallback   ← new
```

Additive, like its two siblings: on any failure the **original** block survives. The publisher's refusal on the open route is what the user has to act on; burying it under a second failure from the TDM endpoint would answer a question they did not ask.

## What is here

| | |
|---|---|
| `Source::fetch_content` | defaulted to `Ok(None)`. The metadata-only contract used to be expressed by each impl setting `pdf_bytes: None` and saying so in a doc-comment — which the orchestrator could not read, so it could not tell a source with nothing to offer from one it had never asked. |
| `HttpClient::fetch_pdf_with_headers` | `fetch_inner(.., headers, true)`. The magic-byte check is **not** optional here: APS needs `X-API-Key` and `Accept: application/pdf` on the request that must be validated, and `fetch_bytes_with_headers` would happily write a publisher error page to `<safekey>.pdf`. |
| `TdmApsSource::fetch_content` | same endpoint; `Accept` selects the representation. Depends on #486 having corrected the path. |
| `PdfLegStatus::TdmFetched` | distinct from `Fetched`: the bytes did not come from an OA host, are not necessarily openly licensed, and were obtained under an agreement the user signed. |
| source label | derived from the leg instead of a two-valued `is_preprint_fallback` flag, which would have labelled the publisher's TDM copy `oa-publisher`. |

## The silent bit worth calling out

`PdfLegStatus` is `#[non_exhaustive]`, so both downstream matches carry `_` arms and **compiled unchanged**. The CLI would have printed the same success line as a plain OA fetch; the MCP envelope would have rendered `{"status": "unknown"}` for a PDF that exists, came from the publisher, and carries an agreement's terms. Both now name the variant explicitly.

That is worth remembering as a general hazard: `#[non_exhaustive]` converts "the compiler will tell me every place this matters" into "nowhere will tell me".

## Still to do before this leaves draft

- [ ] **Reachability e2e through `orchestrator::fetch_paper`** — the load-bearing part. Crossref answers, the OA leg is blocked, APS serves the PDF: assert it is stored, the leg is `TdmFetched`, and the label is `tdm-aps`.
- [ ] Wrong publisher → APS receives **zero** requests (`server.received_requests().is_empty()`), row is `WrongPublisher`.
- [ ] Gates closed → zero requests, row is `Disabled` carrying the enable hint.
- [ ] APS refuses → the original OA block survives verbatim.
- [ ] Non-PDF body → `NotAPdf`, nothing written to the store.
- [ ] Each of the above verified by mutation: severing the wiring must fail that test and only that test.
- [ ] **Licence.** An APS TDM PDF is not OA. The stored `license` must not inherit the OA-chain value — currently unaudited, and the most likely place for this PR to tell a lie.
- [ ] **New ADR.** ADR-0041 rejected routing by Crossref-declared publisher because *"the TDM chain runs precisely when Crossref did not"*. Moving the trigger to the content leg **invalidates that premise** — the new point runs after Crossref answered. Keeping prefix scoping is now a choice rather than a forced move, and must be recorded as one. The ADR also has to restate the privacy consequence: scope is unchanged, **frequency of consultation rises**.
- [ ] `SOURCES.md` (APS is no longer metadata-only), `CAPABILITY.md`, `CHANGELOG.md`, and `scripts/sync_docs_to_site.sh` for the `site/content/` projection.

## Verification so far

Green, and deliberately not sufficient:

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,citation`, and the full `oa-only,metadata,tdm-*` set.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features oa-only,citation`.
- `cargo test --workspace --all-targets --features oa-only,metadata,tdm-*` — 0 failures.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.5`.

Every one of those was green for #442, #454 and #458 too. That is the point of the checklist above.

Refs #458, #484, #445, #442, ADR-0041, ADR-0019, ADR-0032
