### PR TITLE
feat(cli): the store inventory says whether you actually have the PDF (#481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[cli]** `list-recent` and `search --local` show whether a PDF was actually
+  stored. A metadata-only entry — what a blocked content leg leaves behind —
+  rendered identically to a fetched paper, and the inventory command is the only
+  one that answers "what do I have?" without being told the ref in advance. Batch
+  fifty refs with ten blocked, come back later, and the natural conclusion is
+  fifty papers (#481, #118).
+
 - **[cli]** `config path` and `config show` print when stdout is not a terminal.
   They were absent from the ADR-0017 artifact classification, so an implicit
   non-TTY Quiet silenced them: `doiget config path` from a pipe produced zero
@@ -60,6 +67,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[cli]** `list-recent --missing-pdf` lists only the metadata-only entries —
+  "which of my batch need retrying?" without reading a fifty-row table by eye
+  (#481).
+- **[core]** `EntryInfo` gains `size_bytes: Option<u64>` and `has_pdf()`. The
+  `list-recent --mode json` envelope carries both: `0` and `null` both mean "no
+  PDF" while meaning different things about the entry, and a consumer should not
+  have to know that. The `pdf` column is APPENDED to the human table, not
+  inserted — column order is stable for `cut(1)` by contract (#481).
 - **[docs]** `batch --json` record order is stated in `docs/ERRORS.md` §3.2a and
   in `batch --help`: records are emitted as refs complete, not in input order, and
   `ref` is the key. Nothing said so, and zipping stdout against the input file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.7"
+version       = "0.8.10-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/list_recent.rs
+++ b/crates/doiget-cli/src/commands/list_recent.rs
@@ -6,9 +6,16 @@
 //! most-recent first by `[doiget].fetched_at`. Network access is never
 //! required.
 //!
-//! Output is a tab-separated table with a header line. The four columns
+//! Output is a tab-separated table with a header line. The five columns
 //! match [`EntryInfo`](doiget_core::store::EntryInfo): `safekey`, `year`,
-//! `title`, `fetched_at`. Missing `year` / `fetched_at` render as `-`.
+//! `title`, `fetched_at`, `pdf`. Missing `year` / `fetched_at` render as
+//! `-`.
+//!
+//! `pdf` is #481. Without it this command -- the only one that answers
+//! "what do I have?" without knowing the ref in advance -- showed a
+//! metadata-only entry identically to a fetched paper. Batch fifty refs
+//! with ten blocked, come back later, and the natural conclusion is fifty
+//! papers.
 
 use std::io::Write;
 
@@ -28,7 +35,12 @@ const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// Emits a tab-separated table on stdout. The column order is intentionally
 /// stable for `cut(1)` consumption; future fields will be APPENDED, not
 /// inserted.
-pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bool) -> Result<()> {
+pub fn run(
+    limit: usize,
+    missing_pdf: bool,
+    mode: super::output::OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
     // `mode` honors ADR-0017: explicit `Quiet` suppresses the TSV table
     // but the store read still runs (so I/O failures surface as exit 1)
     // (#203). The non-TTY *implicit* Quiet does NOT suppress —
@@ -36,9 +48,15 @@ pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bo
     // listing IS the requested output. Json body is tracked in #204.
     let store_root = resolve_store_root()?;
     let store = FsStore::new(store_root)?;
-    let entries = store
+    let mut entries = store
         .list_recent(limit)
         .context("failed to list recent store entries")?;
+    // #481: "which of my fifty need retrying?" is the question the pdf
+    // column creates, and scanning a fifty-row table by eye is the thing a
+    // flag exists to avoid.
+    if missing_pdf {
+        entries.retain(|e| !e.has_pdf());
+    }
 
     if mode == super::output::OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
@@ -47,19 +65,34 @@ pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bo
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     if mode == super::output::OutputMode::Json {
+        // `EntryInfo` serialises `size_bytes` directly. `has_pdf` is
+        // derived and added beside it, because a consumer should not have
+        // to know that `0` and `null` both mean "no PDF" while meaning
+        // different things about the entry.
+        let entries_json: Vec<serde_json::Value> = entries
+            .iter()
+            .map(|e| {
+                let mut v = serde_json::to_value(e)
+                    .unwrap_or_else(|_| serde_json::json!({ "safekey": e.safekey.as_str() }));
+                if let Some(o) = v.as_object_mut() {
+                    o.insert("has_pdf".into(), serde_json::json!(e.has_pdf()));
+                }
+                v
+            })
+            .collect();
         let envelope = serde_json::json!({
             "ok": true,
-            "count": entries.len(),
-            "entries": entries,
+            "count": entries_json.len(),
+            "entries": entries_json,
         });
         let s = serde_json::to_string_pretty(&envelope)
             .context("failed to serialize list-recent entries to JSON")?;
         writeln!(out, "{s}").context("failed to write list-recent JSON to stdout")?;
         return Ok(());
     }
-    writeln!(out, "safekey\tyear\ttitle\tfetched_at")
+    writeln!(out, "safekey\tyear\ttitle\tfetched_at\tpdf")
         .context("failed to write list-recent header to stdout")?;
-    for e in entries {
+    for e in &entries {
         let year = e.year.map(|y| y.to_string()).unwrap_or_else(|| "-".into());
         let fetched = e
             .fetched_at
@@ -67,13 +100,40 @@ pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bo
             .unwrap_or_else(|| "-".into());
         writeln!(
             out,
-            "{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}",
             e.safekey.as_str(),
             year,
             e.title,
-            fetched
+            fetched,
+            pdf_cell(e)
         )
         .context("failed to write list-recent row to stdout")?;
     }
     Ok(())
+}
+
+/// Render the `pdf` column: the stored PDF size, or a dash for a
+/// metadata-only entry.
+///
+/// #481. APPENDED rather than inserted before `title`, because this
+/// module's contract is explicit that column order is stable for `cut(1)`
+/// and new fields go on the end. The issue suggested inserting it; that
+/// would break every existing `cut -f3` in the wild.
+///
+/// The size rather than a bare boolean: "1.0 MB" and "-" answer "did I get
+/// it?" equally well, and the size additionally answers "is this the paper
+/// or a one-page stub?", which is the next question and costs nothing.
+pub(crate) fn pdf_cell(e: &doiget_core::store::EntryInfo) -> String {
+    match e.size_bytes {
+        // `None` is "no `[doiget]` table", a different unknown from
+        // "0 bytes stored". Both mean no PDF; only one means the entry
+        // lacks the table that would say so.
+        None => "?".to_string(),
+        Some(0) => "-".to_string(),
+        #[allow(clippy::cast_precision_loss)]
+        Some(n) if n >= 1_048_576 => format!("{:.1} MB", n as f64 / 1_048_576.0),
+        #[allow(clippy::cast_precision_loss)]
+        Some(n) if n >= 1024 => format!("{:.1} kB", n as f64 / 1024.0),
+        Some(n) => format!("{n} B"),
+    }
 }

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -165,9 +165,11 @@ fn run_local(
         write_json(&mut out, &local_envelope(query, &entries))?;
         return Ok(());
     }
-    writeln!(out, "safekey\tyear\ttitle\tfetched_at")
+    // Same column as `list-recent` (#481): `search --local` lists store
+    // entries too, so it had the same gap.
+    writeln!(out, "safekey\tyear\ttitle\tfetched_at\tpdf")
         .context("failed to write search header to stdout")?;
-    for e in entries {
+    for e in &entries {
         let year = dash_or(e.year);
         let fetched = e
             .fetched_at
@@ -175,11 +177,12 @@ fn run_local(
             .unwrap_or_else(|| "-".into());
         writeln!(
             out,
-            "{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}",
             e.safekey.as_str(),
             year,
             e.title,
-            fetched
+            fetched,
+            super::list_recent::pdf_cell(e)
         )
         .context("failed to write search row to stdout")?;
     }

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -295,6 +295,13 @@ enum Command {
         /// Number of entries to show.
         #[arg(default_value_t = 10)]
         limit: usize,
+        /// Show only entries with no stored PDF -- the metadata-only ones.
+        ///
+        /// Answers "which of my batch need retrying?" without reading a
+        /// fifty-row table by eye. The `pdf` column carries the same
+        /// information for every row (#481).
+        #[arg(long)]
+        missing_pdf: bool,
     },
     /// Search for papers. Default: external discovery over OpenAlex
     /// (`/works?search=`, ADR-0031) — turn a topic into ranked candidate
@@ -782,8 +789,8 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Info { ref_ }) => {
             doiget_cli::commands::info::run(ref_, mode, out.quiet_was_explicit)
         }
-        Some(Command::ListRecent { limit }) => {
-            doiget_cli::commands::list_recent::run(limit, mode, out.quiet_was_explicit)
+        Some(Command::ListRecent { limit, missing_pdf }) => {
+            doiget_cli::commands::list_recent::run(limit, missing_pdf, mode, out.quiet_was_explicit)
         }
         Some(Command::Search {
             query,

--- a/crates/doiget-cli/tests/info_list_recent_e2e.rs
+++ b/crates/doiget-cli/tests/info_list_recent_e2e.rs
@@ -226,9 +226,114 @@ fn list_recent_on_empty_store_prints_only_header() {
     let stdout = String::from_utf8(assert.get_output().stdout.clone())
         .expect("doiget list-recent stdout was not UTF-8");
     assert_eq!(
-        stdout, "safekey\tyear\ttitle\tfetched_at\n",
+        stdout, "safekey\tyear\ttitle\tfetched_at\tpdf\n",
         "empty store should produce header-only stdout, got:\n{stdout}"
     );
+}
+
+// ---- #481: the inventory must distinguish a stub from a paper ----------
+
+/// Seed one entry with a stored PDF and one metadata-only entry
+/// (`size_bytes = 0`), which is exactly what a blocked content leg leaves
+/// behind.
+fn store_with_one_stub() -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+
+    let (k1, m1) = fixture("gotpdf", "A Paper We Actually Have", 2024, 2024);
+    store.write(&k1, &m1, None).expect("seed fetched entry");
+
+    let (k2, mut m2) = fixture("nopdf", "A Paper We Only Know About", 2023, 2023);
+    if let Some(d) = m2.doiget.as_mut() {
+        // What `fetch` writes when the content leg was blocked: the record
+        // is real, the bytes are not.
+        d.size_bytes = 0;
+    }
+    store
+        .write(&k2, &m2, None)
+        .expect("seed metadata-only entry");
+
+    (dir, root)
+}
+
+/// #481. Two entries, one with a PDF and one without, must not render
+/// alike. Before the `pdf` column they did -- and `list-recent` is the only
+/// command that answers "what do I have?" without being told the ref, so it
+/// was the one place the distinction was unrecoverable.
+#[test]
+fn list_recent_distinguishes_a_metadata_only_entry_from_a_fetched_one() {
+    let (_guard, root) = store_with_one_stub();
+    let assert = doiget(&root).args(["list-recent"]).assert().success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+
+    let have = stdout
+        .lines()
+        .find(|l| l.contains("A Paper We Actually Have"))
+        .unwrap_or_else(|| panic!("missing fetched row in:\n{stdout}"));
+    let stub = stdout
+        .lines()
+        .find(|l| l.contains("A Paper We Only Know About"))
+        .unwrap_or_else(|| panic!("missing metadata-only row in:\n{stdout}"));
+
+    assert!(
+        have.ends_with("1.2 kB"),
+        "a stored PDF must show its size; got:\n{have}"
+    );
+    assert!(
+        stub.ends_with('-'),
+        "a metadata-only entry must be visibly different; got:\n{stub}"
+    );
+}
+
+/// The column answers "which are stubs?" one row at a time. `--missing-pdf`
+/// answers it for a fifty-ref batch, which is the case that produced the
+/// report.
+#[test]
+fn list_recent_missing_pdf_lists_only_the_stubs() {
+    let (_guard, root) = store_with_one_stub();
+    let assert = doiget(&root)
+        .args(["list-recent", "--missing-pdf"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+
+    assert!(
+        stdout.contains("A Paper We Only Know About"),
+        "the stub must be listed; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("A Paper We Actually Have"),
+        "a fetched paper is not missing its PDF; got:\n{stdout}"
+    );
+}
+
+/// The JSON surface carries it too, and carries `has_pdf` beside
+/// `size_bytes` so a consumer does not have to know that `0` and `null`
+/// both mean "no PDF" while meaning different things about the entry.
+#[test]
+fn list_recent_json_carries_size_bytes_and_has_pdf() {
+    let (_guard, root) = store_with_one_stub();
+    let assert = doiget(&root)
+        .args(["--mode", "json", "list-recent"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let entries = v["entries"].as_array().expect("entries array");
+
+    let stub = entries
+        .iter()
+        .find(|e| e["title"].as_str() == Some("A Paper We Only Know About"))
+        .unwrap_or_else(|| panic!("stub missing from {stdout}"));
+    assert_eq!(stub["size_bytes"], serde_json::json!(0));
+    assert_eq!(stub["has_pdf"], serde_json::json!(false));
+
+    let have = entries
+        .iter()
+        .find(|e| e["title"].as_str() == Some("A Paper We Actually Have"))
+        .unwrap_or_else(|| panic!("fetched entry missing from {stdout}"));
+    assert_eq!(have["has_pdf"], serde_json::json!(true));
 }
 
 // ---- #204 JSON-mode coverage --------------------------------------------

--- a/crates/doiget-cli/tests/search_e2e.rs
+++ b/crates/doiget-cli/tests/search_e2e.rs
@@ -169,7 +169,7 @@ fn search_returns_no_match_for_unknown_query() {
         .expect("doiget search stdout was not UTF-8");
     // Header only, no data rows.
     assert_eq!(
-        stdout, "safekey\tyear\ttitle\tfetched_at\n",
+        stdout, "safekey\tyear\ttitle\tfetched_at\tpdf\n",
         "no-match search should produce header-only stdout, got:\n{stdout}"
     );
 }

--- a/crates/doiget-core/src/store/fs_store.rs
+++ b/crates/doiget-core/src/store/fs_store.rs
@@ -165,6 +165,7 @@ impl FsStore {
                 title: md.title,
                 year: md.year,
                 fetched_at: md.doiget.as_ref().map(|d| d.fetched_at),
+                size_bytes: md.doiget.as_ref().map(|d| d.size_bytes),
             });
             if hits.len() >= limit {
                 break;
@@ -289,6 +290,7 @@ impl Store for FsStore {
                     title: md.title,
                     year: md.year,
                     fetched_at: md.doiget.as_ref().map(|d| d.fetched_at),
+                    size_bytes: md.doiget.as_ref().map(|d| d.size_bytes),
                 });
                 if hits.len() >= limit {
                     break;
@@ -783,7 +785,8 @@ fn read_all_entries(metadata_dir: &Utf8Path) -> Result<Vec<EntryInfo>, StoreErro
             safekey,
             title: md.title,
             year: md.year,
-            fetched_at: md.doiget.map(|d| d.fetched_at),
+            fetched_at: md.doiget.as_ref().map(|d| d.fetched_at),
+            size_bytes: md.doiget.as_ref().map(|d| d.size_bytes),
         });
     }
     Ok(out)

--- a/crates/doiget-core/src/store/mod.rs
+++ b/crates/doiget-core/src/store/mod.rs
@@ -64,6 +64,32 @@ pub struct EntryInfo {
     pub year: Option<i32>,
     /// `fetched_at` from the `[doiget]` table, if any.
     pub fetched_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// `size_bytes` from the `[doiget]` table: the size of the stored PDF,
+    /// `0` for a metadata-only entry, `None` when the entry has no
+    /// `[doiget]` table at all.
+    ///
+    /// #481: without it the inventory commands could not tell a fetched
+    /// paper from a metadata-only stub. Every other surface could -- the
+    /// fetch itself failed loudly, the TOML omits `pdf_path`, the
+    /// provenance log carries an `err` row, `doiget info` shows
+    /// `size_bytes = 0` -- and the one command that answers "what do I
+    /// have?" without knowing the ref in advance was the one that dropped
+    /// it. Fifty refs with ten blocked listed as fifty identical rows.
+    pub size_bytes: Option<u64>,
+}
+
+impl EntryInfo {
+    /// Whether a PDF was actually stored for this entry.
+    ///
+    /// `false` for a metadata-only entry (`size_bytes == 0`) and for one
+    /// with no `[doiget]` table. Deliberately not "is this entry useful" --
+    /// a metadata-only entry is a legitimate result, it is just a different
+    /// one, and #118 is the standing rule that the two must not be
+    /// presented alike.
+    #[must_use]
+    pub fn has_pdf(&self) -> bool {
+        self.size_bytes.is_some_and(|n| n > 0)
+    }
 }
 
 /// Errors emitted by [`Store`] implementations.


### PR DESCRIPTION
Closes #481.

Two entries — one fetched, one blocked on the content leg — rendered identically:

```
safekey                          year  title                     fetched_at
doi_10.1109_tsp.2018.2812747     2018  On the Existence …        2026-08-25T05:24:43Z
doi_10.1103_PhysRevX.10.011001   2020  High-Fidelity Measure…    2026-08-25T05:24:43Z
```

Only the first has no PDF. `papers/` held **one** `.pdf`; `papers/.metadata/` held **two** `.toml`.

## Every other surface knew

| surface | distinguishes? |
|---|---|
| the fetch itself | yes — `error[CAPABILITY_DENIED]`, exit 3 |
| the metadata TOML | yes — no `pdf_path`, `size_bytes = 0` |
| the provenance log | yes — an `err` row |
| `doiget info <ref>` | yes — `size_bytes = 0` |
| **`list-recent`** | **no** |

The one command that answers *"what do I have?"* without being told the ref in advance was the one that dropped it. #118 established that a metadata-only stub must not be presented as a success; that was solved at the fetch level and left open at the inventory level.

## Changes

- `EntryInfo` gains `size_bytes: Option<u64>` and `has_pdf()`. `None` is "no `[doiget]` table" — a different unknown from "0 bytes stored".
- `list-recent` and `search --local` gain a `pdf` column. `search --local` lists store entries too, so it had the same gap; the issue asked for it to be checked in the same pass.
- `list-recent --missing-pdf` filters to the stubs.
- The JSON envelope carries `size_bytes` **and** `has_pdf`.

```
safekey                          year  title              fetched_at             pdf
doi_10.1103_PhysRevX.10.011001   2020  High-Fidelity …    2026-08-25T05:24:43Z   1.0 MB
doi_10.1109_tsp.2018.2812747     2018  On the Existence…  2026-08-25T05:24:43Z   -
```

### Two deliberate departures from the issue's suggestion

**The column is appended, not inserted before `title`.** The module contract is explicit — *"column order is intentionally stable for `cut(1)` consumption; future fields will be APPENDED, not inserted"* — and inserting would break every existing `cut -f3` in the wild. The issue's mock-up put `pdf` third; this puts it fifth.

**The size, not a bare boolean.** `1.0 MB` and `-` answer "did I get it?" just as well as `true`/`false`, and the size additionally answers "is this the paper or a one-page stub?", which is the next question and costs nothing.

`has_pdf` is still on the JSON wire beside `size_bytes`, because a consumer should not have to know that `0` and `null` both mean "no PDF" while meaning different things about the entry.

## Verified by mutation

| severed | fails |
|---|---|
| the `pdf` column in the human table | `list_recent_distinguishes_a_metadata_only_entry_from_a_fetched_one`, only |
| `--missing-pdf` made a no-op | `list_recent_missing_pdf_lists_only_the_stubs`, only |
| `has_pdf` dropped from the envelope | `list_recent_json_carries_size_bytes_and_has_pdf`, only |

The three tests seed a store with one real entry and one `size_bytes = 0` stub — which is exactly what a blocked content leg leaves behind — and drive the real binary.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,citation`, and the full `oa-only,metadata,tdm-*` set.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features oa-only,citation`.
- `cargo test --workspace --all-targets --no-default-features --features oa-only`.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.8`.

Two pre-existing header assertions were updated for the new column (`info_list_recent_e2e.rs`, `search_e2e.rs`).

Refs #118, #145, #445, #462
