### PR TITLE
docs(sources): correct what SOURCES.md claims, and repoint what it links to (#495, #496)

### DIFF
--- a/.github/workflows/tos-links.yml
+++ b/.github/workflows/tos-links.yml
@@ -1,0 +1,139 @@
+name: tos-links
+
+# #495 — the ToS column of `docs/SOURCES.md` §1 rots silently.
+#
+# Five of sixteen links were dead or pointing at the wrong document when the
+# 2026-08-25 audit checked them, and nothing had noticed. `docs/SOURCES.md` is
+# `Status: NORMATIVE (user responsibility advisory)`: its whole job is telling a
+# user where each source states its terms, so a 404 there is a broken promise
+# rather than a cosmetic defect.
+#
+# SCHEDULE ONLY, deliberately. A per-PR check would turn an unrelated PR red
+# because a publisher reorganised their website overnight — the wrong failure
+# mode, and the one that trains people to ignore a check. On a schedule, rot
+# opens an issue instead.
+#
+# Third-party Actions are SHA-pinned (repo invariant / ADR-0013 supply-chain).
+
+on:
+  schedule:
+    # Monthly, 1st at 07:15 UTC. Offset from audit.yml (weekly Mon 07:00),
+    # supply-chain.yml (Wed) and codeql.yml (Tue) so the scans do not pile up.
+    # Monthly rather than weekly: publisher sites move on a scale of months,
+    # and every run is outbound traffic to people who did not ask for it.
+    - cron: "15 7 1 * *"
+  # Manual trigger, so a row can be re-checked after a fix without waiting a
+  # month.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tos-links
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: ToS links in SOURCES.md resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      report: ${{ steps.check.outputs.report }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
+
+      - name: Request every link in the source matrix
+        id: check
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Only the §1 matrix: start at its header row, stop at the first
+          # line that is not a table row.
+          mapfile -t urls < <(
+            awk '/^\| Source \| Tier \|/{inmatrix=1; next}
+                 inmatrix && !/^\|/{exit}
+                 inmatrix' docs/SOURCES.md \
+              | grep -oE '<https://[^>]+>' \
+              | tr -d '<>' \
+              | sort -u
+          )
+
+          if [ "${#urls[@]}" -eq 0 ]; then
+            # Fail loudly rather than report a clean sweep of nothing. A table
+            # reformat that silently emptied this list would otherwise look
+            # exactly like "every link is healthy".
+            echo "::error::extracted zero URLs from the SOURCES.md matrix — the table shape changed and this check is no longer looking at anything"
+            exit 1
+          fi
+
+          echo "checking ${#urls[@]} links"
+          bad=""
+          for u in "${urls[@]}"; do
+            # Follow redirects: a 301 to the vendor's new canonical page is
+            # fine. The FINAL status and FINAL url are both reported, so a
+            # link that now lands somewhere unrelated is visible even at 200.
+            out=$(curl -sSL --max-time 30 --retry 2 --retry-delay 5 \
+                    -o /dev/null -w '%{http_code} %{url_effective}' "$u" || echo "000 -")
+            code=${out%% *}
+            final=${out#* }
+            if [ "$code" = "200" ]; then
+              printf '  ok   %s\n' "$u"
+              if [ "$final" != "$u" ]; then
+                printf '       -> redirected to %s\n' "$final"
+              fi
+            else
+              printf '  FAIL %s (%s)\n' "$u" "$code"
+              bad="${bad}- \`${u}\` -> HTTP ${code}"$'\n'
+            fi
+          done
+
+          if [ -n "$bad" ]; then
+            {
+              echo "report<<REPORT_EOF"
+              echo "$bad"
+              echo "REPORT_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "::error::one or more ToS links in docs/SOURCES.md did not return 200"
+            exit 1
+          fi
+
+  notify-cron-failure:
+    name: notify (cron failure)
+    needs: [check]
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPORT: ${{ needs.check.outputs.report }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          body=$(cat <<BODY
+          The scheduled \`tos-links\` check found a link in the \`docs/SOURCES.md\` source
+          matrix that did not return 200.
+
+          ${REPORT}
+
+          Run: ${RUN_URL}
+
+          \`docs/SOURCES.md\` is NORMATIVE and its stated job is to point at each source's
+          terms, so a dead entry is a broken promise rather than a cosmetic defect (#495).
+          Replace it with a page that states the terms — prefer a terms or policy page
+          over API docs or a schema URL.
+
+          Opened automatically; close it once the row is corrected.
+          BODY
+          )
+          gh issue create \
+            --title "docs: a ToS link in SOURCES.md no longer resolves ($(date -u +%Y-%m-%d))" \
+            --label "documentation,automated" \
+            --body "$body" \
+            --repo "${{ github.repository }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[docs]** Five of the sixteen ToS links in `docs/SOURCES.md` §1 no longer led to
+  terms — two 404s, one redirect to a docs-domain root, one to a Swagger schema, one
+  to a portal root. The Elsevier entry was wrong before it died: `legal/tdmrep` is the
+  W3C TDM **Reservation** Protocol, by which a rightsholder signals an opt-out *from*
+  mining, not Elsevier's API terms. All sixteen now resolve, measured (#495, ADR-0046).
+- **[docs]** `docs/SOURCES.md` no longer implies Springer restricts full text. Springer
+  publishes a Full Text (TDM) API and an Open Access API; staying metadata-only there
+  is doiget's conservative choice. The old sentence named Elsevier, Springer and IEEE
+  together with only Elsevier's reason attached, so the weaker cases inherited the
+  stronger one's justification (#496).
+- **[docs]** CORE's key is no longer called "optional". Unregistered use is a
+  token-cost tier — roughly a hundred simple queries a day — so a run can stop working
+  and "optional" gave the reader nothing to diagnose that with (#496).
+- **[docs]** The rate cap cites `LEGAL.md` §6a safeguard 5, the enforced control,
+  instead of §6b safeguard 8, which is marketing-language self-policing. The old
+  citation sent a reader looking for the enforcement basis to the section that has
+  none (#496).
+
 - **[legal]** arXiv is fetched at the rate its Terms of Use publish — one request
   every three seconds over a single connection — instead of 15x that rate and 5x
   the concurrency. `RateLimits` had no per-source dimension at all, and three
@@ -92,6 +110,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[docs]** `docs/SOURCES.md` §6.1 records what each vendor publishes as a rate limit
+  and what doiget does about it. §6 promised doiget adopts a stricter vendor guideline
+  per source while recording no vendor's limit anywhere, so the promise could not be
+  checked against anything. Springer's figures are left **blank and labelled** rather
+  than guessed — their page renders through JavaScript and the audit could not read
+  them, and a plausible wrong number destroys the table's only value (#496, ADR-0046).
+- **[ci]** `tos-links.yml` requests every §1 link monthly and opens an issue on any
+  non-200. Schedule-only by design: a publisher reorganising their site overnight must
+  not turn an unrelated PR red. It fails loudly if it extracts zero URLs, because a
+  table reformat that emptied the list would otherwise look exactly like a clean sweep
+  (#495, ADR-0046).
 - **[core]** `SOURCE_RATE_OVERRIDES` plus `RateLimits::backoff_ms_for` /
   `max_concurrent_for`. Library constants keyed by source name — never
   caller-supplied, since `docs/LEGAL.md` §6a safeguard 5 makes `RateLimits`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.10"
+version = "0.8.10-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.10"
+version = "0.8.10-beta.11"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.10"
+version = "0.8.10-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.10"
+version       = "0.8.10-beta.11"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.10" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.10" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.10" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.11" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.11" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.11" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
+++ b/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
@@ -1,0 +1,121 @@
+# 0046 - In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Refines:** [0014](0014-docs-class-system.md) — which requires an ADR for changes to NORMATIVE content, without saying whether a URL is content
+- **Source:** #495 (five of sixteen ToS links dead or wrong), #496 (CORE, Springer, rate limits, a mis-aimed cross-reference), #498 (the 2026-08-25 vendor-terms audit)
+
+## Context
+
+`docs/SOURCES.md` is `Status: NORMATIVE (user responsibility advisory)`. A
+2026-08-25 audit requested all sixteen links in its §1 matrix and read the prose
+against each vendor's current documentation. It found two different kinds of
+defect, and they do not want the same treatment.
+
+**Wrong claims.** The document asserted things about vendors that were false:
+
+- CORE's key was called "optional". Requests do resolve without one, at roughly a
+  hundred simple queries a day under a token-cost model — so a run stops working
+  and "optional" gives the reader nothing to diagnose it with.
+- `tdm-elsevier`, `tdm-springer` and `tdm-ieee` were named in one sentence as
+  metadata-only, with only Elsevier's reason attached. Springer publishes a Full
+  Text (TDM) API and an Open Access API; staying metadata-only there is doiget's
+  conservative choice, not a vendor restriction. The weaker case inherited the
+  stronger one's justification.
+- §6 promised doiget adopts a stricter vendor guideline per source, while
+  recording no vendor's published limit anywhere — so the promise could not be
+  checked against anything. (arXiv's, the one measured violation, is ADR-0045.)
+- The rate cap cited "LEGAL.md §6 safeguard 8". Safeguard 8 is marketing-language
+  self-policing in §6b, *policy commitments*. The cap is §6a.5, an *enforced
+  control*. The citation sent a reader looking for the enforcement basis to the
+  section that has none — inverting the meaning of the reference.
+
+**Rotted pointers.** Five links no longer led to terms:
+
+| row | was | result | now |
+|---|---|---|---|
+| Crossref | `crossref.org/services/metadata-retrieval/rest-api/` | 404 | `crossref.org/documentation/retrieve-metadata/rest-api/` |
+| Elsevier | `elsevier.com/legal/tdmrep` | 404 | `elsevier.com/about/policies-and-standards/text-and-data-mining` |
+| OpenAlex | `docs.openalex.org/how-to-use-the-api/api-overview` | 200 → redirects to the `help.openalex.org` root; deep target gone | `help.openalex.org/how-to/` |
+| DOAJ | `doaj.org/api` | 200 → redirects to `swagger.json`, a schema | `doaj.org/terms/` |
+| Springer | `dev.springernature.com/` | 200, portal root | `dev.springernature.com/terms-conditions/` |
+
+The Elsevier one was the worst even before it died: `tdmrep` is the **TDM
+Reservation Protocol**, the W3C-track standard by which a rightsholder
+machine-readably signals an opt-out *from* text and data mining. It is not
+Elsevier's API terms. The sole ToS reference for a Tier-3 source pointed at the
+wrong kind of document.
+
+## Decision
+
+**D1 — A claim about a vendor is NORMATIVE content. Changing one needs an ADR.**
+
+What a source requires, permits and limits is exactly what a user relies on this
+document for. This ADR is the record for the four corrections above.
+
+**D2 — Vendor-published limits are recorded in `SOURCES.md` §6.1, or their absence is.**
+
+§6's promise is only meaningful next to what the vendors actually publish. §6.1 now
+carries a row per source: the vendor's limit, what doiget does about it, and where
+the figure came from. A source running on the global cap says so, rather than leaving
+it to be inferred from silence.
+
+**A figure that could not be read is left blank and labelled.** Springer's
+rate-limit page renders its body through JavaScript and the audit could not extract
+the numbers, so the cell says so. A plausible-looking number would be worse than the
+gap, because the entire value of the table is that a reader can check it against the
+vendor.
+
+**D3 — A URL is a pointer, not a claim. Correcting one does not need an ADR.**
+
+Repointing a link at the same document under its new address changes nothing the
+document asserts. Requiring an ADR per publisher site reorganisation would produce
+ADRs that record no decision, and — worse — would make the correction expensive
+enough to defer, which is how five accumulated.
+
+The boundary: if the replacement is *the same document at a new address*, it is a
+pointer fix. If it is a *different document* — as the Elsevier row was, moving from a
+mis-cited opt-out protocol to the actual API policy — then the claim about where the
+vendor states its terms changed, and that is D1.
+
+**D4 — Rot is made visible on a schedule, not per PR.**
+
+`.github/workflows/tos-links.yml` requests every §1 link monthly and opens an issue
+on any non-200. Deliberately **not** a PR check: a publisher reorganising their site
+overnight would turn an unrelated PR red, which is the wrong failure mode and the one
+that teaches people to ignore a check.
+
+It follows redirects and reports the final URL, so a link that still returns 200 while
+landing somewhere unrelated is visible. It fails loudly when it extracts **zero**
+URLs, because a table reformat that emptied the list would otherwise be
+indistinguishable from a clean sweep — the same "silently checking nothing" shape as
+#442 and #454.
+
+## Consequences
+
+**Positive.** §6's promise is auditable. The Springer row no longer implies a vendor
+restriction that does not exist. A reader chasing the rate cap's enforcement basis
+lands on an enforced control. Link rot surfaces within a month instead of at the next
+audit.
+
+**Negative.** §6.1 is a hand-maintained table of facts held by other people, and it
+will drift. Nothing checks the *numbers* — only that the URLs resolve. The scheduled
+job is the floor, not a guarantee, and the honest position is that a vendor can change
+a limit silently and this document will be wrong until someone looks.
+
+**Also negative.** Monthly outbound requests to sixteen third parties who did not ask
+for them. Monthly rather than weekly is the concession: publisher sites move on a
+scale of months.
+
+## Alternatives rejected
+
+- **An ADR per link fix.** Records no decision, and the cost is what let five
+  accumulate.
+- **Per-PR link checking.** Wrong failure mode; see D4.
+- **Guessing Springer's numbers** from the tier names. The table's only value is
+  being checkable, and a plausible wrong number destroys that more thoroughly than a
+  blank does.
+- **Dropping the ToS column** as unmaintainable. It is the mechanism by which
+  LEGAL.md's "the user holds the rights" posture is actionable at all — without a
+  link, "comply with the source's terms" is advice the user cannot follow.

--- a/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
+++ b/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
@@ -4,7 +4,7 @@
 - **Status:** Accepted
 - **Supersedes:** -
 - **Refines:** [0014](0014-docs-class-system.md) — which requires an ADR for changes to NORMATIVE content, without saying whether a URL is content
-- **Source:** #495 (five of sixteen ToS links dead or wrong), #496 (CORE, Springer, rate limits, a mis-aimed cross-reference), #498 (the 2026-08-25 vendor-terms audit)
+- **Source:** #495 (five of sixteen ToS links dead or wrong), #496 (CORE, Springer, rate limits, a cross-reference pointing at the wrong safeguard), #498 (the 2026-08-25 vendor-terms audit)
 
 ## Context
 

--- a/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
+++ b/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
@@ -76,7 +76,7 @@ enough to defer, which is how five accumulated.
 
 The boundary: if the replacement is *the same document at a new address*, it is a
 pointer fix. If it is a *different document* — as the Elsevier row was, moving from a
-mis-cited opt-out protocol to the actual API policy — then the claim about where the
+wrongly cited opt-out protocol to the actual API policy — then the claim about where the
 vendor states its terms changed, and that is D1.
 
 **D4 — Rot is made visible on a schedule, not per PR.**

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -62,6 +62,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
 | 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
 | 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
+| 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 
 ## Conventions
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -11,21 +11,21 @@
 
 | Source | Tier | Phase | Auth | ToS link | doiget feature |
 |---|---|---|---|---|---|
-| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/services/metadata-retrieval/rest-api/> | always-on |
+| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/documentation/retrieve-metadata/rest-api/> | always-on |
 | Unpaywall | 1 (OA) | 1 | email (polite pool) | <https://unpaywall.org/products/api> | always-on |
 | arXiv | 1 (OA) | 1 | none | <https://info.arxiv.org/help/api/index.html> | always-on |
 | ar5iv (full text) | 1 (OA) | 4 (PR4) | none | <https://ar5iv.labs.arxiv.org/> | always-on |
-| OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
+| OpenAlex | 2 (metadata) | 4 | none | <https://help.openalex.org/how-to/> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
-| DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DOAJ | 2 (metadata) | 4 | none | <https://doaj.org/terms/> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
-| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
+| CORE | 2 (metadata) | 4 | free key (`DOIGET_CORE_API_KEY`); unregistered use is token-tiered, see §6.1 | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
-| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
+| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/terms-conditions/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
-| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
+| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
 ### 1.1 When Tier 3 is consulted (ADR-0044)
@@ -48,10 +48,16 @@ retrieval with `Accept: application/pdf`. The stored file reports
 `license = "unknown"`: it came from the publisher under your agreement, not from the
 OA location whose licence Unpaywall reported, and doiget does not guess licences.
 
-`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
-that is its own policy — retrieval of non-open-access article PDFs through the
-ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
-preview rather than the article.
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only — but for three
+different reasons. This paragraph named them in one sentence with only Elsevier's
+reason attached, so the weaker cases inherited the stronger one's justification
+(#496):
+
+| source | why it is metadata-only |
+|---|---|
+| `tdm-elsevier` | **The vendor's policy.** Retrieval of non-open-access article PDFs through the ScienceDirect APIs is not permitted; a non-OA article yields a first-page preview rather than the article. Full-text **XML** is what an entitlement grants, which is the ADR-0032 `paper_text` route rather than the content leg. |
+| `tdm-springer` | **doiget's choice.** Springer publishes a Full Text (TDM) API and an Open Access API alongside the Meta API, so full text is contractually available. Staying metadata-only is a conservative decision here, not a restriction. |
+| `tdm-ieee` | **The contract is not public.** Shipped against an inferred one (ADR-0042), so the narrower surface is the honest one until it can be checked. |
 
 Disclosure is bounded exactly as before: a source is only ever told about DOIs its
 own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
@@ -68,7 +74,14 @@ hold any credential for any user. Before enabling a source, ensure that you:
 - Are operating from a network and device authorized to use those rights.
 
 doiget enforces a hard rate cap of **5 fetches per second** per process to make polite
-behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
+behavior the default ([`LEGAL.md`](LEGAL.md) §6a safeguard 5), tightened per source
+where a vendor publishes something stricter (§6.1 below, ADR-0045).
+
+This cited "§6 safeguard 8" until #496. Safeguard 8 is marketing-language
+self-policing, and it lives in §6b — *policy commitments*, the ones a contributor
+could violate without CI catching it. The rate cap is §6a.5, an *enforced control*.
+The citation sent a reader looking for the enforcement basis to the section that has
+none.
 
 ## 3. Default release binaries
 
@@ -284,9 +297,26 @@ than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the s
 of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
 only ever tighten (ADR-0045).
 
-| source | interval | connections | published terms |
-|---|---|---|---|
-| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+### 6.1 What each vendor publishes, and what doiget does about it
 
-Every other source uses the global 200 ms floor and the global concurrency cap. Sources
-whose vendor limits are not yet recorded are tracked in #496.
+Recorded so the paragraph above is auditable rather than aspirational (#496). A row
+with no `SOURCE_RATE_OVERRIDES` entry runs on the global cap, and the "doiget" column
+says so rather than leaving it to be inferred.
+
+| source | vendor's published limit | doiget | source of the figure |
+|---|---|---|---|
+| arXiv | 1 request / 3 s, single connection | **enforced per-source** (`SOURCE_RATE_OVERRIDES`) | <https://info.arxiv.org/help/api/tou.html> |
+| CORE | token-cost model: 100 tokens/day and 10/min unregistered, 1 000/day and 25/min registered; a complex query costs 3–5 tokens | global cap; the key is what raises the tier | <https://api.core.ac.uk/docs/v3> |
+| OpenAlex | daily and per-second limits, plus a polite pool keyed on `mailto` | global cap; doiget sends `mailto` when a contact email is set | <https://help.openalex.org/how-to/> |
+| Springer | a rate-limits page, tiered Basic / Premium | global cap | <https://dev.springernature.com/docs/rate-limit-details/rate-limits/> — **figures not recorded**, see below |
+| APS | none found | global cap | <https://harvest.aps.org/docs/harvest-api> |
+| Unpaywall, Crossref, DataCite, DOAJ, HAL, OpenAIRE, Europe PMC, Semantic Scholar, IEEE | none found, or not yet checked | global cap | — |
+
+The Springer figures are **absent rather than guessed**: that page renders its body
+through JavaScript and the audit could not extract the numbers. A plausible-looking
+number here would be worse than the gap, because the point of the table is that it can
+be checked against the vendor. Someone should open it in a browser and fill the cell in.
+
+CORE's row is why the §1 matrix no longer calls its key "optional". Requests do resolve
+without one, at roughly a hundred simple queries a day — so a run that worked yesterday
+can stop working today, and "optional" gives the reader nothing to diagnose that with.

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -17,21 +17,21 @@ weight = 200
 
 | Source | Tier | Phase | Auth | ToS link | doiget feature |
 |---|---|---|---|---|---|
-| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/services/metadata-retrieval/rest-api/> | always-on |
+| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/documentation/retrieve-metadata/rest-api/> | always-on |
 | Unpaywall | 1 (OA) | 1 | email (polite pool) | <https://unpaywall.org/products/api> | always-on |
 | arXiv | 1 (OA) | 1 | none | <https://info.arxiv.org/help/api/index.html> | always-on |
 | ar5iv (full text) | 1 (OA) | 4 (PR4) | none | <https://ar5iv.labs.arxiv.org/> | always-on |
-| OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
+| OpenAlex | 2 (metadata) | 4 | none | <https://help.openalex.org/how-to/> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
-| DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DOAJ | 2 (metadata) | 4 | none | <https://doaj.org/terms/> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
-| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
+| CORE | 2 (metadata) | 4 | free key (`DOIGET_CORE_API_KEY`); unregistered use is token-tiered, see §6.1 | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
-| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
+| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/terms-conditions/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
-| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
+| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
 ### 1.1 When Tier 3 is consulted (ADR-0044)
@@ -54,10 +54,16 @@ retrieval with `Accept: application/pdf`. The stored file reports
 `license = "unknown"`: it came from the publisher under your agreement, not from the
 OA location whose licence Unpaywall reported, and doiget does not guess licences.
 
-`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
-that is its own policy — retrieval of non-open-access article PDFs through the
-ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
-preview rather than the article.
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only — but for three
+different reasons. This paragraph named them in one sentence with only Elsevier's
+reason attached, so the weaker cases inherited the stronger one's justification
+(#496):
+
+| source | why it is metadata-only |
+|---|---|
+| `tdm-elsevier` | **The vendor's policy.** Retrieval of non-open-access article PDFs through the ScienceDirect APIs is not permitted; a non-OA article yields a first-page preview rather than the article. Full-text **XML** is what an entitlement grants, which is the ADR-0032 `paper_text` route rather than the content leg. |
+| `tdm-springer` | **doiget's choice.** Springer publishes a Full Text (TDM) API and an Open Access API alongside the Meta API, so full text is contractually available. Staying metadata-only is a conservative decision here, not a restriction. |
+| `tdm-ieee` | **The contract is not public.** Shipped against an inferred one (ADR-0042), so the narrower surface is the honest one until it can be checked. |
 
 Disclosure is bounded exactly as before: a source is only ever told about DOIs its
 own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
@@ -74,7 +80,14 @@ hold any credential for any user. Before enabling a source, ensure that you:
 - Are operating from a network and device authorized to use those rights.
 
 doiget enforces a hard rate cap of **5 fetches per second** per process to make polite
-behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
+behavior the default ([`LEGAL.md`](LEGAL.md) §6a safeguard 5), tightened per source
+where a vendor publishes something stricter (§6.1 below, ADR-0045).
+
+This cited "§6 safeguard 8" until #496. Safeguard 8 is marketing-language
+self-policing, and it lives in §6b — *policy commitments*, the ones a contributor
+could violate without CI catching it. The rate cap is §6a.5, an *enforced control*.
+The citation sent a reader looking for the enforcement basis to the section that has
+none.
 
 ## 3. Default release binaries
 
@@ -290,9 +303,26 @@ than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the s
 of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
 only ever tighten (ADR-0045).
 
-| source | interval | connections | published terms |
-|---|---|---|---|
-| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+### 6.1 What each vendor publishes, and what doiget does about it
 
-Every other source uses the global 200 ms floor and the global concurrency cap. Sources
-whose vendor limits are not yet recorded are tracked in #496.
+Recorded so the paragraph above is auditable rather than aspirational (#496). A row
+with no `SOURCE_RATE_OVERRIDES` entry runs on the global cap, and the "doiget" column
+says so rather than leaving it to be inferred.
+
+| source | vendor's published limit | doiget | source of the figure |
+|---|---|---|---|
+| arXiv | 1 request / 3 s, single connection | **enforced per-source** (`SOURCE_RATE_OVERRIDES`) | <https://info.arxiv.org/help/api/tou.html> |
+| CORE | token-cost model: 100 tokens/day and 10/min unregistered, 1 000/day and 25/min registered; a complex query costs 3–5 tokens | global cap; the key is what raises the tier | <https://api.core.ac.uk/docs/v3> |
+| OpenAlex | daily and per-second limits, plus a polite pool keyed on `mailto` | global cap; doiget sends `mailto` when a contact email is set | <https://help.openalex.org/how-to/> |
+| Springer | a rate-limits page, tiered Basic / Premium | global cap | <https://dev.springernature.com/docs/rate-limit-details/rate-limits/> — **figures not recorded**, see below |
+| APS | none found | global cap | <https://harvest.aps.org/docs/harvest-api> |
+| Unpaywall, Crossref, DataCite, DOAJ, HAL, OpenAIRE, Europe PMC, Semantic Scholar, IEEE | none found, or not yet checked | global cap | — |
+
+The Springer figures are **absent rather than guessed**: that page renders its body
+through JavaScript and the audit could not extract the numbers. A plausible-looking
+number here would be worse than the gap, because the point of the table is that it can
+be checked against the vendor. Someone should open it in a browser and fill the cell in.
+
+CORE's row is why the §1 matrix no longer calls its key "optional". Requests do resolve
+without one, at roughly a hundred simple queries a day — so a run that worked yesterday
+can stop working today, and "optional" gives the reader nothing to diagnose that with.


### PR DESCRIPTION
Closes #495, #496. Adds ADR-0046.

The 2026-08-25 audit found two kinds of defect in `docs/SOURCES.md`, and they do not want the same treatment. That distinction is the ADR.

## Wrong claims — #496

| | was | now |
|---|---|---|
| CORE auth | "optional free key" | free key; **unregistered use is token-tiered** (~100 simple queries/day). "Optional" gave a reader nothing to diagnose a run that stopped working. |
| Springer | named in one sentence with Elsevier and IEEE as metadata-only, with **only Elsevier's reason** attached | a table, one row per reason. Springer publishes a Full Text (TDM) API *and* an Open Access API — staying metadata-only is **doiget's** conservative choice, not a vendor restriction. IEEE's reason is a third thing again: the contract is not public (ADR-0042). |
| vendor limits | §6 promised doiget adopts a stricter vendor guideline per source, and recorded **no vendor's limit anywhere** | §6.1: limit / what doiget does / where the figure came from, per source |
| rate-cap citation | `LEGAL.md` §6 **safeguard 8** | §6a **safeguard 5** |

That last one is worth a sentence: safeguard 8 is marketing-language self-policing and lives in §6b, *policy commitments* — the ones a contributor could violate without CI catching it. The cap is §6a.5, an *enforced control*. The citation sent a reader looking for the enforcement basis to the section that has none, which inverts the meaning of the reference.

**Springer's rate figures are left blank and labelled, not guessed.** That page renders its body through JavaScript and the audit could not read it. The table's only value is being checkable against the vendor, and a plausible-looking wrong number destroys that more thoroughly than a gap does.

## Rotted pointers — #495

Verified with `curl -L` here rather than taken from the issue on trust:

```
Crossref   /services/metadata-retrieval/rest-api/   404
Elsevier   /legal/tdmrep                            404
OpenAlex   docs.openalex.org/...                    200 -> help.openalex.org root (deep target gone)
DOAJ       doaj.org/api                             200 -> swagger.json (a schema, not terms)
Springer   dev.springernature.com/                  200, portal root
```

**The Elsevier row was wrong before it died.** `tdmrep` is the W3C **TDM Reservation Protocol** — the standard by which a rightsholder machine-readably signals an opt-out *from* text and data mining. It is not Elsevier's API terms. The sole ToS reference for a Tier-3 source pointed at the wrong *kind* of document.

All five replacements, and all sixteen resulting links, return 200.

## ADR-0046 — where the line is

`docs/SOURCES.md` is NORMATIVE, so ADR-0014 requires an ADR. But ADR-0014 does not say whether a **URL** is "content", and treating it as such would mean an ADR per publisher site reorganisation — ADRs that record no decision, and a correction cost high enough to defer. Which is how five accumulated.

So: **a claim about a vendor is normative and needs an ADR; a URL is a pointer and repointing it at the same document under a new address does not.**

The boundary bites in this very PR — the Elsevier row moved to a *different* document, so that one is a claim change, not a pointer fix.

## Making rot visible — `tos-links.yml`

Monthly, requests every §1 link, opens an issue on non-200.

**Schedule-only by design.** A publisher reorganising their site overnight must not turn an unrelated PR red — that is the wrong failure mode and the one that teaches people to ignore a check.

Two details that matter:

- It **follows redirects and reports the final URL**, so a link that still returns 200 while landing somewhere unrelated is visible. Two of the five defects above were exactly that shape.
- It **fails loudly when it extracts zero URLs**. A table reformat that emptied the list would otherwise be indistinguishable from a clean sweep — the same "silently checking nothing" shape as #442 and #454.

Both the extraction and the sweep were run against the real file before committing: **16 URLs found, 16 returned 200.**

## Verification

- `curl -L` on all 16 links plus the 5 replacements — all 200.
- The workflow's `awk` extraction run against `docs/SOURCES.md` — 16 URLs, matching the matrix by hand count.
- YAML parses; `jobs = [check, notify-cron-failure]`, `on = [schedule, workflow_dispatch]`.
- `scripts/sync_docs_to_site.sh` regenerated `site/content/developer/sources.md`.
- `scripts/version-bump-gate.sh` — passes at `0.8.10-beta.11`.

Refs #498, ADR-0014, ADR-0042, ADR-0045
