### PR TITLE
fix(cli): the error[CODE] contract holds on every ref-taking command (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 ### Fixed
 
 - **[cli]** Every ref-taking command emits the `docs/ERRORS.md` §3 contract
-  line — `error[INVALID_REF]: invalid ref: …` — for an unparseable input.
+  line — `error[INVALID_REF]: invalid ref: …` — for an unparsable input.
   #119 gave `fetch` the contract and nothing generalised it, so `info`,
   `link`, `cite`, `text`, `tag`, `bib`, `csl` and `source` each printed a raw
   `anyhow` dump: a bare `Error:` plus a `Caused by:` chain leaking internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[cli]** Every ref-taking command emits the `docs/ERRORS.md` §3 contract
+  line — `error[INVALID_REF]: invalid ref: …` — for an unparseable input.
+  #119 gave `fetch` the contract and nothing generalised it, so `info`,
+  `link`, `cite`, `text`, `tag`, `bib`, `csl` and `source` each printed a raw
+  `anyhow` dump: a bare `Error:` plus a `Caused by:` chain leaking internal
+  error types that are in no contract, on a surface whose callers are told
+  they can key off `error[CODE]:`. One renderer now, and a table-driven e2e
+  that fails by naming the command that regressed (#477).
+- **[cli]** `verify` renders a missing input file as `error: failed to read
+  reference file …` with exit 2 rather than an `anyhow` dump. It takes a path,
+  not a ref, and the closed `ErrorCode` set describes fetch outcomes — so it
+  gets the misuse form the CLI already uses elsewhere (#477).
+- **[core]** An input with neither a scheme nor a `10.` prefix reports
+  `RefParseError::UnrecognisedShape` — "neither a DOI … nor an arXiv id" —
+  instead of the arXiv parser's verdict. `Ref::parse` falls through to arXiv,
+  so someone who mistyped a DOI was told about arXiv id shapes (#477).
+
 - **[cli]** `list-recent` and `search --local` show whether a PDF was actually
   stored. A metadata-only entry — what a blocked content leg leaves behind —
   rendered identically to a fetched paper, and the inventory command is the only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.8"
+version = "0.8.10-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.8"
+version = "0.8.10-beta.9"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.8"
+version = "0.8.10-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.8"
+version       = "0.8.10-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.9" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.9" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.9" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -19,7 +19,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use doiget_core::refs::{self, Format};
 use doiget_core::store::{render, FsStore, Metadata, Store};
-use doiget_core::{Ref, Safekey};
+use doiget_core::Safekey;
 
 use super::fetch::CliExit;
 use super::output::print_err;
@@ -64,7 +64,7 @@ pub fn run(
         Some(r) => r,
         None => bail!("specify a ref, `--all`, or `--from-file <FILE>`"),
     };
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let safekey = ref_.safekey();
     match store.read(&safekey)? {
         Some(m) => write_all(&render::to_bibtex(safekey.as_str(), &m)),

--- a/crates/doiget-cli/src/commands/cite.rs
+++ b/crates/doiget-cli/src/commands/cite.rs
@@ -59,7 +59,7 @@ use super::resolve_store_root;
 /// `--quiet` does NOT suppress it. A total miss (no live resolve and no
 /// store entry) returns an error so the CLI exits non-zero.
 pub async fn run(input: String, offline: bool, _mode: super::output::OutputMode) -> Result<()> {
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
 
     // `--offline`: render straight from the store, no network at all.
     if offline {

--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 
 use doiget_core::refs::{self, Format};
 use doiget_core::store::{render, FsStore, Metadata, Store};
-use doiget_core::{Ref, Safekey};
+use doiget_core::Safekey;
 
 use super::fetch::CliExit;
 use super::output::print_err;
@@ -65,7 +65,7 @@ pub fn run(
         Some(r) => r,
         None => bail!("specify a ref, `--all`, or `--from-file <FILE>`"),
     };
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let safekey = ref_.safekey();
     match store.read(&safekey)? {
         Some(m) => write_array(&render::to_csl_array(safekey.as_str(), &m)),

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -725,10 +725,7 @@ pub async fn run_with_options(
     let ref_ = match Ref::parse(&input) {
         Ok(r) => r,
         Err(e) => {
-            print_err(format_args!(
-                "error[{}]: invalid ref: {e}",
-                ErrorCode::InvalidRef.as_wire()
-            ));
+            super::render_ref_parse_error(&e);
             return Err(anyhow::Error::new(CliExit(cli_exit_code(
                 ErrorCode::InvalidRef,
             ))));

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -58,12 +58,12 @@ pub async fn run(
     let ref_ = match Ref::parse(&input) {
         Ok(r) => r,
         Err(e) => {
-            // Bad ref string is user misuse → `docs/ERRORS.md` §4 exit 2
-            // (issue #149), consistent with `fetch`'s INVALID_REF path.
-            print_err(format_args!(
-                "error[{}]: invalid ref: {e}",
-                ErrorCode::InvalidRef.as_wire()
-            ));
+            // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2
+            // (issue #149). NOTE: `fetch` exits 1 for the same input; §4
+            // says misuse is 2, so they disagree and this is the one
+            // following the table. Not reconciled in #477 -- see
+            // `commands::render_ref_parse_error`.
+            super::render_ref_parse_error(&e);
             return Err(anyhow::Error::new(CliExit(2)));
         }
     };

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -12,7 +12,6 @@ use std::io::Write;
 use anyhow::{bail, Context, Result};
 
 use doiget_core::store::{FsStore, Store};
-use doiget_core::Ref;
 
 use super::resolve_store_root;
 
@@ -34,7 +33,7 @@ pub fn run(input: String, mode: super::output::OutputMode, quiet_was_explicit: b
     // caller needs. `Json` serialises `Metadata` directly (it carries
     // `Serialize`); the wire form is the field-name JSON of the on-disk
     // TOML (#204).
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let safekey = ref_.safekey();
 
     let store_root = resolve_store_root()?;

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -1,6 +1,7 @@
 //! `doiget info <ref>` subcommand — read-only metadata inspection.
 //!
-//! Reads the metadata TOML for a given [`Ref`] from the [`FsStore`] and
+//! Reads the metadata TOML for a given [`Ref`](doiget_core::Ref) from the
+//! [`FsStore`] and
 //! prints it on stdout. Network access is never required.
 //!
 //! Per [`docs/PUBLIC_API.md`](../../../../docs/PUBLIC_API.md) §2 the read goes
@@ -18,7 +19,8 @@ use super::resolve_store_root;
 /// Run the `info` subcommand against the configured store.
 ///
 /// `input` is the user-supplied ref string (e.g. `"10.1234/example"`,
-/// `"arxiv:2401.12345"`, or any of the schemes accepted by [`Ref::parse`]).
+/// `"arxiv:2401.12345"`, or any of the schemes accepted by
+/// [`Ref::parse`](doiget_core::Ref::parse)).
 ///
 /// On success, the entry's [`Metadata`](doiget_core::store::Metadata) is
 /// written to stdout as TOML. On a missing entry, the function returns an

--- a/crates/doiget-cli/src/commands/link.rs
+++ b/crates/doiget-cli/src/commands/link.rs
@@ -33,7 +33,7 @@ const OPENALEX_DEFAULT_BASE: &str = "https://api.openalex.org";
 /// [`ErrorCode`] as a process exit code via [`CliExit`] (e.g. a DOI with no
 /// OpenAlex work → `NOT_FOUND`).
 pub async fn run(ref_: String, mode: OutputMode, quiet_was_explicit: bool) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let doi = match parsed {
         Ref::Doi(d) => d,
         Ref::Arxiv(_) => {

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -21,6 +21,57 @@
 //!
 //! Other subcommands (`serve`) land in separate PRs.
 
+/// Parse a ref, or render the failure in the `docs/ERRORS.md` §3
+/// "Researcher (CLI human)" form and return the CLI exit error.
+///
+/// #477. `error[CODE]: message` held on `fetch` alone -- #119 did it there
+/// and nowhere else -- while `info`, `link`, `cite`, `text`, `tag`, `bib`,
+/// `csl` and `source` each wrote their own `with_context("invalid ref: …")`
+/// and let `anyhow` print a bare `Error:` plus a `Caused by:` chain. The
+/// closed error-code set is a load-bearing promise of this project: a
+/// caller is told it can key off `error[CODE]:`, and on eight of nine
+/// commands there was no code to key off, while the `Caused by:` chain
+/// leaked internal error types that are in no contract.
+///
+/// Same shape as `render_fetch_error` and for the same reason -- one
+/// renderer, so a future change to the contract cannot reach some call
+/// sites and miss others.
+///
+/// # Errors
+///
+/// Always, when parsing fails: an [`anyhow::Error`] wrapping
+/// [`CliExit`](fetch::CliExit) with the `INVALID_REF` exit code. The
+/// message has already been written to stderr.
+pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
+    match doiget_core::Ref::parse(input) {
+        Ok(r) => Ok(r),
+        Err(e) => {
+            render_ref_parse_error(&e);
+            Err(anyhow::Error::new(fetch::CliExit(fetch::cli_exit_code(
+                doiget_core::ErrorCode::InvalidRef,
+            ))))
+        }
+    }
+}
+
+/// The renderer on its own, for the two call sites that already choose
+/// their own exit code.
+///
+/// `fetch` exits 1 (`cli_exit_code(InvalidRef)`) and `graph` exits 2,
+/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparseable
+/// argument is misuse, so they disagree and `graph` is the one following
+/// the table. Filed separately rather than changed here: #477 is about the
+/// message, `fetch`'s exit 1 is pinned by a named test, and quietly moving
+/// an exit code is how a script breaks without anyone noticing.
+///
+/// One renderer either way, which is the part that was missing.
+pub fn render_ref_parse_error(e: &doiget_core::RefParseError) {
+    output::print_err(format_args!(
+        "error[{}]: invalid ref: {e}",
+        doiget_core::ErrorCode::InvalidRef.as_wire()
+    ));
+}
+
 pub mod audit_log;
 pub mod batch;
 pub mod bib;

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -58,7 +58,7 @@ pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
 /// their own exit code.
 ///
 /// `fetch` exits 1 (`cli_exit_code(InvalidRef)`) and `graph` exits 2,
-/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparseable
+/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparsable
 /// argument is misuse, so they disagree and `graph` is the one following
 /// the table. Filed separately rather than changed here: #477 is about the
 /// message, `fetch`'s exit 1 is pinned by a named test, and quietly moving

--- a/crates/doiget-cli/src/commands/source.rs
+++ b/crates/doiget-cli/src/commands/source.rs
@@ -48,7 +48,7 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let id: ArxivId = match parsed {
         Ref::Arxiv(a) => a,
         Ref::Doi(_) => {

--- a/crates/doiget-cli/src/commands/tag.rs
+++ b/crates/doiget-cli/src/commands/tag.rs
@@ -14,7 +14,6 @@ use std::io::Write;
 use anyhow::{bail, Context, Result};
 
 use doiget_core::store::{FsStore, Store};
-use doiget_core::Ref;
 
 use super::output::OutputMode;
 use super::resolve_store_root;
@@ -37,7 +36,7 @@ pub fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let ref_ = Ref::parse(&ref_str).with_context(|| format!("invalid ref: {ref_str}"))?;
+    let ref_ = super::parse_ref_or_exit(&ref_str)?;
     let safekey = ref_.safekey();
 
     let store_root = resolve_store_root()?;
@@ -136,7 +135,7 @@ pub fn run_annotate(ref_str: String, text: Option<String>, clear: bool) -> Resul
         bail!("provide annotation <text> or --clear");
     }
 
-    let ref_ = Ref::parse(&ref_str).with_context(|| format!("invalid ref: {ref_str}"))?;
+    let ref_ = super::parse_ref_or_exit(&ref_str)?;
     let safekey = ref_.safekey();
 
     let store_root = resolve_store_root()?;

--- a/crates/doiget-cli/src/commands/text.rs
+++ b/crates/doiget-cli/src/commands/text.rs
@@ -45,7 +45,7 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let id: ArxivId = match parsed {
         Ref::Arxiv(a) => a,
         Ref::Doi(_) => {

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -146,8 +146,22 @@ impl VerifyStatus {
 /// Entry point for `doiget verify <path> [--format] [--strict]`.
 pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMode) -> Result<()> {
     let fmt = parse_format(&format)?;
-    let text = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read reference file {path}"))?;
+    // #477: the misuse form, not a raw `anyhow` dump. `docs/ERRORS.md` §4
+    // classes an unusable argument as misuse (exit 2), and the closed
+    // `ErrorCode` set has no member for "your input file is missing" -- it
+    // describes fetch outcomes. Inventing one would be a wire change to a
+    // NORMATIVE closed set and deserves its own decision, so this uses the
+    // bare `error:` misuse shape the CLI already uses elsewhere (e.g.
+    // `config --network` applied to the wrong action).
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            super::output::print_err(format_args!(
+                "error: failed to read reference file {path}: {e}"
+            ));
+            return Err(anyhow::Error::new(super::fetch::CliExit(2)));
+        }
+    };
     let entries = parse_input(&text, fmt, Some(Utf8Path::new(&path)));
 
     // Resolve effective policy: CLI `--strict` is the strictest setting,

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -33,7 +33,7 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
 // ---- #477: the contract is not "fetch has a code", it is "the CLI has" ---
 
 /// Every ref-taking command emits an `error[CODE]:` first stderr line for
-/// an unparseable input.
+/// an unparsable input.
 ///
 /// This is the assertion that matters. #119 gave `fetch` the contract and
 /// nothing generalised it, so eight sibling commands spent four releases
@@ -46,32 +46,37 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
 #[test]
 fn every_ref_taking_command_emits_the_error_code_contract() {
     // `verify` is excluded: it takes a FILE PATH, not a ref, so an
-    // unparseable value is a missing file rather than a bad ref. It gets
+    // unparsable value is a missing file rather than a bad ref. It gets
     // the `error:` misuse form instead -- see the test below.
-    const COMMANDS: &[&[&str]] = &[
-        &["fetch"],
-        &["info"],
-        &["link"],
-        &["cite"],
-        &["text"],
-        &["bib"],
-        &["csl"],
+    let mut commands: Vec<Vec<&str>> = vec![
+        vec!["fetch"],
+        vec!["info"],
+        vec!["link"],
+        vec!["cite"],
+        vec!["text"],
+        vec!["bib"],
+        vec!["csl"],
         // `source` needs `--out`; the ref is still the last positional.
-        &["source", "--out", "."],
-        &["graph"],
-        &["tag"],
+        vec!["source", "--out", "."],
+        vec!["tag"],
     ];
+    // `graph` only exists in a `citation` build, and CI's default job runs
+    // plain `oa-only` -- where the subcommand is absent and clap answers
+    // "unrecognized subcommand", which is not this contract's business.
+    if cfg!(feature = "citation") {
+        commands.push(vec!["graph"]);
+    }
 
     let td = TempDir::new().expect("tempdir");
     let root = td.path().to_str().expect("utf-8");
 
     let mut broken: Vec<String> = Vec::new();
-    for argv in COMMANDS {
+    for argv in &commands {
         let mut cmd = Command::cargo_bin("doiget").expect("doiget binary built");
         cmd.env("DOIGET_STORE_ROOT", root)
             .env("DOIGET_LOG_PATH", "")
             .env("DOIGET_CONTACT_EMAIL", "test@example.com")
-            .args(*argv)
+            .args(argv)
             .arg("not a doi");
         let out = cmd.output().expect("run doiget");
         let stderr = String::from_utf8_lossy(&out.stderr);

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -29,3 +29,108 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
         // stdout MUST stay clean (ADR-0001 stdio rule).
         .stdout(predicate::str::is_empty());
 }
+
+// ---- #477: the contract is not "fetch has a code", it is "the CLI has" ---
+
+/// Every ref-taking command emits an `error[CODE]:` first stderr line for
+/// an unparseable input.
+///
+/// This is the assertion that matters. #119 gave `fetch` the contract and
+/// nothing generalised it, so eight sibling commands spent four releases
+/// printing a raw `anyhow` dump -- `Error:` plus a `Caused by:` chain that
+/// leaks internal error types belonging to no contract -- while the docs
+/// told callers they could key off `error[CODE]:`.
+///
+/// Table-driven on purpose: a new ref-taking subcommand is added to this
+/// list or it is not covered, and the failure names which one regressed.
+#[test]
+fn every_ref_taking_command_emits_the_error_code_contract() {
+    // `verify` is excluded: it takes a FILE PATH, not a ref, so an
+    // unparseable value is a missing file rather than a bad ref. It gets
+    // the `error:` misuse form instead -- see the test below.
+    const COMMANDS: &[&[&str]] = &[
+        &["fetch"],
+        &["info"],
+        &["link"],
+        &["cite"],
+        &["text"],
+        &["bib"],
+        &["csl"],
+        // `source` needs `--out`; the ref is still the last positional.
+        &["source", "--out", "."],
+        &["graph"],
+        &["tag"],
+    ];
+
+    let td = TempDir::new().expect("tempdir");
+    let root = td.path().to_str().expect("utf-8");
+
+    let mut broken: Vec<String> = Vec::new();
+    for argv in COMMANDS {
+        let mut cmd = Command::cargo_bin("doiget").expect("doiget binary built");
+        cmd.env("DOIGET_STORE_ROOT", root)
+            .env("DOIGET_LOG_PATH", "")
+            .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+            .args(*argv)
+            .arg("not a doi");
+        let out = cmd.output().expect("run doiget");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let first = stderr.lines().next().unwrap_or("");
+
+        if !first.starts_with("error[") {
+            broken.push(format!("{}: {first}", argv.join(" ")));
+        }
+        // The `Caused by:` chain is the anyhow dump the contract replaces.
+        if stderr.contains("Caused by:") {
+            broken.push(format!("{}: leaked a `Caused by:` chain", argv.join(" ")));
+        }
+    }
+
+    assert!(
+        broken.is_empty(),
+        "these commands do not honour the error[CODE] contract for an invalid ref:\n  {}",
+        broken.join("\n  ")
+    );
+}
+
+/// `verify` takes a path, so its failure is a missing file. It still must
+/// not dump anyhow: `docs/ERRORS.md` §4 classes an unusable argument as
+/// misuse, and the closed `ErrorCode` set describes fetch outcomes, so
+/// there is no code for "your input file is missing" (#477).
+#[test]
+fn verify_renders_a_missing_input_file_as_misuse_not_an_anyhow_dump() {
+    let td = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .env("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8"))
+        .env("DOIGET_LOG_PATH", "")
+        .args(["verify", "no-such-file.bib"])
+        .assert()
+        .code(2)
+        .stderr(
+            predicate::str::starts_with("error: failed to read reference file")
+                .and(predicate::str::contains("Caused by:").not()),
+        )
+        .stdout(predicate::str::is_empty());
+}
+
+/// A mistyped DOI must not be told about arXiv.
+///
+/// `Ref::parse` falls through to the arXiv parser for anything without a
+/// scheme or a `10.` prefix, and reported that parser's failure verbatim --
+/// so `doiget fetch 10-1109-tsp` answered "input does not match any known
+/// arXiv id shape" to someone who was clearly aiming at a DOI (#477).
+#[test]
+fn an_unrecognised_ref_names_neither_shape_rather_than_arxiv() {
+    let td = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .env("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8"))
+        .env("DOIGET_LOG_PATH", "")
+        .args(["fetch", "not-a-doi"])
+        .assert()
+        .stderr(
+            predicate::str::contains("neither a DOI")
+                .and(predicate::str::contains("nor an arXiv id")),
+        );
+}

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -2313,10 +2313,25 @@ mod tests {
     }
 
     #[test]
-    fn ref_parse_bare_without_10_prefix_uses_arxiv_errors() {
-        // Bare ambiguous fallback: ArxivId parser is dispatched and its
-        // error surfaces. `1.2.3` is neither a DOI nor an arXiv shape.
-        assert_eq!(Ref::parse("1.2.3"), Err(RefParseError::InvalidArxivShape));
+    fn ref_parse_bare_without_10_prefix_reports_neither_shape() {
+        // The comment on this test always said the right thing -- "`1.2.3`
+        // is neither a DOI nor an arXiv shape" -- while the assertion said
+        // `InvalidArxivShape`, which is the fallback parser's verdict
+        // rather than the truth about the input (#477). Someone who
+        // mistyped a DOI was told about arXiv id shapes.
+        assert_eq!(Ref::parse("1.2.3"), Err(RefParseError::UnrecognisedShape));
+    }
+
+    #[test]
+    fn an_explicit_arxiv_scheme_still_reports_the_arxiv_shape_error() {
+        // The narrowing in #477 applies ONLY to the ambiguous fall-through.
+        // When the caller declared `arxiv:`, the arXiv parser's verdict IS
+        // the truth about the input, and generalising it there would lose
+        // information rather than gain it.
+        assert_eq!(
+            Ref::parse("arxiv:1.2.3"),
+            Err(RefParseError::InvalidArxivShape)
+        );
     }
 
     #[test]

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -263,7 +263,13 @@ impl Ref {
         if s.starts_with("10.") {
             return Doi::parse(s).map(Ref::Doi);
         }
-        ArxivId::parse(s).map(Ref::Arxiv)
+        // Last resort. The input declared no scheme and has no `10.`
+        // prefix, so trying arXiv is a guess -- and reporting the guess's
+        // failure verbatim tells a user who mistyped a DOI about arXiv
+        // (#477). Report what is actually known: it matched neither.
+        ArxivId::parse(s)
+            .map(Ref::Arxiv)
+            .map_err(|_| RefParseError::UnrecognisedShape)
     }
 }
 
@@ -524,6 +530,14 @@ pub enum RefParseError {
     /// Input matched neither the new-style nor old-style arXiv shape.
     #[error("input does not match any known arXiv id shape")]
     InvalidArxivShape,
+    /// Input carried no scheme and no `10.` prefix, so it could have been
+    /// either kind of ref, and it was neither.
+    ///
+    /// #477: the fall-through used to report [`Self::InvalidArxivShape`],
+    /// so someone who mistyped a DOI was told about arXiv. The input names
+    /// no shape, so neither should the error.
+    #[error("input is neither a DOI (expected '10.<registrant>/<suffix>') nor an arXiv id")]
+    UnrecognisedShape,
 }
 
 impl From<RefParseError> for ErrorCode {


### PR DESCRIPTION
Closes #477.

```
$ doiget fetch  not-a-doi
error[INVALID_REF]: invalid ref: …

$ doiget info   not-a-doi
Error: invalid ref: not-a-doi

Caused by:
    …
```

**Eight of nine** ref-taking commands printed the second shape. #119 gave `fetch` the contract and nothing generalised it, so `info`, `link`, `cite`, `text`, `tag`, `bib`, `csl` and `source` each wrote their own `with_context("invalid ref: …")` and let `anyhow` dump a bare `Error:` plus a `Caused by:` chain — leaking internal error types that belong to no contract, on a surface whose callers are told they can key off `error[CODE]:`.

Same shape as #442 / #454 / #458: the correct mechanism existed, was documented as shared (`render_fetch_error` is `pub(crate)` *precisely* so this would not happen), and most call sites did not go through it.

- `commands::render_ref_parse_error` — the one renderer.
- `commands::parse_ref_or_exit` — renderer + `CliExit`, used by the eight.
- `fetch` and `graph` route through the renderer, keeping the exit codes they already had.

## Three judgement calls worth flagging

**Exit codes are deliberately untouched.** `fetch` exits 1 and `graph` exits 2 for the same input, and `ERRORS.md` §4 says misuse is 2 — so they disagree and `graph` is the one following the table. But `fetch`'s 1 is pinned by a test someone named `fetch_invalid_ref_emits_cargo_style_error_and_exit_1`, so either §4 is right and the test enshrined a bug, or §4 is incomplete. Opposite changes, so it wants a decision, not a patch: **filed as #492**. The eight converted commands keep the exit 1 anyhow already gave them, so this PR changes no exit code anywhere.

**`verify` gets the misuse form, not a code.** It takes a path, so an unusable value is a missing file rather than a bad ref. The closed `ErrorCode` set describes *fetch outcomes* and has no member for "your input file is missing"; inventing one is a wire change to a NORMATIVE closed set and deserves its own decision. So it renders `error: failed to read reference file …` with exit 2 per §4 — the same bare-`error:` misuse shape the CLI already uses for e.g. `config --network` on the wrong action.

**The arXiv message.** `Ref::parse` falls through to the arXiv parser for anything with no scheme and no `10.` prefix, and reported that parser's verdict verbatim — so a mistyped DOI was answered *"input does not match any known arXiv id shape"*. New `RefParseError::UnrecognisedShape` says it matched neither, which is what is actually known. The narrowing applies **only** to the ambiguous fall-through: an explicit `arxiv:` scheme still reports `InvalidArxivShape`, because there the parser's verdict *is* the truth, and there is now a test for each.

An existing test asserted the old variant while its own comment read *"`1.2.3` is neither a DOI nor an arXiv shape"* — the comment was right and the assertion pinned the fallback's verdict.

## The test is the point

`every_ref_taking_command_emits_the_error_code_contract` drives all ten through the real binary and asserts the first stderr line starts with `error[` and that no `Caused by:` chain appears. Table-driven, so a new ref-taking subcommand is either added to the list or is not covered, and a failure **names which command regressed**:

```
these commands do not honour the error[CODE] contract for an invalid ref:
  info: Error: invalid ref: not a doi
  info: leaked a `Caused by:` chain
```

That is the mutation output from reverting `info.rs` alone. Reverting the parse fall-through fails only the arXiv-message test.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,citation`, and the full `oa-only,metadata,tdm-*` set.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features oa-only,citation`.
- `cargo test --workspace --all-targets --no-default-features --features oa-only,citation`.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.9`.

Refs #119, #287, #462, #492, ADR-0023
