### PR TITLE
docs(legal): declare the network surface the shipped binary actually has (#494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.
+  It said "Crossref, Unpaywall, arXiv"; a default `oa-only` build also registers
+  `oa_publisher_allowlist` (~20 publisher/repository patterns), `api.openalex.org`
+  (discovery, ADR-0031, always-on) and `ar5iv.labs.arxiv.org` (ADR-0032, always-on).
+  **OpenAlex was absent entirely** — a third-party service contacted by the shipped
+  binary with no opt-in — and the one document written for publisher legal teams was
+  the one that did not say so (#494, ADR-0047).
+- **[legal]** `docs/LEGAL.md` lists all four TDM features. `tdm-ieee` landed with
+  ADR-0042 and was missing from §2 and §6a.3; `SOURCES.md` had it (#494).
+- **[legal]** §6a.1 no longer claims credentials are read from
+  `~/.config/doiget/credentials.toml`. They are not — the resolver reads
+  `std::env::var` and nothing else, and no code path opens that file. `CONFIG.md` §6
+  specifies it in full regardless, which is #509 (#494, ADR-0047).
+- **[legal]** §6a.1's "*Enforced by: CI grep for embedded key patterns*" is removed.
+  **No such check exists.** §6a is defined as controls a machine enforces, as opposed
+  to §6b policy commitments, so an enforcement clause naming nothing was in the wrong
+  section — the same defect as the §6 safeguard-8 citation in #496 (#494, ADR-0047).
+
 - **[docs]** Five of the sixteen ToS links in `docs/SOURCES.md` §1 no longer led to
   terms — two 404s, one redirect to a docs-domain root, one to a Swagger schema, one
   to a portal root. The Elsevier entry was wrong before it died: `legal/tdmrep` is the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.11"
+version = "0.8.10-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.11"
+version = "0.8.10-beta.12"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.11"
+version = "0.8.10-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.11"
+version       = "0.8.10-beta.12"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.11" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.11" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.11" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.12" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.12" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.12" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/DECISIONS/0047-legal-claims-are-read-off-the-code.md
+++ b/docs/DECISIONS/0047-legal-claims-are-read-off-the-code.md
@@ -1,0 +1,98 @@
+# 0047 - LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0046](0046-vendor-claims-are-normative-links-are-pointers.md) — same audit, same class of defect, applied to claims about *doiget* rather than about vendors
+- **Source:** #494 (network surface under-declared, `tdm-ieee` absent), #509 (a documented credentials file nothing reads)
+
+## Context
+
+`docs/LEGAL.md` is `Status: NORMATIVE` and says of itself that "users,
+contributors, publisher legal teams, and future reviewers" should rely on it.
+The 2026-08-25 audit and the correction pass that followed found four false
+statements in it. They are all the same shape: someone wrote down what the
+system was believed to do, and nothing brought the sentence back to the code.
+
+**The shipped binary's network surface.** §2 said default binaries "include only
+Open Access sources (Crossref, Unpaywall, arXiv)". Reading the production client
+assembly in `crates/doiget-cli/src/commands/fetch.rs`, a default `oa-only` build
+registers four allowlists: `tier_1_allowlist`, `oa_publisher_allowlist` (~20
+publisher and repository patterns), `discovery_allowlist` (`api.openalex.org`,
+ADR-0031, always-on) and `fulltext_allowlist` (`ar5iv.labs.arxiv.org`,
+ADR-0032, always-on). **OpenAlex was absent from the list entirely** — a
+third-party service, not an arXiv subdomain, contacted by the shipped binary with
+no opt-in. `SOURCES.md` had documented both as always-on Tier 1 the whole time.
+
+**`tdm-ieee`.** §2 and §6a.3 both enumerated three TDM features. There are four;
+`tdm-ieee` landed with ADR-0042. `SOURCES.md` listed all four.
+
+**A credentials file nothing reads.** §6a.1 said credentials come from env vars
+"or `~/.config/doiget/credentials.toml`". The TDM resolver reads `std::env::var`
+and nothing else, and no code path opens that file — while `CONFIG.md` §6
+specifies it in full, including a 0600 permission warning that also does not
+exist (#509).
+
+**An enforcement clause naming nothing.** §6a.1 cited "*CI grep for embedded key
+patterns*". There is no secret scanner in the tree; `posture-lint.yml` greps for
+marketing terms, HTTP-server imports, telemetry imports and non-rustls TLS
+backends. §6a is *defined* as "mechanically enforced by code, type system, Cargo,
+or CI" — as distinct from §6b, the policy commitments a contributor could weaken
+without machine-checkable resistance. An item in §6a whose enforcement clause
+names nothing is in the wrong section, and that split is the whole point of
+having two.
+
+## Decision
+
+**D1 — The network-surface claim is derived from the allowlist assembly, not
+written from memory.** §2 now carries a table of the four allowlists the
+production client is built from and names the code they come from, so a reader —
+or a publisher's counsel — can check the claim against one function rather than
+trusting a remembered summary.
+
+This is why the claim rotted: `discovery_allowlist` and `fulltext_allowlist` were
+added by ADR-0031 and ADR-0032, both correctly documented in `SOURCES.md`, and
+nothing connected either to the sentence in LEGAL.md that enumerated hosts.
+
+**D2 — Every item in §6a must name enforcement that exists.** An item whose
+*Enforced by:* clause cites a mechanism that is absent either gets the mechanism
+built or moves to §6b. Citing an imaginary control is worse than admitting a
+policy commitment, because §6a is the half a reader is invited to verify.
+
+The §6a.1 clause is corrected to the two controls that are real (`secrecy::Secret`
+types, the `tracing` redactor). Building the secret scanner is a reasonable
+follow-up; asserting one exists is not.
+
+**D3 — A claim that turns out to describe an unimplemented feature is corrected
+immediately, and the gap is filed separately.** The `credentials.toml` sentence
+is removed from LEGAL.md now, and whether to implement `CONFIG.md` §6 is #509.
+Leaving a known-false statement standing in the legal document while an issue is
+open is what #472 was about.
+
+`CONFIG.md` §6 is deliberately left as it is: editing it *is* the decision, and
+that decision is not this ADR's to make.
+
+## Consequences
+
+**Positive.** The network-surface claim is falsifiable against one function.
+§6a means what it says. A reader chasing an enforcement basis lands on something
+that exists.
+
+**Negative.** The §2 table duplicates knowledge held in `fetch.rs`, and duplicated
+knowledge drifts — which is exactly how this ADR came to be needed. Naming the
+function is a mitigation, not a fix. A CI check that diffs the documented host set
+against the allowlists would be the real answer; it does not exist, and per D2
+this ADR does not claim it does.
+
+**Negative.** §6a.1 is now weaker on paper, having lost an enforcement clause. It
+was always this weak; the clause was decoration.
+
+## Alternatives rejected
+
+- **Fold this into ADR-0046.** That ADR's subject is the vendor-claim / pointer
+  distinction in `SOURCES.md`, a distinct idea. Broadening it to "all normative
+  claims" would blunt the one thing it says sharply.
+- **Leave the `credentials.toml` sentence until #509 is decided.** Ships a false
+  statement in the legal document for the duration.
+- **Move safeguard 1 to §6b** rather than correct its clause. The type-level
+  controls are real and machine-enforced; only the clause was wrong.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -63,6 +63,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
 | 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
+| 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
 
 ## Conventions
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -30,11 +30,32 @@ boundaries.
 
 This is enforced structurally rather than only by documentation:
 
-- Default released binaries include only Open Access sources (Crossref, Unpaywall, arXiv).
+- Default released binaries (`oa-only`) include only Open Access sources. In full,
+  the hosts a default build is able to contact — read off the allowlists the
+  production client is assembled from in
+  `crates/doiget-cli/src/commands/fetch.rs`, not from memory:
+
+  | allowlist | hosts | what it is for |
+  |---|---|---|
+  | `tier_1_allowlist` | `api.crossref.org`, `*.crossref.org`, `api.unpaywall.org`, `arxiv.org`, `export.arxiv.org` | DOI and arXiv resolution |
+  | `oa_publisher_allowlist` | ~20 publisher and repository patterns (`*.springer.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.plos.org`, `*.mdpi.com`, `*.frontiersin.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.nih.gov`, `*.aps.org`, `scipost.org`, …) | following the OA PDF URL an index reported; the host is wherever the OA copy lives (ADR-0027) |
+  | `discovery_allowlist` | `api.openalex.org` | `doiget search` discovery (ADR-0031 D4), **always-on, no env gate** |
+  | `fulltext_allowlist` | `ar5iv.labs.arxiv.org` | `doiget text` structured full text (ADR-0032), **always-on** |
+
+  This list read "Crossref, Unpaywall, arXiv" until #494. **OpenAlex was absent
+  entirely** — a third-party service, not an arXiv subdomain, reached by the shipped
+  binary with no opt-in. `SOURCES.md` had documented both discovery and ar5iv as
+  always-on Tier 1 the whole time; the one document written for publisher legal teams
+  was the one that did not say so.
+
+  A user-supplied `[[network.additional_hosts]]` entry (ADR-0028) can extend the
+  allowlist at runtime. That is the user's own decision about their own network, and
+  it is the only way the set above grows without a rebuild.
 - Institutional / TDM source code paths are gated by Cargo features (`tdm-elsevier`,
-  `tdm-aps`, `tdm-springer`) and are **not present** in the default published binary; a
-  user wishing to enable them must rebuild from source. See [`SCOPE.md`](SCOPE.md) and
-  ADR-0002.
+  `tdm-aps`, `tdm-springer`, `tdm-ieee`) and are **not present** in the default
+  published binary; a user wishing to enable them must rebuild from source. See
+  [`SCOPE.md`](SCOPE.md) and ADR-0002. (`tdm-ieee` landed with ADR-0042 and was
+  missing from this list until #494 — `SOURCES.md` had all four.)
 - Even when compiled in, TDM sources require both an explicit per-publisher
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
@@ -115,10 +136,24 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from environment variables or
-   `~/.config/doiget/credentials.toml`, wrapped in `secrecy::Secret`, and never
-   logged in raw form. *Enforced by:* `secrecy::Secret` types in
-   `doiget-core`; `tracing` redactor; CI grep for embedded key patterns.
+   binary. Credentials are read at runtime from **environment variables**
+   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
+   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
+   `tracing` redactor.
+
+   Two corrections here (#494):
+
+   - This said credentials are also read from `~/.config/doiget/credentials.toml`.
+     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
+     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
+     specifies it in full anyway, which is tracked as #509. A user following that
+     section today writes a key into a file doiget ignores.
+   - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
+     check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
+     imports, telemetry imports and non-rustls TLS backends; there is no secret
+     scanner in the tree. §6a is defined as controls a machine enforces, so an
+     enforcement clause that names nothing does not belong in it. The safeguard
+     itself stands on the type-level ones that are real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
    the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
@@ -127,8 +162,8 @@ them requires changing source files that are gated by branch protection.
    resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
-   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`). Default builds and crates.io
-   artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
+   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and
+   crates.io artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
    `[features]` declarations; `posture-lint.yml` import-pattern grep;
    ADR-0002.
 

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -36,11 +36,32 @@ boundaries.
 
 This is enforced structurally rather than only by documentation:
 
-- Default released binaries include only Open Access sources (Crossref, Unpaywall, arXiv).
+- Default released binaries (`oa-only`) include only Open Access sources. In full,
+  the hosts a default build is able to contact — read off the allowlists the
+  production client is assembled from in
+  `crates/doiget-cli/src/commands/fetch.rs`, not from memory:
+
+  | allowlist | hosts | what it is for |
+  |---|---|---|
+  | `tier_1_allowlist` | `api.crossref.org`, `*.crossref.org`, `api.unpaywall.org`, `arxiv.org`, `export.arxiv.org` | DOI and arXiv resolution |
+  | `oa_publisher_allowlist` | ~20 publisher and repository patterns (`*.springer.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.plos.org`, `*.mdpi.com`, `*.frontiersin.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.nih.gov`, `*.aps.org`, `scipost.org`, …) | following the OA PDF URL an index reported; the host is wherever the OA copy lives (ADR-0027) |
+  | `discovery_allowlist` | `api.openalex.org` | `doiget search` discovery (ADR-0031 D4), **always-on, no env gate** |
+  | `fulltext_allowlist` | `ar5iv.labs.arxiv.org` | `doiget text` structured full text (ADR-0032), **always-on** |
+
+  This list read "Crossref, Unpaywall, arXiv" until #494. **OpenAlex was absent
+  entirely** — a third-party service, not an arXiv subdomain, reached by the shipped
+  binary with no opt-in. `SOURCES.md` had documented both discovery and ar5iv as
+  always-on Tier 1 the whole time; the one document written for publisher legal teams
+  was the one that did not say so.
+
+  A user-supplied `[[network.additional_hosts]]` entry (ADR-0028) can extend the
+  allowlist at runtime. That is the user's own decision about their own network, and
+  it is the only way the set above grows without a rebuild.
 - Institutional / TDM source code paths are gated by Cargo features (`tdm-elsevier`,
-  `tdm-aps`, `tdm-springer`) and are **not present** in the default published binary; a
-  user wishing to enable them must rebuild from source. See [`SCOPE.md`](SCOPE.md) and
-  ADR-0002.
+  `tdm-aps`, `tdm-springer`, `tdm-ieee`) and are **not present** in the default
+  published binary; a user wishing to enable them must rebuild from source. See
+  [`SCOPE.md`](SCOPE.md) and ADR-0002. (`tdm-ieee` landed with ADR-0042 and was
+  missing from this list until #494 — `SOURCES.md` had all four.)
 - Even when compiled in, TDM sources require both an explicit per-publisher
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
@@ -121,10 +142,24 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from environment variables or
-   `~/.config/doiget/credentials.toml`, wrapped in `secrecy::Secret`, and never
-   logged in raw form. *Enforced by:* `secrecy::Secret` types in
-   `doiget-core`; `tracing` redactor; CI grep for embedded key patterns.
+   binary. Credentials are read at runtime from **environment variables**
+   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
+   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
+   `tracing` redactor.
+
+   Two corrections here (#494):
+
+   - This said credentials are also read from `~/.config/doiget/credentials.toml`.
+     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
+     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
+     specifies it in full anyway, which is tracked as #509. A user following that
+     section today writes a key into a file doiget ignores.
+   - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
+     check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
+     imports, telemetry imports and non-rustls TLS backends; there is no secret
+     scanner in the tree. §6a is defined as controls a machine enforces, so an
+     enforcement clause that names nothing does not belong in it. The safeguard
+     itself stands on the type-level ones that are real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
    the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
@@ -133,8 +168,8 @@ them requires changing source files that are gated by branch protection.
    resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
-   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`). Default builds and crates.io
-   artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
+   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and
+   crates.io artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
    `[features]` declarations; `posture-lint.yml` import-pattern grep;
    ADR-0002.
 


### PR DESCRIPTION
Closes #494. Adds ADR-0047. Stacked on #508 — merge that first.

Four false statements in `docs/LEGAL.md`, all the same shape: what the system was *believed* to do, written down, with nothing bringing the sentence back to the code.

## 1. The default binary talks to more than three hosts

§2 said default binaries include only "Crossref, Unpaywall, arXiv". Reading the production client assembly in `crates/doiget-cli/src/commands/fetch.rs`, a default `oa-only` build registers **four** allowlists:

| allowlist | hosts |
|---|---|
| `tier_1_allowlist` | `api.crossref.org`, `*.crossref.org`, `api.unpaywall.org`, `arxiv.org`, `export.arxiv.org` |
| `oa_publisher_allowlist` | ~20 publisher/repository patterns — `*.springer.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.plos.org`, `*.mdpi.com`, `*.biorxiv.org`, `europepmc.org`, `*.nih.gov`, `*.aps.org`, … |
| `discovery_allowlist` | `api.openalex.org` — ADR-0031, **always-on, no env gate** |
| `fulltext_allowlist` | `ar5iv.labs.arxiv.org` — ADR-0032, **always-on** |

**OpenAlex was absent from the list entirely.** A third-party service, not an arXiv subdomain, contacted by the shipped binary with no opt-in.

`SOURCES.md` had documented both discovery and ar5iv as always-on Tier 1 the whole time. The one document written for publisher legal teams was the one that did not say so — which is the interesting part, and the reason ADR-0047's D1 makes §2 name the function it is read from rather than restate a remembered summary.

## 2. `tdm-ieee`

§2 and §6a.3 enumerated three TDM features. There are four; `tdm-ieee` landed with ADR-0042 and `SOURCES.md` listed all four.

## 3 & 4. Two things found while checking the rest of §6a

#494 asked for the section to be checked against the code rather than only the two lines it quoted. Doing that turned up two more:

**A credentials file nothing reads.** §6a.1 said credentials come from env vars "or `~/.config/doiget/credentials.toml`". They do not — the TDM resolver reads `std::env::var` and nothing else, and no code path opens that file. `CONFIG.md` §6 nonetheless specifies it in full, with a schema and a `0600` permission warning that also does not exist. A user following the NORMATIVE documentation writes their key into a file doiget ignores. **Filed as #509**, because whether to implement it or delete the docs is a decision, not an edit — and the `agreed = true` field in that schema is a weaker act of consent than an env var typed in the session that runs the fetch, which deserves to be decided rather than inherited.

The sentence is corrected here regardless. Leaving a known-false claim standing in the legal document while an issue is open is what #472 was about.

**An enforcement clause naming nothing.** §6a.1 cited "*CI grep for embedded key patterns*". There is no secret scanner in the tree; `posture-lint.yml` greps for marketing terms, HTTP-server imports, telemetry imports and non-rustls TLS backends.

That is why ADR-0047 has a second half. **§6a is defined as controls a machine enforces**, as against §6b, the policy commitments a contributor could weaken without machine-checkable resistance. An item in §6a whose enforcement clause names nothing is in the wrong section, and that split is the whole point of having two. Same defect as the §6 safeguard-8 citation in #496, one level up: there a *real* control was cited by the wrong number; here an *absent* one was cited at all.

§6a.1 keeps the two controls that are real — `secrecy::Secret` types and the `tracing` redactor. Building the scanner is a reasonable follow-up; asserting one exists is not.

## Verification

Every claim written into the doc was read off the code first:

- `crates/doiget-cli/src/commands/fetch.rs:246-261` — the four `allowlists.extend(...)` calls, and which are `#[cfg]`-gated (only `tier_2` and `tier_3` are).
- `crates/doiget-core/src/http.rs` — `tier_1_allowlist:200`, `oa_publisher_allowlist:468`, `discovery_allowlist:288`, `fulltext_allowlist:313`.
- `crates/doiget-core/src/lib.rs:1455-1463` — `std::env::var` for both the agreement var and the key; no file read.
- `.github/workflows/posture-lint.yml` — four greps, none for keys; no gitleaks/trufflehog anywhere in `.github/`.
- `crates/doiget-core/Cargo.toml:25-28` — four `tdm-*` features.

`scripts/sync_docs_to_site.sh` regenerated `site/content/use/legal.md`. `scripts/version-bump-gate.sh` passes at `0.8.10-beta.12`.

Refs #498, #509, #496, ADR-0014, ADR-0031, ADR-0032, ADR-0042, ADR-0046
