### PR TITLE
fix(legal): fetch arXiv at the rate its Terms of Use publish (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[legal]** arXiv is fetched at the rate its Terms of Use publish — one request
+  every three seconds over a single connection — instead of 15x that rate and 5x
+  the concurrency. `RateLimits` had no per-source dimension at all, and three
+  places in the tree, including `docs/SOURCES.md`, asserted the global 5/sec cap
+  "comfortably respects" the guideline. §6 of the same document promised doiget
+  would adopt a stricter vendor value per source; the promise was real and the
+  mechanism did not exist (#493, ADR-0045).
+
 - **[cli]** Every ref-taking command emits the `docs/ERRORS.md` §3 contract
   line — `error[INVALID_REF]: invalid ref: …` — for an unparsable input.
   #119 gave `fetch` the contract and nothing generalised it, so `info`,
@@ -84,6 +92,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[core]** `SOURCE_RATE_OVERRIDES` plus `RateLimits::backoff_ms_for` /
+  `max_concurrent_for`. Library constants keyed by source name — never
+  caller-supplied, since `docs/LEGAL.md` §6a safeguard 5 makes `RateLimits`
+  unsynthesizable on purpose. An entry can only ever TIGHTEN: the accessors take
+  the stricter of the global value and the entry, and a test pins the table so an
+  entry that would be silently ignored fails the build (#493, ADR-0045).
+- **[core]** `RateLimiter::pace` for additional requests inside one attempt.
+  arXiv's terms cap requests and one arXiv attempt issues two — the Atom feed,
+  then the PDF — so the second was previously unpaced (#493).
 - **[cli]** `list-recent --missing-pdf` lists only the metadata-only entries —
   "which of my batch need retrying?" without reading a fifty-row table by eye
   (#481).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.9"
+version = "0.8.10-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.9"
+version = "0.8.10-beta.10"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.9"
+version = "0.8.10-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.9"
+version       = "0.8.10-beta.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.9" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.9" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.9" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.10" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.10" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.10" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1007,9 +1007,89 @@ impl RateLimits {
     }
 
     /// Per-source backoff in milliseconds between consecutive requests.
+    ///
+    /// The floor that applies to every source. A source whose vendor
+    /// publishes something stricter gets that instead -- see
+    /// [`Self::backoff_ms_for`].
     pub const fn per_source_backoff_ms(&self) -> u64 {
         self.per_source_backoff_ms
     }
+
+    /// The minimum gap between two requests to `source`, in milliseconds.
+    ///
+    /// [`Self::per_source_backoff_ms`] unless [`SOURCE_RATE_OVERRIDES`]
+    /// names a stricter value, in which case the stricter one wins. Never
+    /// looser: `docs/SOURCES.md` promises doiget adopts a stricter vendor
+    /// guideline at the per-source level rather than relaxing the global
+    /// cap, and `max` here is what makes that promise structural instead of
+    /// a matter of getting every table entry right.
+    #[must_use]
+    pub fn backoff_ms_for(&self, source: &str) -> u64 {
+        match source_rate(source) {
+            Some(r) => r.min_interval_ms.max(self.per_source_backoff_ms),
+            None => self.per_source_backoff_ms,
+        }
+    }
+
+    /// The concurrency ceiling for `source`.
+    ///
+    /// Clamped to [`Self::max_concurrent_fetches`], so a table entry can
+    /// only ever tighten the global cap.
+    #[must_use]
+    pub fn max_concurrent_for(&self, source: &str) -> u32 {
+        match source_rate(source) {
+            Some(r) => r.max_concurrent.min(self.max_concurrent_fetches),
+            None => self.max_concurrent_fetches,
+        }
+    }
+}
+
+/// A vendor-published rate guideline stricter than the global cap.
+///
+/// Library constants selected by source key, never caller-supplied:
+/// `docs/LEGAL.md` §6a safeguard 5 makes [`RateLimits`] unsynthesizable by
+/// downstream code on purpose, and a per-source table that took values from
+/// a caller would hand back exactly what that safeguard withholds.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct SourceRate {
+    /// Minimum milliseconds between two requests to this source.
+    pub min_interval_ms: u64,
+    /// Maximum simultaneous requests to this source.
+    pub max_concurrent: u32,
+}
+
+/// Sources whose published terms are stricter than the global cap.
+///
+/// #493. The global cap is 5 requests/second and 5 concurrent, against
+/// arXiv's published *"make no more than one request every three seconds,
+/// and limit requests to a single connection at a time"* -- 15x the rate
+/// and 5x the concurrency. Three places in the tree asserted the global cap
+/// "comfortably respects" it.
+///
+/// A table rather than a config knob, and consulted through
+/// [`RateLimits::backoff_ms_for`] rather than read directly, so an entry can
+/// only ever tighten.
+///
+/// Keys are [`crate::source::Source::name`] values.
+pub const SOURCE_RATE_OVERRIDES: &[(&str, SourceRate)] = &[(
+    // <https://info.arxiv.org/help/api/tou.html>, read 2026-08-25. The
+    // limit is collective across every machine under the caller's control,
+    // and circumventing it may have access blocked.
+    "arxiv",
+    SourceRate {
+        min_interval_ms: 3_000,
+        max_concurrent: 1,
+    },
+)];
+
+/// The override for `source`, if any.
+#[must_use]
+pub fn source_rate(source: &str) -> Option<SourceRate> {
+    SOURCE_RATE_OVERRIDES
+        .iter()
+        .find(|(k, _)| *k == source)
+        .map(|(_, r)| *r)
 }
 
 /// A successful TDM grant.

--- a/crates/doiget-core/src/rate_limiter.rs
+++ b/crates/doiget-core/src/rate_limiter.rs
@@ -41,12 +41,19 @@ pub struct RateLimiter {
     global_starts: Arc<Mutex<Vec<Instant>>>,
     // Earliest-allowed start time per source name.
     per_source_next: Arc<Mutex<HashMap<String, Instant>>>,
+    // #493: per-source concurrency, for sources whose terms cap it below
+    // the global semaphore. Created lazily so a source with no override
+    // costs nothing.
+    per_source_sem: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
 }
 
 /// Held while a fetch is in flight; releases the concurrency slot on drop.
 #[derive(Debug)]
 pub struct Permit {
     _slot: OwnedSemaphorePermit,
+    // #493: held for the same lifetime as the global slot when the source
+    // has a stricter concurrency cap.
+    _source_slot: Option<OwnedSemaphorePermit>,
 }
 
 impl RateLimiter {
@@ -58,7 +65,37 @@ impl RateLimiter {
             sem: Arc::new(Semaphore::new(max)),
             global_starts: Arc::new(Mutex::new(Vec::new())),
             per_source_next: Arc::new(Mutex::new(HashMap::new())),
+            per_source_sem: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Wait out the per-source interval for one ADDITIONAL request inside a
+    /// fetch that already holds a [`Permit`].
+    ///
+    /// #493. arXiv's terms cap *requests*, and one arXiv attempt issues two
+    /// of them -- the Atom feed, then the PDF -- under a single `acquire`.
+    /// The second was previously unpaced, so even a perfectly serialised
+    /// caller sent two requests back to back.
+    ///
+    /// Does not touch the concurrency slots: the caller already holds them,
+    /// and taking them again would deadlock at `max_concurrent_for == 1`,
+    /// which is exactly the arXiv case.
+    pub async fn pace(&self, source: &str) {
+        let backoff = Duration::from_millis(self.limits.backoff_ms_for(source));
+        let mut next_map = self.per_source_next.lock().await;
+        if let Some(&next) = next_map.get(source) {
+            if Instant::now() < next {
+                drop(next_map);
+                sleep_until(next).await;
+                next_map = self.per_source_next.lock().await;
+            }
+        }
+        let start = Instant::now();
+        next_map.insert(source.to_string(), start + backoff);
+        drop(next_map);
+
+        let mut starts = self.global_starts.lock().await;
+        starts.push(start);
     }
 
     /// Block until a slot is available, then return a [`Permit`].
@@ -109,9 +146,38 @@ impl RateLimiter {
             sleep_until(wake).await;
         }
 
+        // Step 2b: per-source concurrency (#493). After the global
+        // semaphore, so the global cap is still the ceiling, and before the
+        // interval wait, so a source capped at one connection serialises
+        // rather than piling up sleepers.
+        let source_slot = {
+            let cap = self.limits.max_concurrent_for(source) as usize;
+            if cap >= self.limits.max_concurrent_fetches() as usize {
+                None
+            } else {
+                let sem = {
+                    let mut map = self.per_source_sem.lock().await;
+                    Arc::clone(
+                        map.entry(source.to_string())
+                            .or_insert_with(|| Arc::new(Semaphore::new(cap))),
+                    )
+                };
+                #[allow(clippy::expect_used)]
+                Some(
+                    sem.acquire_owned()
+                        .await
+                        .expect("per-source semaphore is never closed"),
+                )
+            }
+        };
+
         // Step 3: per-source backoff. Acquire `per_source_next` strictly
         // after dropping `global_starts` above (lock order documented).
-        let backoff = Duration::from_millis(self.limits.per_source_backoff_ms());
+        //
+        // #493: `backoff_ms_for`, not `per_source_backoff_ms` -- the
+        // vendor's published guideline when it is stricter than the global
+        // 200 ms floor.
+        let backoff = Duration::from_millis(self.limits.backoff_ms_for(source));
         let mut next_map = self.per_source_next.lock().await;
         let now = Instant::now();
         if let Some(&next) = next_map.get(source) {
@@ -134,7 +200,10 @@ impl RateLimiter {
         starts.push(start);
         drop(starts);
 
-        Permit { _slot: slot }
+        Permit {
+            _slot: slot,
+            _source_slot: source_slot,
+        }
     }
 
     /// Tell the limiter to delay further starts to `source` by at least
@@ -307,5 +376,89 @@ mod tests {
             elapsed_x,
             delay
         );
+    }
+
+    // ---- #493: a vendor guideline stricter than the global cap ---------
+
+    /// arXiv publishes one request every three seconds. The global cap is
+    /// 5/s, so before #493 two consecutive arXiv requests were 200 ms
+    /// apart -- 15x the permitted rate -- while three places in the tree
+    /// asserted the global cap "comfortably respects" the guideline.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn arxiv_requests_are_three_seconds_apart() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        let t0 = Instant::now();
+        drop(rl.acquire("arxiv").await);
+        drop(rl.acquire("arxiv").await);
+        let elapsed = Instant::now() - t0;
+        assert!(
+            elapsed >= Duration::from_millis(3_000),
+            "arXiv requests must be >= 3 s apart; got {elapsed:?}"
+        );
+    }
+
+    /// The table only ever tightens. A source with no entry keeps the
+    /// global 200 ms floor, so the fix cannot have slowed everything else
+    /// down by accident.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn a_source_without_an_override_keeps_the_global_backoff() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        let t0 = Instant::now();
+        drop(rl.acquire("crossref").await);
+        drop(rl.acquire("crossref").await);
+        let elapsed = Instant::now() - t0;
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "the global floor still applies; got {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(3_000),
+            "crossref has no override and must not inherit arXiv's; got {elapsed:?}"
+        );
+    }
+
+    /// The second request of ONE arXiv attempt is paced too. arXiv caps
+    /// requests, not attempts, and an attempt issues two -- the Atom feed
+    /// and the PDF -- under a single permit (#493).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn pace_spaces_a_second_request_inside_one_attempt() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        let permit = rl.acquire("arxiv").await;
+        let t0 = Instant::now();
+        // Deliberately while the permit is still held: `pace` must not
+        // touch the concurrency slots, or arXiv's cap of one connection
+        // would deadlock against itself.
+        rl.pace("arxiv").await;
+        let elapsed = Instant::now() - t0;
+        drop(permit);
+        assert!(
+            elapsed >= Duration::from_millis(3_000),
+            "the second leg must wait out the interval; got {elapsed:?}"
+        );
+    }
+
+    /// The table is a ceiling-tightener, not a general knob: an entry that
+    /// tried to be *looser* than the global settings must not take effect.
+    #[test]
+    fn an_override_can_only_tighten() {
+        let l = RateLimits::HARD_CODED;
+        assert_eq!(l.backoff_ms_for("arxiv"), 3_000);
+        assert_eq!(l.backoff_ms_for("crossref"), l.per_source_backoff_ms());
+        assert_eq!(l.max_concurrent_for("arxiv"), 1);
+        assert_eq!(l.max_concurrent_for("crossref"), l.max_concurrent_fetches());
+        // Every entry is at least as strict as the global cap on both axes.
+        // `backoff_ms_for` / `max_concurrent_for` enforce it at call time;
+        // this pins the TABLE, so a future entry cannot be added in the
+        // belief that it relaxes something and then silently do nothing.
+        for (name, r) in crate::SOURCE_RATE_OVERRIDES {
+            assert!(
+                r.min_interval_ms >= l.per_source_backoff_ms(),
+                "{name}: an override looser than the global floor is silently ignored"
+            );
+            assert!(
+                r.max_concurrent <= l.max_concurrent_fetches(),
+                "{name}: an override cannot raise the global concurrency cap"
+            );
+        }
     }
 }

