### PR TITLE
fix(cli): three places the human is told less than the machine (#476, #478, #479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[cli]** `config path` and `config show` print when stdout is not a terminal.
+  They were absent from the ADR-0017 artifact classification, so an implicit
+  non-TTY Quiet silenced them: `doiget config path` from a pipe produced zero
+  bytes and exited 0, which made the documented way to locate your config file
+  answer a script, a CI step or an agent with silence *and* success. Explicit
+  Quiet still silences them (#476, ADR-0017 Amendment 1/2).
+- **[cli]** The human denial help names the one trust flag that covers the
+  attempted host, and says so when neither does. It listed both unconditionally
+  while `remediation::for_denial` — the MCP and `batch --json` path — already
+  computed which one applied, so the agent got a better diagnostic than the
+  human. `*.strath.ac.uk` is covered by `trust_academic_repos` only; following
+  `trust_oa_registries` there cost a round (#478).
+- **[cli]** `widening_suggestions` describes `*.parent` as "the whole domain".
+  It said "the whole publisher", which is wrong for the case that fires most
+  often: every host in the built-in academic list is a university (#478).
+
 - **[diagnostics]** A per-source attempt row keeps its `DenialContext`, so
   `remediation` is reachable from it. `classify_attempt` flattened everything that
   was not a `NotFound` or an access refusal into `Failed { detail: "<prose>" }` —
@@ -44,6 +60,11 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[docs]** `batch --json` record order is stated in `docs/ERRORS.md` §3.2a and
+  in `batch --help`: records are emitted as refs complete, not in input order, and
+  `ref` is the key. Nothing said so, and zipping stdout against the input file
+  positionally is the obvious thing to write — it works until one fetch is slow,
+  then attaches a result to the wrong DOI with no error anywhere (#479).
 - **[errors]** `AttemptOutcome::Disabled` carries `&'static [&'static str]` and the
   wire gains `required_env`. Tier 3 needs two variables and the code joined them
   into `"A + B"`, which put a separator on the #459 wire that a consumer had to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.6"
+version = "0.8.10-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.6"
+version = "0.8.10-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.6"
+version = "0.8.10-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.6"
+version       = "0.8.10-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.6" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.6" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.6" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -142,12 +142,26 @@ pub async fn run(
     mode: super::output::OutputMode,
     network: bool,
     force: bool,
+    quiet_was_explicit: bool,
 ) -> Result<()> {
-    // `mode` honors ADR-0017: `Quiet` suppresses the TOML dump (`show`)
-    // and the path println! (`path`); `doctor` is unaffected because its
-    // per-check output is on stderr and only the failure/success exit
-    // code is the user-visible signal (#203). Json body for `show` is
-    // tracked in #204.
+    // `mode` honors ADR-0017, per ACTION rather than per command -- like
+    // `audit-log`, `config` is not uniformly one class:
+    //
+    //   * `path` / `show` are ARTIFACT. Their stdout IS the thing the
+    //     caller asked for, so only an EXPLICIT Quiet silences them. The
+    //     implicit non-TTY Quiet must not, which is #476: `doiget config
+    //     path` from a pipe printed zero bytes and exited 0, so the
+    //     documented way to find your config file (`docs/CONFIG.md` SS4,
+    //     SS12) answered a script, a CI step or an agent with silence AND
+    //     success. Third time the ADR-0017 classification was found
+    //     incomplete, after #219/#220 and #301.
+    //   * `init` is a STATUS report about a write that happened. Quiet of
+    //     either kind silences it; the exit code carries the outcome.
+    //   * `doctor` is unaffected either way -- its per-check output is on
+    //     stderr and the exit code is the signal (#203).
+    //
+    // Json body for `show` is tracked in #204.
+    let artifact_quiet = mode == super::output::OutputMode::Quiet && quiet_was_explicit;
     let cfg = ResolvedConfig::from_env()?;
     if network && action != "doctor" {
         eprintln_err("error: --network applies to `config doctor` only");
@@ -158,8 +172,14 @@ pub async fn run(
         return Err(anyhow::Error::new(CliExit(2)));
     }
     match action.as_str() {
+        "show" if artifact_quiet => {}
         "show" => match mode {
-            super::output::OutputMode::Quiet => {}
+            super::output::OutputMode::Quiet => {
+                // Implicit (non-TTY) Quiet: `show` is artifact-class, so
+                // render rather than suppress (#476).
+                let s = toml::to_string_pretty(&cfg)?;
+                print!("{s}");
+            }
             super::output::OutputMode::Json => {
                 // #204: `ResolvedConfig` is `Serialize` (already used for
                 // the TOML branch).
@@ -173,8 +193,12 @@ pub async fn run(
             }
         },
         "init" => init_config(&cfg, force, mode)?,
+        "path" if artifact_quiet => {}
         "path" => match mode {
-            super::output::OutputMode::Quiet => {}
+            super::output::OutputMode::Quiet => {
+                // Implicit (non-TTY) Quiet: naming the file IS the job.
+                println!("{}", cfg.config_path);
+            }
             super::output::OutputMode::Json => {
                 // Minimal JSON object so callers can parse the path
                 // uniformly; no trailing-newline ambiguity vs the raw
@@ -1003,6 +1027,7 @@ mod tests {
             crate::commands::output::OutputMode::Human,
             false,
             false,
+            false,
         )
         .await
         .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
@@ -1025,6 +1050,7 @@ mod tests {
         run(
             "doctor".into(),
             crate::commands::output::OutputMode::Human,
+            false,
             false,
             false,
         )
@@ -1080,6 +1106,7 @@ mod tests {
             crate::commands::output::OutputMode::Human,
             false,
             false,
+            false,
         )
         .await
         .expect_err("doctor should fail when user-extension config is malformed");
@@ -1119,6 +1146,7 @@ mod tests {
         let err = run(
             "bogus".into(),
             crate::commands::output::OutputMode::Human,
+            false,
             false,
             false,
         )

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1100,14 +1100,50 @@ fn denial_note_lines(dc: &DenialContext, config_path: Option<&camino::Utf8Path>)
     out.push(format!(
         "  = help: that host is not on the allowlist yet; widen it in {where_}"
     ));
-    out.push(
-        "          [network] trust_academic_repos = true   # 15 curated academic suffixes"
-            .to_string(),
-    );
-    out.push(
-        "          [network] trust_oa_registries  = true   # DOAJ, SciELO, Zenodo, OSF, HAL"
-            .to_string(),
-    );
+    // #478: name the ONE flag that covers this host, not both.
+    //
+    // `trust_flag_for_host` already computes it, and
+    // `remediation::for_denial` calls it -- so MCP and `batch --json`
+    // consumers were getting the precise answer while the human was shown
+    // two flags with nothing to choose between them, and following the
+    // wrong one cost a round. The human has less context than the agent,
+    // not more.
+    //
+    // `None` means neither flag covers the host (a genuine publisher). The
+    // machine path offers no flag there; so does this one now, rather than
+    // suggesting two settings that cannot possibly help.
+    //
+    // Three cases, and "we did not compute it" is not the same answer as
+    // "we computed it and neither applies":
+    match dc.attempted.as_deref() {
+        // Known host, one flag covers it. Name that one.
+        Some(h) => match doiget_core::remediation::trust_flag_for_host(h) {
+            Some((flag, pattern, note)) => out.push(format!(
+                "          [network] {flag} = true   # covers {pattern} ({note})"
+            )),
+            // Known host, neither flag covers it -- a genuine publisher.
+            // The machine path offers no flag here (there is a test for
+            // it: `a_publisher_host_offers_no_trust_flag`), so neither
+            // does this one. Suggesting two settings that cannot help is
+            // worse than saying so.
+            None => out.push(
+                "          # neither trust_academic_repos nor trust_oa_registries covers this host"
+                    .to_string(),
+            ),
+        },
+        // No host to test. Both flags stay listed, because the reason for
+        // narrowing is absent rather than resolved.
+        None => {
+            out.push(
+                "          [network] trust_academic_repos = true   # 15 curated academic suffixes"
+                    .to_string(),
+            );
+            out.push(
+                "          [network] trust_oa_registries  = true   # DOAJ, SciELO, Zenodo, OSF, HAL"
+                    .to_string(),
+            );
+        }
+    }
     if dc.attempted.is_some() {
         for (pattern, why) in doiget_core::remediation::widening_suggestions(attempted) {
             out.push(format!(
@@ -1807,6 +1843,72 @@ host = "*.uj.edu.pl"
         assert!(
             joined.contains("docs/CONFIG.md §3.1"),
             "the schema section must be named; got:\n{joined}"
+        );
+    }
+
+    /// #478. Only ONE of the two flags covers any given host, and
+    /// `remediation::trust_flag_for_host` already computes which -- so the
+    /// MCP and `batch --json` consumers got the precise answer while the
+    /// human was shown both with nothing to choose between them.
+    #[test]
+    fn the_help_names_only_the_trust_flag_that_covers_the_host() {
+        let mut dc = denial(DenialReason::RedirectNotInAllowlist);
+        dc.attempted = Some("strathprints.strath.ac.uk".to_string());
+        let joined = denial_note_lines(&dc, None).join(
+            "
+",
+        );
+
+        assert!(
+            joined.contains("trust_academic_repos = true"),
+            "an *.ac.uk host is covered by the academic list; got:
+{joined}"
+        );
+        assert!(
+            !joined.contains("trust_oa_registries"),
+            "trust_oa_registries does nothing for this host and must not be offered; got:
+{joined}"
+        );
+        assert!(
+            joined.contains("*.ac.uk"),
+            "naming the pattern is what makes the suggestion checkable; got:
+{joined}"
+        );
+    }
+
+    /// And when neither covers it -- a genuine publisher host -- the human
+    /// is told so rather than handed two settings that cannot help. The
+    /// machine path already behaved this way
+    /// (`a_publisher_host_offers_no_trust_flag` in `doiget-core`).
+    #[test]
+    fn a_publisher_host_is_offered_no_trust_flag_in_the_human_help() {
+        let mut dc = denial(DenialReason::RedirectNotInAllowlist);
+        dc.attempted = Some("link.springer.com".to_string());
+        let joined = denial_note_lines(&dc, None).join(
+            "
+",
+        );
+
+        assert!(
+            !joined.contains("trust_academic_repos = true"),
+            "neither flag covers a publisher host; got:
+{joined}"
+        );
+        assert!(
+            !joined.contains("trust_oa_registries = true"),
+            "neither flag covers a publisher host; got:
+{joined}"
+        );
+        assert!(
+            joined.contains("neither trust_academic_repos nor trust_oa_registries"),
+            "saying so is the point -- silence would read as an omission; got:
+{joined}"
+        );
+        // The per-host escape hatch is still the real answer here.
+        assert!(
+            joined.contains("additional_hosts]] host = \"link.springer.com\""),
+            "got:
+{joined}"
         );
     }
 

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -162,9 +162,23 @@ pub struct ResolvedOutput {
 ///   particular is almost always piped (`doiget text arxiv:… > paper.txt`),
 ///   so the implicit-Quiet fallback would otherwise blank the output.
 ///
-/// `audit-log` is omitted on purpose: it is *informational* in Human
-/// mode and *artifact* in Json mode; the command checks the resolved
-/// mode rather than its name, so this classifier doesn't apply.
+/// Two commands are omitted on purpose, because a name-level predicate
+/// cannot express them and pretending otherwise would be worse than the
+/// omission:
+///
+/// - `audit-log` is *informational* in Human mode and *artifact* in Json
+///   mode; the command checks the resolved mode rather than its name.
+/// - `config` is artifact-class in `path` and `show` (their stdout is the
+///   requested value) and status-class in `init`; `doctor` writes to
+///   stderr and is unaffected either way. It takes `quiet_was_explicit`
+///   and decides per action (#476).
+///
+/// This is the third time the list has been found incomplete (#219/#220,
+/// #301, #476), and the reason is visible above: it is a hand-maintained
+/// enumeration of a property no type carries. Deriving it from the command
+/// definition would end the pattern. Until then, a new subcommand that
+/// writes a *value* to stdout has to be added here or handled per action,
+/// or it is silent to every non-interactive caller.
 pub fn is_artifact_command(name: &str) -> bool {
     matches!(
         name,

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -253,6 +253,12 @@ enum Command {
         link: Option<Utf8PathBuf>,
     },
     /// Fetch many refs from a newline-separated text file.
+    ///
+    /// With `--json`, records are written as each ref COMPLETES, not in
+    /// input order: up to 5 fetches run concurrently and a parse error
+    /// returns instantly where a 1 MB PDF does not. Key on the `ref` field
+    /// of each record; zipping stdout against the input file positionally
+    /// attaches results to the wrong DOI (#479).
     Batch {
         /// Path to a file containing one ref per line.
         path: String,
@@ -769,7 +775,10 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             action,
             network,
             force,
-        }) => doiget_cli::commands::config::run(action, mode, network, force).await,
+        }) => {
+            doiget_cli::commands::config::run(action, mode, network, force, out.quiet_was_explicit)
+                .await
+        }
         Some(Command::Info { ref_ }) => {
             doiget_cli::commands::info::run(ref_, mode, out.quiet_was_explicit)
         }

--- a/crates/doiget-cli/tests/quiet_honoring_e2e.rs
+++ b/crates/doiget-cli/tests/quiet_honoring_e2e.rs
@@ -115,6 +115,42 @@ fn config_path_quiet_produces_no_stdout() {
         .stdout(predicate::str::is_empty());
 }
 
+// ---- #476: implicit (non-TTY) Quiet must NOT silence `config` ---------
+//
+// `assert_cmd` always gives the child a pipe, never a terminal, so these
+// exercise exactly the state the bug was reported in: no mode flag, no
+// `DOIGET_MODE`, stdout not a TTY. Before #476 both printed zero bytes and
+// exited 0 -- the documented way to locate your config file answering a
+// script, a CI step or an agent with silence AND success.
+//
+// The pair above (explicit `--mode quiet`) is what must keep working; these
+// are what must stop being suppressed. Both halves matter: fixing this by
+// making `config` unconditionally loud would break #203.
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn config_path_prints_when_stdout_is_not_a_tty() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+        .args(["config", "path"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("config.toml"));
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn config_show_prints_when_stdout_is_not_a_tty() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+        .args(["config", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
 // ---- audit-log Quiet + chain issues: exit non-zero, stdout empty ------
 //
 // Self-review for #207 §2: tampered-log under Quiet must still raise

--- a/crates/doiget-core/src/remediation.rs
+++ b/crates/doiget-core/src/remediation.rs
@@ -177,7 +177,10 @@ pub fn widening_suggestions(host: &str) -> Vec<(String, &'static str)> {
         return out;
     }
     let parent = parent_labels.join(".");
-    out.push((format!("*.{parent}"), "the whole publisher"));
+    // "the whole publisher" was wrong for the dominant case (#478): this
+    // fires most often for institutional repositories, and every host in
+    // the built-in `trust_academic_repos` list is a university.
+    out.push((format!("*.{parent}"), "the whole domain"));
     out.push((parent, "apex too (a wildcard does not match it)"));
     out
 }

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -57,7 +57,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 |---|---|
 | Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
-| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). **Records are emitted in completion order, not input order** — see below. |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
 
 ### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
@@ -125,6 +125,22 @@ Emitted only for reasons with a configuration channel — `redirect_not_in_allow
 `host_in_block_list`. A `size_cap_exceeded` or `capability_not_granted` denial carries no
 `remediation`, because offering a host to trust would send the caller after a fix that
 cannot work.
+
+### 3.2a `batch --json` record order (NORMATIVE)
+
+Records are written as each ref **completes**. `batch` runs up to
+`RateLimits::HARD_CODED.max_concurrent_fetches()` fetches at once and emits each
+record when its task finishes, so stdout is in completion order and reordering is
+the normal case rather than a rare one: a parse error returns instantly, a 1 MB PDF
+does not.
+
+**Key on the `ref` field.** Zipping stdout against the input file positionally is the
+obvious thing to write, it works on a small or uniform batch, and the first time a
+fetch is slow it attaches a result to the wrong DOI with no error anywhere (#479).
+
+Input order would cost buffering the whole run before emitting anything, which
+would end streaming for large batches. The order is not going to change; consumers
+that need input order must sort by `ref` themselves.
 
 ### 3.3 Structured `attempts` (NORMATIVE; ADR-0043)
 

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -63,7 +63,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 |---|---|
 | Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
-| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). **Records are emitted in completion order, not input order** — see below. |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
 
 ### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
@@ -131,6 +131,22 @@ Emitted only for reasons with a configuration channel — `redirect_not_in_allow
 `host_in_block_list`. A `size_cap_exceeded` or `capability_not_granted` denial carries no
 `remediation`, because offering a host to trust would send the caller after a fix that
 cannot work.
+
+### 3.2a `batch --json` record order (NORMATIVE)
+
+Records are written as each ref **completes**. `batch` runs up to
+`RateLimits::HARD_CODED.max_concurrent_fetches()` fetches at once and emits each
+record when its task finishes, so stdout is in completion order and reordering is
+the normal case rather than a rare one: a parse error returns instantly, a 1 MB PDF
+does not.
+
+**Key on the `ref` field.** Zipping stdout against the input file positionally is the
+obvious thing to write, it works on a small or uniform batch, and the first time a
+fetch is slow it attaches a result to the wrong DOI with no error anywhere (#479).
+
+Input order would cost buffering the whole run before emitting anything, which
+would end streaming for large batches. The order is not going to change; consumers
+that need input order must sort by `ref` themselves.
 
 ### 3.3 Structured `attempts` (NORMATIVE; ADR-0043)
 


### PR DESCRIPTION
Closes #476, #478, #479. Batched because they are one theme: every non-interactive or human-facing surface here knew less than the machine path did.

## #476 — `config path` and `config show` are silent to every pipe

```
$ doiget config path
$ echo $?
0
```

Zero bytes on stdout, zero on stderr, exit 0. The command whose entire job is to name the config file answered with silence **and** success, so a caller could not tell an empty answer from a suppressed one.

The resolver worked and the renderer worked; the only thing between them was the ADR-0017 artifact classification, which never listed `config`. That matters more here than for the earlier cases because the tool's own docs tell you to run it — `docs/CONFIG.md` sends you to `doiget config path` to find the file that `config init` writes.

`config` is not uniformly one class, so it joins `audit-log` in deciding **per action** rather than per name:

| action | class | implicit non-TTY Quiet |
|---|---|---|
| `path`, `show` | artifact — stdout **is** the requested value | prints |
| `init` | status report about a write | silent |
| `doctor` | diagnostic, writes to stderr | unaffected |

Explicit Quiet still silences all of them; #203 is untouched.

This is the third time the list has been found incomplete (#219/#220, #301, #476), so the reason is now written down where the list is maintained: it is a hand-kept enumeration of a property no type carries. Deriving it from the command definition would end the pattern.

**Verified against the real binary**, because the `config` e2e tests are `cfg(not(windows))` and this was developed on Windows:

```
$ doiget config path | cat
C:\Users\...\doiget\config.toml
$ doiget --mode quiet config path | wc -c
0
```

## #478 — the agent got a better diagnostic than the human

The help listed both trust flags unconditionally. Only one covers any given host; `remediation::trust_flag_for_host` already computes which, and `remediation::for_denial` already calls it — so MCP and `batch --json` consumers got the precise answer while the human, who has *less* context, was shown two options with nothing to choose between them. Following the wrong one costs a round.

Three cases now, because **"we did not compute it" is not the same answer as "we computed it and neither applies"**:

| state | output |
|---|---|
| known host, one flag covers it | that flag, with the pattern it matched (`# covers *.ac.uk (UK academic institutions …)`) |
| known host, neither covers it (a publisher) | says so — the machine path already offered none here, and there is a test for it |
| no host to test | both stay listed; the reason for narrowing is absent, not resolved |

That last row is why the pre-existing `redirect_denial_help_degrades_without_config_dir_or_host` still passes: collapsing "unknown" into "neither" would have been a regression dressed as a fix.

Fourth instance this cycle of *the correct mechanism exists, is documented, and this call site does not go through it* — after #442, #454 and #458.

**Also**: `widening_suggestions` described `*.parent` as "the whole publisher". This fires most often for institutional repositories, and every host in the built-in academic list is a university, so it now says "the whole domain". That string is on the machine wire too.

## #479 — `batch --json` record order

Records are emitted as refs **complete**: 5 fetches run at once and a parse error returns instantly where a 1 MB PDF does not, so reordering is the normal case. Nothing documented it.

Zipping stdout against the input file positionally is the obvious consumer to write, it works on a small or uniform batch, and it attaches a result to the wrong DOI the first time a fetch is slow — with no error anywhere. Stated in `docs/ERRORS.md` §3.2a (NORMATIVE) and in `batch --help`, with `ref` named as the key.

Input order is not adopted: it costs buffering the whole run before emitting anything, which ends streaming for large batches.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,citation`, and the full `oa-only,metadata,tdm-*` set.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features oa-only,citation`.
- `cargo test --workspace --all-targets --no-default-features --features oa-only`.
- Two new `denial_note_lines` tests (covering flag named, other absent; publisher host offered none) and two new non-TTY `config` e2e tests.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.7`.

Closes #476, #478, #479
