### PR TITLE
fix(diagnostics): keep the DenialContext on per-source attempt rows (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[diagnostics]** A per-source attempt row keeps its `DenialContext`, so
+  `remediation` is reachable from it. `classify_attempt` flattened everything that
+  was not a `NotFound` or an access refusal into `Failed { detail: "<prose>" }` —
+  so a redirect denial, oversized body or not-a-PDF on a *metadata-chain* source,
+  the richest and most actionable failures, became an untyped string on a surface
+  #459 advertises as machine-readable. The blocked PDF leg had carried the same
+  structure end to end since #459; the two mechanisms now agree (#470, ADR-0023,
+  ADR-0043).
+
 - **[orchestrator]** A Tier-3 TDM source is consulted when the **content leg** is
   blocked, not only when Crossref missed. It was asked the metadata question all
   along, and Crossref answers that question readily for a publisher's own DOIs — so
@@ -35,6 +44,11 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[errors]** `AttemptOutcome::Disabled` carries `&'static [&'static str]` and the
+  wire gains `required_env`. Tier 3 needs two variables and the code joined them
+  into `"A + B"`, which put a separator on the #459 wire that a consumer had to
+  split on — the thing the `detail()` / `wire()` split exists to avoid. `detail`
+  still carries the joined form, so nothing that reads it today breaks (#470).
 - **[errors]** `PdfLegStatus::TdmFetched` is distinct from `Fetched`, and the stored
   source label names the publisher rather than `oa-publisher`. A TDM copy did not
   come from an OA host and carries an agreement's terms.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.5"
+version = "0.8.10-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.5"
+version = "0.8.10-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.5"
+version = "0.8.10-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.5"
+version       = "0.8.10-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -864,7 +864,7 @@ mod tests {
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
             SourceAttempt::new("core", AttemptOutcome::NoRecord),

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -2059,7 +2059,7 @@ host = "*.uj.edu.pl"
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
         ];
@@ -2087,13 +2087,13 @@ host = "*.uj.edu.pl"
             SourceAttempt::new(
                 "core",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_CORE",
+                    env: &["DOIGET_ENABLE_CORE"],
                 },
             ),
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
         ];

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4086,6 +4086,58 @@ mod attempt_denial_tests {
         assert_eq!(outcome.wire(), "consulted_failed");
     }
 