--- a/crates/doiget-core/src/rate_limiter.rs
+++ b/crates/doiget-core/src/rate_limiter.rs
@@ -81,6 +81,14 @@ impl RateLimiter {
     /// and taking them again would deadlock at `max_concurrent_for == 1`,
     /// which is exactly the arXiv case.
     pub async fn pace(&self, source: &str) {
+        // The global cap admits this request too. Review of #493 caught the
+        // first draft pushing a start into `global_starts` WITHOUT waiting
+        // on the window -- which inflates the window for every other source
+        // while never being bounded by it. It cannot bite at arXiv's 3 s
+        // interval, and "it cannot bite in practice" is the reasoning that
+        // produced #493 in the first place.
+        self.await_global_rate_window().await;
+
         let backoff = Duration::from_millis(self.limits.backoff_ms_for(source));
         let mut next_map = self.per_source_next.lock().await;
         if let Some(&next) = next_map.get(source) {
@@ -122,29 +130,8 @@ impl RateLimiter {
             .await
             .expect("rate-limiter semaphore is never closed");
 
-        // Step 2: global rate cap. Loop until the rolling-second window has
-        // room, sleeping until the oldest entry ages out if it does not.
-        let max_per_sec = self.limits.max_fetches_per_second() as usize;
-        let one_sec = Duration::from_secs(1);
-        loop {
-            let mut starts = self.global_starts.lock().await;
-            let now = Instant::now();
-            // Prune entries older than 1 s. starts is FIFO so we can drop
-            // a contiguous prefix.
-            let cutoff = now.checked_sub(one_sec).unwrap_or(now);
-            let drop_count = starts.iter().take_while(|t| **t <= cutoff).count();
-            if drop_count > 0 {
-                starts.drain(..drop_count);
-            }
-            if starts.len() < max_per_sec {
-                break;
-            }
-            // Window is full — wake at the moment the oldest entry ages out.
-            // starts.len() >= max_per_sec >= 1 here, so [0] is safe.
-            let wake = starts[0] + one_sec;
-            drop(starts);
-            sleep_until(wake).await;
-        }
+        // Step 2: global rate cap.
+        self.await_global_rate_window().await;
 
         // Step 2b: per-source concurrency (#493). After the global
         // semaphore, so the global cap is still the ceiling, and before the
@@ -203,6 +190,35 @@ impl RateLimiter {
         Permit {
             _slot: slot,
             _source_slot: source_slot,
+        }
+    }
+
+    /// Block until the global rolling-second window has room.
+    ///
+    /// Loops because another task may take the slot between the wake and
+    /// the re-check. Holds only `global_starts`, and never across a sleep,
+    /// so it composes with the documented lock order.
+    async fn await_global_rate_window(&self) {
+        let max_per_sec = self.limits.max_fetches_per_second() as usize;
+        let one_sec = Duration::from_secs(1);
+        loop {
+            let mut starts = self.global_starts.lock().await;
+            let now = Instant::now();
+            // Prune entries older than 1 s. `starts` is FIFO, so this is a
+            // contiguous prefix.
+            let cutoff = now.checked_sub(one_sec).unwrap_or(now);
+            let drop_count = starts.iter().take_while(|t| **t <= cutoff).count();
+            if drop_count > 0 {
+                starts.drain(..drop_count);
+            }
+            if starts.len() < max_per_sec {
+                return;
+            }
+            // Window is full -- wake when the oldest entry ages out.
+            // `starts.len() >= max_per_sec >= 1` here, so `[0]` is safe.
+            let wake = starts[0] + one_sec;
+            drop(starts);
+            sleep_until(wake).await;
         }
     }
 
@@ -434,6 +450,30 @@ mod tests {
         assert!(
             elapsed >= Duration::from_millis(3_000),
             "the second leg must wait out the interval; got {elapsed:?}"
+        );
+    }
+
+    /// `pace` is admitted by the global window, not merely recorded in it.
+    ///
+    /// Found by reading the diff, not by a failing test -- the first draft
+    /// pushed a start into `global_starts` without ever waiting on the
+    /// window, so an extra request inflated the cap for every other source
+    /// while being bounded by none of it. Unreachable at arXiv's 3 s
+    /// interval, which is precisely the argument that let #493 ship.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn pace_is_admitted_by_the_global_window_too() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        // Fill the rolling second to the global maximum, on distinct
+        // sources so no per-source interval is in play.
+        for s in ["a", "b", "c", "d", "e"] {
+            drop(rl.acquire(s).await);
+        }
+        let t0 = Instant::now();
+        rl.pace("f").await;
+        let elapsed = Instant::now() - t0;
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "pace must wait for the global window exactly as acquire does; got {elapsed:?}"
         );
     }
 

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -1,8 +1,15 @@
 //! arXiv source — arXiv id → PDF + Atom-feed metadata.
 //!
-//! Spec: `docs/SOURCES.md` §4 arXiv. No auth; the API has a 3-second-per-request
-//! rate guideline that doiget's 5/sec global + 200ms per-source backoff
-//! comfortably respects (no extra source-specific tuning needed).
+//! Spec: `docs/SOURCES.md` §4 arXiv. No auth. The API's Terms of Use cap
+//! requests at **one every three seconds, single connection** — stricter
+//! than the global 5/sec + 200 ms backoff, which this comment previously
+//! claimed "comfortably respects" it. It did not: that was 15x the rate and
+//! 5x the concurrency (#493, ADR-0045).
+//!
+//! The limit now comes from [`crate::SOURCE_RATE_OVERRIDES`], and because
+//! it caps REQUESTS rather than attempts, the PDF leg below calls
+//! [`crate::rate_limiter::RateLimiter::pace`] — one attempt issues two
+//! requests, and only the first was paced by the permit.
 //!
 //! # Fetch flow (full)
 //!
@@ -277,6 +284,14 @@ impl Source for ArxivSource {
         };
 
         // ----- PDF leg -------------------------------------------------
+        //
+        // #493: arXiv's terms cap REQUESTS, not attempts, and this is the
+        // second request of this attempt -- the Atom leg above was the
+        // first. The `acquire` permit paced that one; without this the two
+        // went out back to back, so even a perfectly serialised caller
+        // broke the published interval.
+        ctx.rate_limiter.pace(self.name()).await;
+
         let url = self.pdf_url(id)?;
 
         // `fetch_pdf` enforces the magic-byte check (`%PDF-`) per

--- a/docs/DECISIONS/0045-per-source-rate-limits.md
+++ b/docs/DECISIONS/0045-per-source-rate-limits.md
@@ -1,0 +1,108 @@
+# 0045 - Per-source rate limits, taken as the stricter of the vendor's terms and the global cap
+
+- **Date:** 2026-08-25
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #493 (arXiv fetched at 15x its published rate), #496 (no vendor limit recorded anywhere), #498 (the 2026-08-25 vendor-terms audit)
+
+## Context
+
+`RateLimits` carried three numbers for the whole process: 5 concurrent fetches,
+5 requests per second, 200 ms between consecutive requests to the same source.
+There was no per-source dimension at all.
+
+arXiv's [API Terms of Use](https://info.arxiv.org/help/api/tou.html) say:
+
+> make no more than one request every three seconds, and limit requests to a
+> single connection at a time
+
+That is **15x the permitted rate and 5x the permitted concurrency**, on a Tier-1
+always-on source that ships in every published binary. The page adds that the
+limit is collective across every machine under the caller's control and that
+circumventing it may have access blocked.
+
+Three places asserted the opposite — `sources/arxiv.rs`, `docs/SOURCES.md` §4,
+and, worst, `docs/SOURCES.md` §6:
+
+> If a source publishes a stricter rate guideline, doiget will adopt the stricter
+> value at the per-source level rather than relax the global cap.
+
+arXiv publishes exactly such a guideline. Nothing adopted it. The promise was
+real and the mechanism to keep it did not exist.
+
+A second, quieter problem: arXiv's terms cap **requests**, and one arXiv attempt
+issues **two** — the Atom feed, then the PDF — under a single `acquire`. Even a
+perfectly serialised caller sent those back to back.
+
+## Decision
+
+**D1 — A per-source table of vendor guidelines, as library constants.**
+
+`SOURCE_RATE_OVERRIDES: &[(&str, SourceRate)]`, keyed by `Source::name`, with
+`SourceRate { min_interval_ms, max_concurrent }`. arXiv is 3000 ms / 1.
+
+Constants, not configuration, and not caller-supplied. `docs/LEGAL.md` §6a
+safeguard 5 makes `RateLimits` unsynthesizable by downstream code on purpose;
+a per-source table that accepted caller values would hand back precisely what
+that safeguard withholds.
+
+**D2 — An entry can only tighten.**
+
+Callers go through `RateLimits::backoff_ms_for(source)` and
+`max_concurrent_for(source)`, which return `max(global, entry)` and
+`min(global, entry)` respectively. The global cap stays the ceiling.
+
+This is the load-bearing part. §6's promise was kept by intention before, and
+intention is what failed. Taking the stricter of the two makes it impossible for
+a table entry to relax anything even if someone writes one that tries, and the
+table itself is pinned by a test asserting every entry is at least as strict as
+the global cap on both axes — so an entry that would be silently ignored fails
+the build instead of sitting there looking effective.
+
+**D3 — Concurrency is enforced with a per-source semaphore, after the global one.**
+
+Ordering matters: global semaphore first (the ceiling still binds), then the
+per-source one, then the interval wait. A source capped at one connection
+therefore serialises rather than accumulating sleepers behind a shared interval.
+
+**D4 — `RateLimiter::pace(source)` for additional requests inside one attempt.**
+
+It waits out the source's interval and records the start, without touching the
+concurrency slots — the caller already holds them, and re-taking them would
+deadlock at `max_concurrent == 1`, which is exactly the arXiv case. The arXiv
+PDF leg calls it.
+
+The alternative — one `acquire` per HTTP request — would have been cleaner in
+the abstract and wrong here: the permit's lifetime is what bounds concurrency
+for the whole attempt, and splitting it would let a second attempt interleave
+between one attempt's two legs.
+
+## Consequences
+
+**arXiv fetches are now ~6 s per paper** (two paced requests), against well under
+a second before. That is the rate the vendor publishes. A batch of arXiv refs is
+correspondingly slower, and there is no opt-out: per D1 there is no knob, and per
+LEGAL.md §6a there should not be one.
+
+**Nothing else changes.** Every source without an entry keeps the 200 ms floor
+and the global concurrency cap; there is a test for that specifically, so this
+change cannot have slowed the rest of the tree by accident.
+
+**The table is now the place vendor limits are recorded.** #496 tracks the ones
+still unwritten (Springer's tier system, CORE's 10/min token bucket, OpenAlex).
+Adding them is an entry each, not a redesign — which is the point of doing the
+mechanism and arXiv together rather than per source.
+
+**`docs/SOURCES.md` is `Status: NORMATIVE`**, so per ADR-0014 this ADR is the
+record for the change to §4 and §6.
+
+## Alternatives rejected
+
+- **Lower the global cap to 1 request / 3 s.** Correct for arXiv, absurd for
+  Crossref, and it would make every other source pay arXiv's price.
+- **A config knob.** Directly against LEGAL.md §6a safeguard 5 and safeguard 8:
+  the rate limit is hard-coded so that it cannot be argued with.
+- **Pace only between attempts, not within one.** Leaves the measured violation
+  in place — arXiv counts requests, and an attempt is two of them.
+- **Per-source `Retry-After` only, reacting to 429s.** Reactive, and the terms
+  are a *guideline to observe*, not a limit to discover by tripping it.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -61,6 +61,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0042 | `tdm-ieee` ships against an inferred contract, marked unverified | Accepted (0.8.9) | `feat/430-tdm-ieee` | #430 |
 | 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
 | 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
+| 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
 
 ## Conventions
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -39,7 +39,8 @@ This is enforced structurally rather than only by documentation:
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
   runtime. See [`CAPABILITY.md`](CAPABILITY.md).
-- A hard-coded rate limit (5 concurrent fetches, 5/second) prevents bulk-scraping
+- A hard-coded rate limit (5 concurrent fetches, 5/second — stricter still for
+  sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
 ## 3. Tool-neutrality framing
@@ -141,8 +142,22 @@ them requires changing source files that are gated by branch protection.
    `MAX_FETCHES_PER_SECOND = 5.0` are library constants. The struct
    `RateLimits` exposes only `HARD_CODED`; field visibility is `pub(crate)`,
    so external callers cannot synthesize a `RateLimits` with different
-   values. *Enforced by:* `pub(crate)` field visibility,
-   `#[non_exhaustive]` on `RateLimits`, smoke tests in `lib.rs::tests`.
+   values.
+
+   Those two are the **ceiling**, not the whole limit. A source whose vendor
+   publishes something stricter is held to the stricter value, from the
+   `SOURCE_RATE_OVERRIDES` table (ADR-0045) — arXiv, for instance, at one
+   request every three seconds over a single connection. Table entries are
+   library constants for the same reason `RateLimits` is: an override a
+   caller could supply would hand back exactly what this safeguard
+   withholds. `RateLimits::backoff_ms_for` and `max_concurrent_for` return
+   the stricter of the global value and the entry, so an entry can only ever
+   tighten. *Enforced by:* `pub(crate)` field visibility,
+   `#[non_exhaustive]` on `RateLimits`, the `max`/`min` in those two
+   accessors, and smoke tests in `lib.rs::tests` and
+   `rate_limiter.rs::tests` — including one that fails the build if a table
+   entry is looser than the global cap and would therefore be silently
+   ignored.
 
 ### 6b. Policy commitments (3)
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -120,8 +120,14 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 ### arXiv
 
-- Public, no-auth API, but the API has a 3-second-per-request rate guideline. doiget's
-  global 5/sec cap respects this.
+- Public, no-auth API. Its [Terms of Use](https://info.arxiv.org/help/api/tou.html)
+  cap requests at **one every three seconds, over a single connection**, collectively
+  across every machine under the caller's control.
+- doiget applies that per-source, via `SOURCE_RATE_OVERRIDES` (ADR-0045). One arXiv
+  *attempt* issues two *requests* — the Atom feed, then the PDF — and both are paced,
+  because the guideline counts requests.
+- This page previously claimed the global 5/sec cap "respects this". It did not: the
+  effective rate was 15x the guideline and the concurrency 5x (#493).
 - doiget uses arXiv for: arXiv id → PDF + metadata. The parsed metadata
   also carries the **published DOI** and **journal reference** when the
   submitter supplied them (`<arxiv:doi>` / `<arxiv:journal_ref>`) — the
@@ -272,5 +278,15 @@ doiget's defaults are designed to be on the polite side of every source we know 
 - `User-Agent: doiget/<version> (+https://github.com/QAtlasHub/doiget)`.
 - Honors `Retry-After` headers (treats 429 as `RATE_LIMITED` with the indicated wait).
 
-If a source publishes a stricter rate guideline, doiget will adopt the stricter value at
-the per-source level rather than relax the global cap.
+If a source publishes a stricter rate guideline, doiget adopts the stricter value at
+the per-source level rather than relaxing the global cap. This is now mechanical rather
+than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the stricter
+of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
+only ever tighten (ADR-0045).
+
+| source | interval | connections | published terms |
+|---|---|---|---|
+| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+
+Every other source uses the global 200 ms floor and the global concurrency cap. Sources
+whose vendor limits are not yet recorded are tracked in #496.

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -126,8 +126,14 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 ### arXiv
 
-- Public, no-auth API, but the API has a 3-second-per-request rate guideline. doiget's
-  global 5/sec cap respects this.
+- Public, no-auth API. Its [Terms of Use](https://info.arxiv.org/help/api/tou.html)
+  cap requests at **one every three seconds, over a single connection**, collectively
+  across every machine under the caller's control.
+- doiget applies that per-source, via `SOURCE_RATE_OVERRIDES` (ADR-0045). One arXiv
+  *attempt* issues two *requests* — the Atom feed, then the PDF — and both are paced,
+  because the guideline counts requests.
+- This page previously claimed the global 5/sec cap "respects this". It did not: the
+  effective rate was 15x the guideline and the concurrency 5x (#493).
 - doiget uses arXiv for: arXiv id → PDF + metadata. The parsed metadata
   also carries the **published DOI** and **journal reference** when the
   submitter supplied them (`<arxiv:doi>` / `<arxiv:journal_ref>`) — the
@@ -278,5 +284,15 @@ doiget's defaults are designed to be on the polite side of every source we know 
 - `User-Agent: doiget/<version> (+https://github.com/QAtlasHub/doiget)`.
 - Honors `Retry-After` headers (treats 429 as `RATE_LIMITED` with the indicated wait).
 
-If a source publishes a stricter rate guideline, doiget will adopt the stricter value at
-the per-source level rather than relax the global cap.
+If a source publishes a stricter rate guideline, doiget adopts the stricter value at
+the per-source level rather than relaxing the global cap. This is now mechanical rather
+than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the stricter
+of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
+only ever tighten (ADR-0045).
+
+| source | interval | connections | published terms |
+|---|---|---|---|
+| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+
+Every other source uses the global 200 ms floor and the global concurrency cap. Sources
+whose vendor limits are not yet recorded are tracked in #496.

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -45,7 +45,8 @@ This is enforced structurally rather than only by documentation:
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
   runtime. See [`CAPABILITY.md`](CAPABILITY.md).
-- A hard-coded rate limit (5 concurrent fetches, 5/second) prevents bulk-scraping
+- A hard-coded rate limit (5 concurrent fetches, 5/second — stricter still for
+  sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
 ## 3. Tool-neutrality framing
@@ -147,8 +148,22 @@ them requires changing source files that are gated by branch protection.
    `MAX_FETCHES_PER_SECOND = 5.0` are library constants. The struct
    `RateLimits` exposes only `HARD_CODED`; field visibility is `pub(crate)`,
    so external callers cannot synthesize a `RateLimits` with different
-   values. *Enforced by:* `pub(crate)` field visibility,
-   `#[non_exhaustive]` on `RateLimits`, smoke tests in `lib.rs::tests`.
+   values.
+
+   Those two are the **ceiling**, not the whole limit. A source whose vendor
+   publishes something stricter is held to the stricter value, from the
+   `SOURCE_RATE_OVERRIDES` table (ADR-0045) — arXiv, for instance, at one
+   request every three seconds over a single connection. Table entries are
+   library constants for the same reason `RateLimits` is: an override a
+   caller could supply would hand back exactly what this safeguard
+   withholds. `RateLimits::backoff_ms_for` and `max_concurrent_for` return
+   the stricter of the global value and the entry, so an entry can only ever
+   tighten. *Enforced by:* `pub(crate)` field visibility,
+   `#[non_exhaustive]` on `RateLimits`, the `max`/`min` in those two
+   accessors, and smoke tests in `lib.rs::tests` and
+   `rate_limiter.rs::tests` — including one that fails the build if a table
+   entry is looser than the global cap and would therefore be silently
+   ignored.
 
 ### 6b. Policy commitments (3)
 


### PR DESCRIPTION
Closes #493. Adds ADR-0045. Stacked on #499 — merge that first.

> make no more than one request every three seconds, and limit requests to a single connection at a time
>
> — [arXiv API Terms of Use](https://info.arxiv.org/help/api/tou.html)

doiget ran a global 5 requests/second, 5 concurrent, 200 ms per-source backoff, and had **no per-source dimension at all**. That is **15x the permitted rate and 5x the permitted concurrency**, on a Tier-1 always-on source that ships in every published binary. The terms note the limit is collective across every machine under the caller's control, and that circumventing it may have access blocked.

Three places asserted the opposite. The worst is `docs/SOURCES.md` §6:

> If a source publishes a stricter rate guideline, doiget will adopt the stricter value at the per-source level rather than relax the global cap.

arXiv publishes exactly such a guideline. Nothing adopted it. **The promise was real and the mechanism to keep it did not exist.**

## The mechanism

`SOURCE_RATE_OVERRIDES`, keyed by `Source::name`. Library constants — not configuration, never caller-supplied: `docs/LEGAL.md` §6a safeguard 5 makes `RateLimits` unsynthesizable by downstream code on purpose, and a table that took caller values would hand back precisely what that safeguard withholds.

**An entry can only tighten.** `backoff_ms_for` returns `max(global, entry)`, `max_concurrent_for` returns `min(global, entry)`. The global cap stays the ceiling.

That is the load-bearing part. §6's promise was kept *by intention* before, and intention is what failed — so the accessors make it structurally impossible for an entry to relax anything, and a test pins the table itself so an entry that *would* be silently ignored fails the build rather than sitting there looking effective.

Per-source concurrency gets its own semaphore, taken **after** the global one so the ceiling still binds and a one-connection source serialises rather than accumulating sleepers behind a shared interval.

## The half that is easy to miss

arXiv's terms cap **requests**, and one arXiv attempt issues **two** — the Atom feed, then the PDF — under a single `acquire`. The second was unpaced, so even a perfectly serialised caller sent them back to back.

`RateLimiter::pace(source)` waits out the interval for an additional request **without touching the concurrency slots**: the caller already holds them, and re-taking them would deadlock at `max_concurrent == 1`, which is exactly the arXiv case.

The obvious alternative — one `acquire` per HTTP request — is cleaner in the abstract and wrong here: the permit's lifetime is what bounds concurrency for the whole attempt, and splitting it would let a second attempt interleave between one attempt's two legs.

## Cost, stated plainly

**arXiv is now ~6 s per paper**, against well under a second before. That is the rate the vendor publishes, and there is no opt-out by design (D1: no knob; LEGAL.md §6a safeguard 8: the limit is hard-coded so it cannot be argued with).

`fetch_arxiv_e2e` goes from instant to 6.2 s. **Nothing else moves** — there is a test asserting a source with no entry still gets the 200 ms floor and the global concurrency cap, so this cannot have slowed the rest of the tree by accident.

## Verified by mutation

| severed | fails |
|---|---|
| `acquire` back to the global floor | the arXiv-interval and `pace` tests |
| the override table emptied | those two **plus** the table-invariant test |
| `pace` made a no-op | the `pace` test, only |

## Corrections

- `sources/arxiv.rs` module comment — claimed the global cap "comfortably respects" the guideline.
- `docs/SOURCES.md` §4 — same claim, in a NORMATIVE doc.
- `docs/SOURCES.md` §6 — now describes the mechanism rather than promising it, and carries the per-source table with the vendor link.

`docs/SOURCES.md` is `Status: NORMATIVE`, so per ADR-0014 this ships with **ADR-0045**, which also records why the table is the place future vendor limits go (#496 tracks Springer, CORE and OpenAlex) so it is not re-litigated per source.

Refs #496, #498, ADR-0014