+    /// The accessors are a narrowing, so the negative case matters as much
+    /// as the positive one: a caller that treated `denial()` as
+    /// "is this a failure" would mis-handle every `Failed` row.
+    #[test]
+    fn the_accessors_narrow_rather_than_generalise() {
+        let failed = AttemptOutcome::Failed {
+            detail: "connection reset".to_string(),
+        };
+        assert!(failed.denial().is_none());
+        assert!(failed.required_env().is_none());
+        assert!(failed.detail().is_some());
+
+        let disabled = AttemptOutcome::Disabled {
+            env: &["DOIGET_ENABLE_HAL"],
+        };
+        assert!(disabled.denial().is_none());
+        assert!(
+            disabled.detail().is_none(),
+            "`Disabled` carries structure; the joined string is built at the wire"
+        );
+        assert!(!disabled.was_consulted());
+        assert_eq!(
+            disabled.render(),
+            "not consulted (set DOIGET_ENABLE_HAL to enable)"
+        );
+    }
+
+    /// `attempted` is optional on a `DenialContext`, and the size cap has
+    /// no host to name. The prose has to hold either way.
+    #[test]
+    fn a_denial_without_an_attempted_host_still_renders() {
+        let outcome = AttemptOutcome::Denied {
+            denial: DenialContext {
+                reason: DenialReason::SizeCapExceeded,
+                source: Some("core".to_string()),
+                attempted: None,
+                expected: None,
+                hop_index: None,
+                cap: None,
+                actual: None,
+            },
+        };
+        assert_eq!(outcome.render(), "consulted: refused (SizeCapExceeded)");
+
+        // No config channel for a size cap, so no remediation key -- as
+        // opposed to an empty array, which would read as "we looked and
+        // there is nothing you can do" without saying so.
+        let v = attempts_to_value(&[SourceAttempt::new("core", outcome)]);
+        assert!(v[0].get("remediation").is_none(), "row: {}", v[0]);
+        assert!(v[0].get("denial_context").is_some(), "row: {}", v[0]);
+    }
+
     /// #470's second half. Tier 3 needs two variables, and joining them
     /// into `"A + B"` meant a consumer had to split on the separator --
     /// exactly what the `detail()` / `wire()` split exists to avoid.

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4088,7 +4088,7 @@ mod attempt_denial_tests {
 
     /// The accessors are a narrowing, so the negative case matters as much
     /// as the positive one: a caller that treated `denial()` as
-    /// "is this a failure" would mis-handle every `Failed` row.
+    /// "is this a failure" would mishandle every `Failed` row.
     #[test]
     fn the_accessors_narrow_rather_than_generalise() {
         let failed = AttemptOutcome::Failed {

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -25,6 +25,7 @@ use crate::sources::arxiv::ArxivSource;
 use crate::sources::crossref::CrossrefSource;
 use crate::sources::unpaywall::UnpaywallSource;
 use crate::store::{DoigetExtension, Metadata, Store};
+use crate::DenialContext;
 use crate::{ArxivId, CapabilityProfile, Doi, Ref, Safekey, MAX_BATCH_REFS, SCHEMA_VERSION};
 
 /// Outcome of a successful [`metadata_only`] call.
@@ -1725,7 +1726,7 @@ async fn try_tdm_content_fallback(
     struct ContentEntry<'a> {
         name: &'static str,
         /// What the user must set, rendered verbatim into the trace.
-        enable_hint: &'static str,
+        enable_hint: &'static [&'static str],
         /// DOI prefixes this publisher registered (ADR-0041).
         prefixes: &'static [&'static str],
         /// Human name, for the wrong-publisher message.
@@ -1779,7 +1780,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-aps")]
     chain.push(ContentEntry {
         name: "tdm-aps",
-        enable_hint: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+        enable_hint: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"],
         prefixes: crate::sources::tdm_aps::PUBLISHER_PREFIXES,
         publisher: "American Physical Society (APS)",
         src: &aps,
@@ -1787,7 +1788,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-elsevier")]
     chain.push(ContentEntry {
         name: "tdm-elsevier",
-        enable_hint: "DOIGET_KEY_ELSEVIER + DOIGET_AGREE_TDM_ELSEVIER",
+        enable_hint: &["DOIGET_KEY_ELSEVIER", "DOIGET_AGREE_TDM_ELSEVIER"],
         prefixes: crate::sources::tdm_elsevier::PUBLISHER_PREFIXES,
         publisher: "Elsevier BV",
         src: &elsevier,
@@ -1795,7 +1796,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-springer")]
     chain.push(ContentEntry {
         name: "tdm-springer",
-        enable_hint: "DOIGET_KEY_SPRINGER + DOIGET_AGREE_TDM_SPRINGER",
+        enable_hint: &["DOIGET_KEY_SPRINGER", "DOIGET_AGREE_TDM_SPRINGER"],
         prefixes: crate::sources::tdm_springer::PUBLISHER_PREFIXES,
         publisher: "Springer Nature",
         src: &springer,
@@ -1803,7 +1804,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-ieee")]
     chain.push(ContentEntry {
         name: "tdm-ieee",
-        enable_hint: "DOIGET_KEY_IEEE + DOIGET_AGREE_TDM_IEEE",
+        enable_hint: &["DOIGET_KEY_IEEE", "DOIGET_AGREE_TDM_IEEE"],
         prefixes: crate::sources::tdm_ieee::PUBLISHER_PREFIXES,
         publisher: "IEEE",
         src: &ieee,
@@ -3699,8 +3700,15 @@ pub enum AttemptOutcome {
     /// Runtime flag unset — **not consulted**. Carries the env var so the
     /// message can name the exact thing the user has to change.
     Disabled {
-        /// e.g. `"DOIGET_ENABLE_HAL"`.
-        env: &'static str,
+        /// Every variable that has to be set, e.g.
+        /// `["DOIGET_ENABLE_HAL"]` or
+        /// `["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"]`.
+        ///
+        /// A list rather than a string because Tier 3 needs two, and
+        /// joining them into `"A + B"` put a separator on the #459 wire
+        /// that a consumer would have had to split on — which is the
+        /// thing the `detail()` / `wire()` split exists to avoid (#470).
+        env: &'static [&'static str],
     },
     /// This source cannot serve this kind of ref at all (e.g. an arXiv id
     /// handed to a DOI-only resolver). Not a misconfiguration.
@@ -3727,6 +3735,20 @@ pub enum AttemptOutcome {
         /// Source-specific detail, e.g. the access-rights code observed.
         detail: String,
     },
+    /// **Consulted**, and refused by a policy control with a structured
+    /// reason: a redirect off the allowlist, an insecure redirect, an
+    /// oversized body, a not-a-PDF (ADR-0023).
+    ///
+    /// Distinct from [`Self::Failed`] because the [`DenialContext`] is what
+    /// [`crate::remediation::for_denial`] consumes. `PdfLegStatus::Blocked`
+    /// kept it end to end and the MCP layer turned it into a remediation;
+    /// per-source rows flattened the same information to prose, so the
+    /// richest and most actionable case degraded to text on a wire that
+    /// #459 advertises as machine-readable (#470).
+    Denied {
+        /// The structured denial, verbatim.
+        denial: DenialContext,
+    },
     /// **Consulted.** The request itself failed (transport, auth, schema).
     Failed {
         /// Rendered error.
@@ -3747,7 +3769,11 @@ impl AttemptOutcome {
     pub fn was_consulted(&self) -> bool {
         matches!(
             self,
-            Self::NoRecord | Self::NotOpenAccess { .. } | Self::Failed { .. } | Self::Resolved
+            Self::NoRecord
+                | Self::NotOpenAccess { .. }
+                | Self::Denied { .. }
+                | Self::Failed { .. }
+                | Self::Resolved
         )
     }
 
@@ -3770,6 +3796,7 @@ impl AttemptOutcome {
             Self::NotNeeded => "not_consulted_not_needed",
             Self::NoRecord => "consulted_no_record",
             Self::NotOpenAccess { .. } => "consulted_not_open_access",
+            Self::Denied { .. } => "consulted_denied",
             Self::Failed { .. } => "consulted_failed",
             Self::Resolved => "consulted_resolved",
         }
@@ -3783,10 +3810,34 @@ impl AttemptOutcome {
     #[must_use]
     pub fn detail(&self) -> Option<&str> {
         match self {
-            Self::Disabled { env } => Some(env),
+            // `Disabled` and `Denied` carry structure, not a string.
+            // See `required_env` and `denial`; `attempts_to_value` renders
+            // both, and still emits a joined `detail` for each so the #459
+            // wire stays backwards compatible.
+            Self::Disabled { .. } | Self::Denied { .. } => None,
             Self::WrongPublisher { detail }
             | Self::NotOpenAccess { detail }
             | Self::Failed { detail } => Some(detail),
+            _ => None,
+        }
+    }
+
+    /// The variables a `Disabled` row needs set, in the order the user
+    /// should set them. `None` for every other outcome.
+    #[must_use]
+    pub fn required_env(&self) -> Option<&'static [&'static str]> {
+        match self {
+            Self::Disabled { env } => Some(env),
+            _ => None,
+        }
+    }
+
+    /// The structured denial behind a `Denied` row, which is what
+    /// [`crate::remediation::for_denial`] takes. `None` otherwise.
+    #[must_use]
+    pub fn denial(&self) -> Option<&DenialContext> {
+        match self {
+            Self::Denied { denial } => Some(denial),
             _ => None,
         }
     }
@@ -3796,7 +3847,9 @@ impl AttemptOutcome {
     #[must_use]
     pub fn render(&self) -> String {
         match self {
-            Self::Disabled { env } => format!("not consulted (set {env} to enable)"),
+            Self::Disabled { env } => {
+                format!("not consulted (set {} to enable)", env.join(" + "))
+            }
             Self::NotApplicable => "not consulted (cannot serve this ref kind)".to_string(),
             Self::WrongPublisher { detail } => format!("not consulted ({detail})"),
             Self::NotNeeded => "not consulted (an earlier source answered)".to_string(),
@@ -3804,6 +3857,13 @@ impl AttemptOutcome {
             Self::NotOpenAccess { detail } => {
                 format!("consulted: found, not open access ({detail})")
             }
+            // `{:?}` on the reason: `render` is explicitly prose (`wire`
+            // is the stable token), and the attempted host is the part a
+            // human acts on.
+            Self::Denied { denial } => match &denial.attempted {
+                Some(a) => format!("consulted: refused ({:?}, {a})", denial.reason),
+                None => format!("consulted: refused ({:?})", denial.reason),
+            },
             Self::Failed { detail } => format!("consulted: failed ({detail})"),
             Self::Resolved => "consulted: resolved".to_string(),
         }
@@ -3851,6 +3911,21 @@ pub fn attempts_to_value(attempts: &[SourceAttempt]) -> serde_json::Value {
                 o.insert("outcome".into(), serde_json::json!(a.outcome.wire()));
                 if let Some(d) = a.outcome.detail() {
                     o.insert("detail".into(), serde_json::json!(d));
+                }
+                if let Some(env) = a.outcome.required_env() {
+                    // `detail` stays a joined string so a #459-era consumer
+                    // reads the same field it always did; `required_env` is
+                    // the form that does not need splitting.
+                    o.insert("detail".into(), serde_json::json!(env.join(" + ")));
+                    o.insert("required_env".into(), serde_json::json!(env));
+                }
+                if let Some(dc) = a.outcome.denial() {
+                    o.insert("detail".into(), serde_json::json!(a.outcome.render()));
+                    o.insert("denial_context".into(), serde_json::json!(dc));
+                    let rem = crate::remediation::for_denial(dc);
+                    if !rem.is_empty() {
+                        o.insert("remediation".into(), serde_json::json!(rem));
+                    }
                 }
                 o.insert(
                     "consulted".into(),
@@ -3908,9 +3983,134 @@ fn classify_attempt(e: &FetchError) -> AttemptOutcome {
                 detail: hint.clone(),
             }
         }
-        other => AttemptOutcome::Failed {
-            detail: other.to_string(),
+        // A policy refusal before the untyped fallback (#470). The
+        // conversion already exists and yields exactly the reason /
+        // attempted / expected / hop_index that `remediation::for_denial`
+        // consumes; `classify_attempt` used to walk straight past it and
+        // stringify.
+        //
+        // `CapabilityNotGranted` is deliberately excluded. It is produced
+        // by a source's defensive gate BEFORE any request goes out, and
+        // `Denied` reports `was_consulted() == true` — which is the exact
+        // predicate the #442 reachability tests assert on. Routing it here
+        // would make a source that was never contacted claim it was. The
+        // orchestrator already reports that state as `Disabled`, which
+        // also names the variables to set.
+        other => match Option::<DenialContext>::from(other) {
+            Some(denial) if denial.reason != crate::DenialReason::CapabilityNotGranted => {
+                AttemptOutcome::Denied { denial }
+            }
+            _ => AttemptOutcome::Failed {
+                detail: other.to_string(),
+            },
         },
+    }
+}
+
+#[cfg(all(test, feature = "metadata"))]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod attempt_denial_tests {
+    use super::*;
+
+    use crate::http::HttpError;
+    use crate::DenialReason;
+
+    fn redirect_denial() -> FetchError {
+        FetchError::Http(HttpError::RedirectDenied {
+            source_key: "hal".to_string(),
+            host: "cdn.example.org".to_string(),
+            expected_hosts: vec!["hal.science".to_string()],
+        })
+    }
+
+    /// #470. A redirect denial on a metadata-chain source used to flatten
+    /// to `Failed { detail: "..." }` -- an untyped string on a wire #459
+    /// advertises as machine-readable, for the one case that is richest and
+    /// most actionable.
+    #[test]
+    fn a_policy_refusal_keeps_its_denial_context() {
+        let outcome = classify_attempt(&redirect_denial());
+        let denial = outcome
+            .denial()
+            .expect("a redirect denial must survive classification");
+        assert_eq!(denial.reason, DenialReason::RedirectNotInAllowlist);
+        assert_eq!(denial.attempted.as_deref(), Some("cdn.example.org"));
+        assert_eq!(outcome.wire(), "consulted_denied");
+        assert!(
+            outcome.was_consulted(),
+            "a refusal means a request went out"
+        );
+    }
+
+    /// The point of keeping it: `remediation::for_denial` becomes reachable
+    /// from a per-source row, so the row can tell the user what to change.
+    /// `PdfLegStatus::Blocked` could already do this; the rows could not.
+    #[test]
+    fn a_denied_row_carries_a_remediation_on_the_wire() {
+        let attempts = vec![SourceAttempt::new(
+            "hal",
+            classify_attempt(&redirect_denial()),
+        )];
+        let v = attempts_to_value(&attempts);
+        let row = &v[0];
+
+        assert_eq!(row["outcome"], serde_json::json!("consulted_denied"));
+        assert_eq!(
+            row["denial_context"]["reason"],
+            serde_json::json!("redirect_not_in_allowlist"),
+            "row: {row}"
+        );
+        let rem = row["remediation"]
+            .as_array()
+            .unwrap_or_else(|| panic!("a redirect denial has a config channel; row: {row}"));
+        assert!(!rem.is_empty());
+        assert!(
+            row["detail"].is_string(),
+            "`detail` must stay populated for a #459-era consumer; row: {row}"
+        );
+    }
+
+    /// `CapabilityNotGranted` is produced BEFORE any request goes out, so
+    /// routing it to `Denied` would make a source that was never contacted
+    /// report `was_consulted() == true` -- the predicate the #442
+    /// reachability tests rest on.
+    #[test]
+    fn an_ungranted_capability_is_not_reported_as_consulted_and_denied() {
+        let outcome = classify_attempt(&FetchError::NotEligible {
+            source_key: "tdm-aps".into(),
+        });
+        assert!(
+            outcome.denial().is_none(),
+            "got {outcome:?}: this never reached the network"
+        );
+        assert_eq!(outcome.wire(), "consulted_failed");
+    }
+
+    /// #470's second half. Tier 3 needs two variables, and joining them
+    /// into `"A + B"` meant a consumer had to split on the separator --
+    /// exactly what the `detail()` / `wire()` split exists to avoid.
+    #[test]
+    fn a_disabled_row_lists_its_variables_instead_of_joining_them() {
+        let attempts = vec![SourceAttempt::new(
+            "tdm-aps",
+            AttemptOutcome::Disabled {
+                env: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"],
+            },
+        )];
+        let v = attempts_to_value(&attempts);
+        let row = &v[0];
+
+        assert_eq!(
+            row["required_env"],
+            serde_json::json!(["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"]),
+            "row: {row}"
+        );
+        // Unchanged for anyone already reading it.
+        assert_eq!(
+            row["detail"],
+            serde_json::json!("DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS"),
+            "row: {row}"
+        );
     }
 }
 
@@ -3981,12 +4181,20 @@ async fn resolve_optional_chain(
     // that borrows the source, while a `SourceAttempt` holds a `'static`
     // key so the trace can outlive the chain. A test asserts the two agree,
     // so this cannot drift into a lie.
-    let chain: Vec<(&'static str, &'static str, &dyn crate::source::Source)> = vec![
-        ("datacite", "DOIGET_ENABLE_DATACITE", &datacite),
-        ("europe-pmc", "DOIGET_ENABLE_EUROPE_PMC", &epmc),
-        ("openaire", "DOIGET_ENABLE_OPENAIRE", &openaire),
-        ("hal", "DOIGET_ENABLE_HAL", &hal),
-        ("core", "DOIGET_ENABLE_CORE", &core),
+    // `&'static [&'static str]` rather than a single var: `AttemptOutcome::
+    // Disabled` now carries the whole list, because Tier 3 needs two and a
+    // joined string put a separator on the #459 wire (#470). Tier 2 needs
+    // one, which is a one-element list.
+    let chain: Vec<(
+        &'static str,
+        &'static [&'static str],
+        &dyn crate::source::Source,
+    )> = vec![
+        ("datacite", &["DOIGET_ENABLE_DATACITE"], &datacite),
+        ("europe-pmc", &["DOIGET_ENABLE_EUROPE_PMC"], &epmc),
+        ("openaire", &["DOIGET_ENABLE_OPENAIRE"], &openaire),
+        ("hal", &["DOIGET_ENABLE_HAL"], &hal),
+        ("core", &["DOIGET_ENABLE_CORE"], &core),
     ];
 
     let mut resolved: Option<(&'static str, Value)> = None;
@@ -4075,7 +4283,7 @@ async fn resolve_tdm_chain(
     struct Entry<'a> {
         name: &'static str,
         /// What the user must set, rendered verbatim into the trace.
-        enable_hint: &'static str,
+        enable_hint: &'static [&'static str],
         /// DOI prefixes this publisher registered.
         prefixes: &'static [&'static str],
         /// Human name, for the wrong-publisher message.
@@ -4115,7 +4323,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-aps")]
     chain.push(Entry {
         name: "tdm-aps",
-        enable_hint: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+        enable_hint: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"],
         prefixes: crate::sources::tdm_aps::PUBLISHER_PREFIXES,
         publisher: "American Physical Society (APS)",
         src: &aps,
@@ -4123,7 +4331,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-elsevier")]
     chain.push(Entry {
         name: "tdm-elsevier",
-        enable_hint: "DOIGET_KEY_ELSEVIER + DOIGET_AGREE_TDM_ELSEVIER",
+        enable_hint: &["DOIGET_KEY_ELSEVIER", "DOIGET_AGREE_TDM_ELSEVIER"],
         prefixes: crate::sources::tdm_elsevier::PUBLISHER_PREFIXES,
         publisher: "Elsevier BV",
         src: &elsevier,
@@ -4131,7 +4339,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-springer")]
     chain.push(Entry {
         name: "tdm-springer",
-        enable_hint: "DOIGET_KEY_SPRINGER + DOIGET_AGREE_TDM_SPRINGER",
+        enable_hint: &["DOIGET_KEY_SPRINGER", "DOIGET_AGREE_TDM_SPRINGER"],
         prefixes: crate::sources::tdm_springer::PUBLISHER_PREFIXES,
         publisher: "Springer Nature",
         src: &springer,
@@ -4139,7 +4347,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-ieee")]
     chain.push(Entry {
         name: "tdm-ieee",
-        enable_hint: "DOIGET_KEY_IEEE + DOIGET_AGREE_TDM_IEEE",
+        enable_hint: &["DOIGET_KEY_IEEE", "DOIGET_AGREE_TDM_IEEE"],
         prefixes: crate::sources::tdm_ieee::PUBLISHER_PREFIXES,
         publisher: "IEEE",
         src: &ieee,
@@ -4434,7 +4642,7 @@ mod chain_tests {
         assert_eq!(
             outcome(&attempts, "hal"),
             &AttemptOutcome::Disabled {
-                env: "DOIGET_ENABLE_HAL"
+                env: &["DOIGET_ENABLE_HAL"]
             },
             "a disabled source must name the variable that enables it"
         );
@@ -4951,7 +5159,7 @@ mod tdm_chain_tests {
         assert_eq!(
             o,
             &AttemptOutcome::Disabled {
-                env: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS"
+                env: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"]
             },
             "a closed Tier-3 gate must name the key AND the agreement"
         );

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4007,7 +4007,21 @@ fn classify_attempt(e: &FetchError) -> AttemptOutcome {
     }
 }
 
-#[cfg(all(test, feature = "metadata"))]
+// Gated exactly as `classify_attempt` is, not more narrowly. Gating these
+// on `metadata` alone left the new code compiled but untested under the
+// coverage job's feature set (`tdm-*` without `metadata`) -- a smaller copy
+// of the same "is this actually exercised?" question #442/#458 are about,
+// and the reason `codecov/patch` failed on this PR.
+#[cfg(all(
+    test,
+    any(
+        feature = "metadata",
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
+    )
+))]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod attempt_denial_tests {
     use super::*;

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4595,7 +4595,7 @@ mod tests {
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
             SourceAttempt::new("core", AttemptOutcome::NoRecord),

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -132,17 +132,44 @@ The resolution trace introduced in #413/#438, previously CLI text only.
 
 ```jsonc
 "attempts": [
-  { "source": "hal",  "outcome": "not_consulted_disabled", "detail": "DOIGET_ENABLE_HAL", "consulted": false },
-  { "source": "core", "outcome": "consulted_no_record",                                   "consulted": true  }
+  { "source": "hal", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_ENABLE_HAL", "required_env": ["DOIGET_ENABLE_HAL"], "consulted": false },
+  { "source": "tdm-aps", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+    "required_env": ["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"], "consulted": false },
+  { "source": "core", "outcome": "consulted_denied",
+    "detail": "consulted: refused (RedirectNotInAllowlist, cdn.example.org)",
+    "denial_context": { "reason": "redirect_not_in_allowlist", "attempted": "cdn.example.org",
+                        "expected": ["core.ac.uk"], "hop_index": 1 },
+    "remediation": [ /* … */ ], "consulted": true }
 ]
 ```
 
 `outcome` is a **closed** enum:
 `not_consulted_disabled`, `not_consulted_not_applicable`,
 `not_consulted_wrong_publisher`, `not_consulted_not_needed`, `consulted_no_record`,
-`consulted_not_open_access`, `consulted_failed`, `consulted_resolved`.
+`consulted_not_open_access`, `consulted_denied`, `consulted_failed`,
+`consulted_resolved`.
 
 `detail` is present only for the variants carrying one, and is opaque text.
+
+**`required_env`** (#470) accompanies `not_consulted_disabled`: the variables to set,
+as a list. `detail` carries the same set joined with `" + "` and is retained for
+compatibility — do not parse it. Tier-3 sources need two variables and Tier-2 one,
+which is why the joined form was a separator a consumer had to split on.
+
+**`denial_context`** and **`remediation`** (#470) accompany `consulted_denied`, and
+carry the same ADR-0023 structure the blocked PDF leg already carried. Before this,
+a redirect denial, an oversized body or a not-a-PDF on a *metadata-chain* source —
+the richest and most actionable failures — flattened into `consulted_failed` with an
+opaque string, on a surface documented as machine-readable. `remediation` is omitted
+when the denial reason has no configuration channel (`InsecureScheme` has none:
+the fix for an `http://` redirect is not to trust the host).
+
+`consulted_denied` is a *refusal by a policy control*, distinct from
+`consulted_failed` (transport, auth, schema). `CapabilityNotGranted` is **not** a
+`consulted_denied`: it is produced before any request goes out, so reporting it as
+consulted would misstate reach.
 `consulted` is redundant with `outcome` and present anyway: it is the single question
 every consumer has — *did anyone else look?* — and requiring them to memorise which of
 eight tokens implies it invites the confusion the trace exists to end.

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -138,17 +138,44 @@ The resolution trace introduced in #413/#438, previously CLI text only.
 
 ```jsonc
 "attempts": [
-  { "source": "hal",  "outcome": "not_consulted_disabled", "detail": "DOIGET_ENABLE_HAL", "consulted": false },
-  { "source": "core", "outcome": "consulted_no_record",                                   "consulted": true  }
+  { "source": "hal", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_ENABLE_HAL", "required_env": ["DOIGET_ENABLE_HAL"], "consulted": false },
+  { "source": "tdm-aps", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+    "required_env": ["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"], "consulted": false },
+  { "source": "core", "outcome": "consulted_denied",
+    "detail": "consulted: refused (RedirectNotInAllowlist, cdn.example.org)",
+    "denial_context": { "reason": "redirect_not_in_allowlist", "attempted": "cdn.example.org",
+                        "expected": ["core.ac.uk"], "hop_index": 1 },
+    "remediation": [ /* … */ ], "consulted": true }
 ]
 ```
 
 `outcome` is a **closed** enum:
 `not_consulted_disabled`, `not_consulted_not_applicable`,
 `not_consulted_wrong_publisher`, `not_consulted_not_needed`, `consulted_no_record`,
-`consulted_not_open_access`, `consulted_failed`, `consulted_resolved`.
+`consulted_not_open_access`, `consulted_denied`, `consulted_failed`,
+`consulted_resolved`.
 
 `detail` is present only for the variants carrying one, and is opaque text.
+
+**`required_env`** (#470) accompanies `not_consulted_disabled`: the variables to set,
+as a list. `detail` carries the same set joined with `" + "` and is retained for
+compatibility — do not parse it. Tier-3 sources need two variables and Tier-2 one,
+which is why the joined form was a separator a consumer had to split on.
+
+**`denial_context`** and **`remediation`** (#470) accompany `consulted_denied`, and
+carry the same ADR-0023 structure the blocked PDF leg already carried. Before this,
+a redirect denial, an oversized body or a not-a-PDF on a *metadata-chain* source —
+the richest and most actionable failures — flattened into `consulted_failed` with an
+opaque string, on a surface documented as machine-readable. `remediation` is omitted
+when the denial reason has no configuration channel (`InsecureScheme` has none:
+the fix for an `http://` redirect is not to trust the host).
+
+`consulted_denied` is a *refusal by a policy control*, distinct from
+`consulted_failed` (transport, auth, schema). `CapabilityNotGranted` is **not** a
+`consulted_denied`: it is produced before any request goes out, so reporting it as
+consulted would misstate reach.
 `consulted` is redundant with `outcome` and present anyway: it is the single question
 every consumer has — *did anyone else look?* — and requiring them to memorise which of
 eight tokens implies it invites the confusion the trace exists to end.


### PR DESCRIPTION
Closes #470. Both halves.

## The inconsistency

`PdfLegStatus::Blocked` carried the structured denial end to end and the MCP layer turned it into a remediation. Per-source rows could not, because `classify_attempt` walked past the conversion that already existed one call away:

```rust
other => AttemptOutcome::Failed { detail: other.to_string() }
```

So a redirect denial, oversized body, not-a-PDF or insecure redirect on a **metadata-chain** source — HAL, DataCite, CORE, any `tdm-*` — became opaque text on a surface #459 advertises as machine-readable, for the richest and most actionable case it has.

Now `AttemptOutcome::Denied { denial }`, with `attempts_to_value` emitting `denial_context` and `remediation` beside the existing `detail`.

### One thing the issue did not call out

**`CapabilityNotGranted` is excluded from the mapping.** It is produced by a source's defensive gate *before any request goes out*, and `Denied` reports `was_consulted() == true` — the exact predicate the #442 reachability tests rest on. Routing it through would have made a source that was never contacted claim it was, which is the thing this whole cluster of issues exists to prevent. It stays `Failed`; the orchestrator already reports that state as `Disabled`, which also names the variables to set.

## `Disabled` carries a list

`Disabled { env: &'static str }` documented one variable. Tier 3 needs two and the code joined them into `"DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS"` — fine while it was only rendered into a sentence, not fine once #459 put `detail` on a wire, because a consumer then had to split on `" + "`.

Now `&'static [&'static str]`, surfaced as `required_env`:

```jsonc
{ "source": "tdm-aps", "outcome": "not_consulted_disabled",
  "detail": "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
  "required_env": ["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"], "consulted": false }
```

`detail` keeps the joined form, so nothing reading it today breaks.

## Verified by mutation

| severed | fails |
|---|---|
| the `Denied` arm in `classify_attempt` | both denial tests |
| the `remediation` insert | the wire test, **only** |
| the `CapabilityNotGranted` exclusion | the reach test, **only** |
| the `required_env` insert | the disabled test, **only** |

## Docs

`docs/ERRORS.md` §3.3 is NORMATIVE, so `consulted_denied` joins the closed `outcome` enum there, with a worked example of the new keys and an explicit note that `CapabilityNotGranted` is not one of them. `site/content/developer/errors.md` regenerated via `scripts/sync_docs_to_site.sh`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,citation`, and the full `oa-only,metadata,tdm-*` set.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features oa-only,citation`.
- `cargo test --workspace --all-targets` on both `oa-only` and the full `tdm-*` set.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.6`.

Refs #459, #468, ADR-0023, ADR-0043
