### PR TITLE
test: make the three diagnostic wiring points fail when disconnected (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+
+- **[legal]** `docs/LEGAL.md` §2a states the **access ceiling** — what doiget may
+  attempt for a given ref, and what bounds it. §1 and §2 said only what doiget does
+  *not* do, so the positive limit existed as a shared belief: *"never go beyond what
+  Unpaywall reports"*. That belief is false. The ceiling rose twice, deliberately and
+  with ADRs — ADR-0044's Tier-3 content leg and #445's optional-source fall-through —
+  and neither could be reviewed against a limit that was never written down. Every
+  clause names the code that enforces it (#497, ADR-0048).
+
 ### Fixed
 
 - **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[test]** The three diagnostic wiring points would have survived being
+  disconnected. `batch --json`'s one line threading a real outcome's trace into the
+  record, and the MCP envelope's `attempts` and `remediation` insertions, each had
+  every nearby assertion calling the leaf helper directly with hand-built arguments —
+  so reverting any of them left the whole suite green while the trace or the
+  remediation vanished from the wire, which is the regression #459 exists to prevent.
+  `FetchPaperOutcome::for_test_synthetic_with_attempts` makes the first testable at
+  all: the plain constructor hard-codes `attempts: Vec::new()`, so the one test that
+  did drive `classify_joined` could not have observed a trace even if it had looked
+  (#471, #459).
+
 - **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.
   It said "Crossref, Unpaywall, arXiv"; a default `oa-only` build also registers
   `oa_publisher_allowlist` (~20 publisher/repository patterns), `api.openalex.org`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.12"
+version       = "0.8.10-beta.13"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.12" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.12" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.12" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.13" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.13" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.13" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.13"
+version       = "0.8.10-beta.14"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.13" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.13" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.13" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.14" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.14" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.14" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -972,6 +972,71 @@ mod tests {
         );
     }
 
+    /// #471. The ONE line that threads a real outcome's trace into the
+    /// `--json` record had no test behind it: every assertion about
+    /// `attempts` called `build_jsonl_failure` directly with hand-built
+    /// arguments, and the only test that went through `classify_joined`
+    /// built its outcome with `for_test_synthetic`, which hard-codes
+    /// `attempts: Vec::new()` -- so it could not have observed a trace even
+    /// if it had looked.
+    ///
+    /// Reverting `batch.rs`'s `&outcome.attempts` to `&[]` left the whole
+    /// suite green while silently dropping the trace from `--json`, which is
+    /// the regression #459 exists to prevent.
+    #[test]
+    fn classify_joined_threads_the_real_outcomes_trace_into_the_json_record() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        use doiget_core::ErrorCode as Ec;
+
+        let blocked = PdfLegStatus::Blocked {
+            code: Ec::NetworkError,
+            message: "publisher refused".to_string(),
+            denial: None,
+            suggested_arxiv_id: None,
+        };
+        // A trace with something in it, and something a `&[]` cannot fake.
+        let attempts = vec![
+            SourceAttempt::new("crossref", AttemptOutcome::Resolved),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_HAL"],
+                },
+            ),
+        ];
+
+        let outcome = classify_joined(
+            Ok(TaskOutcome {
+                input: "10.1234/foo".to_string(),
+                result: Ok(FetchPaperOutcome::for_test_synthetic_with_attempts(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    blocked,
+                    attempts,
+                )),
+            }),
+            true,
+        );
+
+        let rec = outcome
+            .json_record
+            .unwrap_or_else(|| panic!("json mode must produce a record"));
+
+        let rows = rec["error"]["attempts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the trace must reach the wire; record: {rec}"));
+        assert_eq!(rows.len(), 2, "record: {rec}");
+        assert_eq!(rows[0]["source"], serde_json::json!("crossref"));
+        assert_eq!(rows[1]["source"], serde_json::json!("hal"));
+        // #470's structured form travels with it -- which is what proves this
+        // is the real outcome's trace rather than a placeholder.
+        assert_eq!(
+            rows[1]["required_env"],
+            serde_json::json!(["DOIGET_ENABLE_HAL"]),
+            "record: {rec}"
+        );
+    }
+
     #[test]
     fn classify_joined_blocked_pdf_emits_failure_with_denial_context() {
         // #210: a `PdfLegStatus::Blocked` outcome is reported as a

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -913,6 +913,30 @@ impl FetchPaperOutcome {
             attempts: Vec::new(),
         }
     }
+
+    /// [`Self::for_test_synthetic`] carrying a resolution trace.
+    ///
+    /// #471: the plain constructor hard-codes `attempts: Vec::new()`, so a
+    /// test driving `classify_joined` with a `Blocked` outcome could not
+    /// observe a trace even if it looked -- and none did. Reverting the one
+    /// line that threads `outcome.attempts` into `build_jsonl_failure` left
+    /// the whole suite green, silently dropping the trace from `--json`,
+    /// which is the regression #459 exists to prevent.
+    ///
+    /// `#[doc(hidden)]` for the same reason as its sibling: not a stable
+    /// public API.
+    #[doc(hidden)]
+    pub fn for_test_synthetic_with_attempts(
+        safekey: impl Into<String>,
+        source: impl Into<String>,
+        pdf_leg: PdfLegStatus,
+        attempts: Vec<SourceAttempt>,
+    ) -> Self {
+        Self {
+            attempts,
+            ..Self::for_test_synthetic(safekey, source, pdf_leg)
+        }
+    }
 }
 
 /// Resolve a [`Ref`] to a PDF (or metadata-only fallback) and write it

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4582,6 +4582,72 @@ mod tests {
     /// #459: the trace, and the distinction it exists to make. Absent
     /// rather than `[]` when unavailable — #413 was filed because those
     /// two were the same observable.
+    /// #471. `fetch_paper_success_envelope` is the only caller that inserts
+    /// `"attempts"`, and `pdf_leg_json` the only one that inserts
+    /// `"remediation"` -- and neither was called from any test. Every test
+    /// naming those fields called the leaf helpers directly with
+    /// hand-constructed values, so disconnecting either wiring point left
+    /// the suite green while the trace and the remediation vanished from the
+    /// envelope an agent reads.
+    ///
+    /// This drives the ENVELOPE BUILDER, so both insertions are exercised at
+    /// the point where a real outcome meets the wire.
+    #[test]
+    fn the_success_envelope_carries_the_trace_and_the_remediation() {
+        use doiget_core::orchestrator::{AttemptOutcome, FetchPaperOutcome, SourceAttempt};
+        use doiget_core::{DenialContext, DenialReason, ErrorCode};
+
+        let blocked = PdfLegStatus::Blocked {
+            code: ErrorCode::NetworkError,
+            message: "redirect target not in allowlist".to_string(),
+            denial: Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: Some("oa-publisher".to_string()),
+                attempted: Some("cdn.example.org".to_string()),
+                expected: Some(vec!["good.example.org".to_string()]),
+                hop_index: Some(1),
+                cap: None,
+                actual: None,
+            }),
+            suggested_arxiv_id: None,
+        };
+        let outcome = FetchPaperOutcome::for_test_synthetic_with_attempts(
+            "doi__10_1234_foo",
+            "oa-publisher",
+            blocked,
+            vec![
+                SourceAttempt::new("crossref", AttemptOutcome::Resolved),
+                SourceAttempt::new(
+                    "hal",
+                    AttemptOutcome::Disabled {
+                        env: &["DOIGET_ENABLE_HAL"],
+                    },
+                ),
+            ],
+        );
+
+        let env = fetch_paper_success_envelope(&outcome, "doi:10.1234/foo");
+
+        // The trace reached the envelope.
+        let rows = env["attempts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("attempts must be on the envelope; got {env}"));
+        assert_eq!(rows.len(), 2, "{env}");
+        assert_eq!(rows[0]["source"], json!("crossref"));
+        assert_eq!(
+            rows[1]["required_env"],
+            json!(["DOIGET_ENABLE_HAL"]),
+            "the #470 structured form travels with it; got {env}"
+        );
+
+        // And so did the remediation, through `pdf_leg_json`.
+        let rem = env["pdf"]["remediation"]
+            .as_array()
+            .unwrap_or_else(|| panic!("a redirect denial has a config channel; got {env}"));
+        assert!(!rem.is_empty(), "{env}");
+        assert_eq!(env["pdf"]["status"], json!("blocked"), "{env}");
+    }
+
     #[test]
     fn attempts_json_distinguishes_no_trace_from_an_empty_one() {
         use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};

--- a/docs/DECISIONS/0048-access-ceiling.md
+++ b/docs/DECISIONS/0048-access-ceiling.md
@@ -1,0 +1,104 @@
+# 0048 - The access ceiling is written down, and widening it amends the written form
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #497 (the operative invariant is not the believed one), #498 (the 2026-08-25 vendor-terms audit)
+
+## Context
+
+`docs/LEGAL.md` §1 and §2 state what doiget does **not** do: no access-control
+circumvention, no proxying across user boundaries, no redistribution. All still
+true, all still verifiable.
+
+What was missing was the positive statement. Given a ref, *what is doiget
+permitted to try, and where does it stop?*
+
+The rule the project operated under informally was **"never go beyond what
+Unpaywall reports"**. Clean, checkable, and no longer what the code does. It rose
+twice:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is
+  asked for the bytes. For `tdm-aps` that returns a PDF from a location Unpaywall
+  never listed.
+- **#445** — when the OA chain and the arXiv preprint fallback are exhausted, the
+  enabled optional sources are asked whether anyone else holds a copy, and the URL
+  they report is tried. Also not from Unpaywall.
+
+Both are opt-in, both have ADRs, both stay inside publisher-sanctioned APIs and
+inside the redirect allowlist, and both record their outcome in the attempt trace.
+**Neither is improper.** The defect is that the rule everyone believed was being
+enforced was not the rule being enforced, and the gap had never been written down —
+so ADR-0044 was reviewed against a ceiling that existed only as a shared belief.
+
+An unstated invariant cannot be checked. That is how both widenings happened
+without anyone deciding the ceiling had moved.
+
+## Decision
+
+**D1 — `LEGAL.md` gains §2a, stating the ceiling positively.** Two kinds of
+location, and no third:
+
+- **(a) a location an enabled source reported** — the URL appears verbatim in a
+  response from a source the build *and* the runtime profile enabled;
+- **(b) an endpoint built from a vendor's own documented URL scheme** for the
+  identifier the user supplied.
+
+Bounded on every request and every redirect hop by the host allowlist, by
+credential-plus-consent for Tier 3, by prefix scoping for Tier 3, and by the
+attempt trace.
+
+**D2 — Every clause names where it is enforced, and is falsifiable by reading
+that code.** §2a cites `optional_source_oa_url`'s dispatch, the `*_url`
+constructors, the `redirect::Policy::custom` closure, `PUBLISHER_PREFIXES`, and
+`SourceAttempt`. A reader who thinks a clause is false can go and check it in one
+place.
+
+**#497 proposed a candidate wording that this ADR rejects**, and the reason is
+instructive. It suggested doiget "never constructs a content URL that no enabled
+source reported". **That is false.** arXiv's `/pdf/<id>.pdf`, ar5iv's `/html/<id>`
+and every Tier-3 TDM endpoint are constructed from an identifier, not reported by
+anyone. Writing that sentence would have replaced an unstated invariant with a
+stated false one — worse, because it reads as verified.
+
+The issue anticipated this: *"That is a guess at the shape, not a proposal — the
+exact wording should be derived by reading `orchestrator.rs` and the allowlist."*
+It was, and the shape came out different.
+
+The distinction that matters is not *reported vs constructed*. It is **documented
+by the vendor vs guessed by us**. Constructing `/pdf/<id>.pdf` against arXiv's
+published scheme is exactly as sanctioned as following a URL Unpaywall handed
+over; inferring a publisher's URL pattern from observation would not be, and
+§2a's "no third kind" is what forbids it.
+
+**D3 — Widening (a) or (b) amends §2a in the same PR.** Not "should" — the ceiling
+is only useful as something a reviewer can hold a diff against.
+
+## Consequences
+
+**Positive.** The argument for the current posture is written and true. It is no
+longer "we never exceed Unpaywall" — which is false — but "every leg is a
+publisher-sanctioned API or an index the user switched on, at an allowlisted host,
+under the user's own credential where one is required, with the attempt recorded".
+That is defensible, and each conjunct is checkable.
+
+**Negative.** §2a is prose asserting properties of code, and nothing mechanically
+ties the two. A change could widen (b) and leave §2a stale exactly as ADR-0044 did.
+D3 is a review discipline, not a control — the honest classification, and the same
+distinction `LEGAL.md` §6a/§6b draws between enforced and committed. Making it
+enforceable would need something like a lint over the `*_url` constructors; that
+does not exist and this ADR does not pretend it does.
+
+**Negative.** Naming code locations in a NORMATIVE document means a refactor that
+renames `optional_source_oa_url` makes §2a wrong. Accepted deliberately: a clause
+citing nothing is unfalsifiable, which is the failure this ADR exists to fix, and
+ADR-0047 D2 made the same trade for §6a.
+
+## Alternatives rejected
+
+- **Restore the Unpaywall-only ceiling** by reverting ADR-0044 and #445. Both are
+  opt-in, sanctioned and useful; the problem was never the widening, only that it
+  was undeclared.
+- **Adopt #497's proposed wording.** False, as above.
+- **Leave the invariant implicit** and rely on ADR review. That was the default for
+  two releases, and it produced this issue.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -64,6 +64,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
+| 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
 
 ## Conventions
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -64,6 +64,81 @@ This is enforced structurally rather than only by documentation:
   sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
+## 2a. Access ceiling (binding constraint)
+
+§1 and §2 say what doiget does **not** do. This says what it **may** do, because an
+unstated ceiling cannot be checked — and the next feature that widens the content leg
+would widen it against nothing. Two widenings already shipped without anyone deciding
+the ceiling had moved (see "How this changed", below), which is what #497 is about.
+
+Written to be **falsifiable by reading the code**, not aspirational. Every clause below
+names where it is enforced.
+
+### The ceiling
+
+Given a ref, doiget attempts retrieval from exactly two kinds of location:
+
+**(a) A location an enabled source reported.** The URL appears verbatim in a response
+doiget received from a source that both the build and the runtime capability profile
+have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
+and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+`fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
+behind its own `DOIGET_ENABLE_*` flag.
+*Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
+per-source extractor and returns `None` for any other source name.
+
+**(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
+the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's
+`/html/<id>`; a Tier-3 publisher's documented TDM endpoint for a DOI whose registrant
+prefix says that publisher issued it.
+*Enforced by:* the `*_url` constructors in each source module, each of which is a
+`base.join(<documented path>)` and nothing else.
+
+**There is no third kind.** doiget does not derive a candidate URL from the *content*
+of a document it fetched — no link-following, no scraping, no `href` extraction — and
+does not guess a publisher URL pattern the publisher has not documented.
+
+### What bounds both, on every request and every redirect hop
+
+1. **Host allowlist.** The host must match the per-source allowlist. A redirect to a
+   host off the list fails as `RedirectDenied`; a non-`https` redirect fails as
+   `InsecureRedirect`; hop count is capped. This applies to every hop, not only the
+   first. *Enforced by:* the `reqwest::redirect::Policy::custom` closure in
+   `crates/doiget-core/src/http.rs`; ADR-0027.
+2. **Credential and consent, Tier 3 only.** The Cargo feature must be compiled in, the
+   user must supply their own API key, and the user must separately set
+   `DOIGET_AGREE_TDM_<PUBLISHER>=1`. All three, or the source is unavailable.
+   *Enforced by:* §6a.2, §6a.3, §6a.4.
+3. **Prefix scoping, Tier 3 only.** A publisher's endpoint is asked only about DOIs its
+   own registrant prefix covers, so enabling one TDM source does not disclose an
+   unrelated reading list to that publisher. *Enforced by:* `PUBLISHER_PREFIXES` per
+   source, checked before credentials; ADR-0041, ADR-0044.
+4. **Every attempt is recorded.** Consulted or not, and why. *Enforced by:*
+   `SourceAttempt` / `attempts_to_value`; ADR-0029, ADR-0043.
+
+### How this changed, and why it is still defensible
+
+The rule this project operated under informally was **"never go beyond what Unpaywall
+reports"**. That was clean and checkable, and it is no longer what the code does. The
+ceiling rose twice, both times deliberately, both times with an ADR, and neither time
+was this document updated to say so:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is asked
+  for the bytes. For `tdm-aps` that returns a PDF. Unpaywall never listed that location.
+- **#445 / ADR-0029** — when the OA chain and the arXiv preprint fallback are both
+  exhausted, the enabled optional sources are asked whether anyone else holds a copy,
+  and the URL they report is tried.
+
+Neither is improper. But the argument for them is **not** "we never exceed Unpaywall" —
+that argument is simply false now. The real argument is the one written above: every
+leg is a publisher-sanctioned API or an index the user switched on, reached at a host
+on the allowlist, under the user's own credential where one is required, with the
+attempt recorded.
+
+**A change that widens (a) or (b) amends this section in the same PR.** That is the
+point of writing it down: ADR-0044 could not have been reviewed against a ceiling that
+existed only as a shared belief.
+
 ## 3. Tool-neutrality framing
 
 doiget is positioned as a **general-purpose automation tool** in the sense familiar from

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -28,6 +28,10 @@
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
+it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
+not try before amends that section in the same PR (#497, ADR-0048).
+
 ### 1.1 When Tier 3 is consulted (ADR-0044)
 
 Tier-3 sources are asked two different questions at two different points, and the

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -34,6 +34,10 @@ weight = 200
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
+it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
+not try before amends that section in the same PR (#497, ADR-0048).
+
 ### 1.1 When Tier 3 is consulted (ADR-0044)
 
 Tier-3 sources are asked two different questions at two different points, and the

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -70,6 +70,81 @@ This is enforced structurally rather than only by documentation:
   sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
+## 2a. Access ceiling (binding constraint)
+
+§1 and §2 say what doiget does **not** do. This says what it **may** do, because an
+unstated ceiling cannot be checked — and the next feature that widens the content leg
+would widen it against nothing. Two widenings already shipped without anyone deciding
+the ceiling had moved (see "How this changed", below), which is what #497 is about.
+
+Written to be **falsifiable by reading the code**, not aspirational. Every clause below
+names where it is enforced.
+
+### The ceiling
+
+Given a ref, doiget attempts retrieval from exactly two kinds of location:
+
+**(a) A location an enabled source reported.** The URL appears verbatim in a response
+doiget received from a source that both the build and the runtime capability profile
+have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
+and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+`fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
+behind its own `DOIGET_ENABLE_*` flag.
+*Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
+per-source extractor and returns `None` for any other source name.
+
+**(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
+the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's
+`/html/<id>`; a Tier-3 publisher's documented TDM endpoint for a DOI whose registrant
+prefix says that publisher issued it.
+*Enforced by:* the `*_url` constructors in each source module, each of which is a
+`base.join(<documented path>)` and nothing else.
+
+**There is no third kind.** doiget does not derive a candidate URL from the *content*
+of a document it fetched — no link-following, no scraping, no `href` extraction — and
+does not guess a publisher URL pattern the publisher has not documented.
+
+### What bounds both, on every request and every redirect hop
+
+1. **Host allowlist.** The host must match the per-source allowlist. A redirect to a
+   host off the list fails as `RedirectDenied`; a non-`https` redirect fails as
+   `InsecureRedirect`; hop count is capped. This applies to every hop, not only the
+   first. *Enforced by:* the `reqwest::redirect::Policy::custom` closure in
+   `crates/doiget-core/src/http.rs`; ADR-0027.
+2. **Credential and consent, Tier 3 only.** The Cargo feature must be compiled in, the
+   user must supply their own API key, and the user must separately set
+   `DOIGET_AGREE_TDM_<PUBLISHER>=1`. All three, or the source is unavailable.
+   *Enforced by:* §6a.2, §6a.3, §6a.4.
+3. **Prefix scoping, Tier 3 only.** A publisher's endpoint is asked only about DOIs its
+   own registrant prefix covers, so enabling one TDM source does not disclose an
+   unrelated reading list to that publisher. *Enforced by:* `PUBLISHER_PREFIXES` per
+   source, checked before credentials; ADR-0041, ADR-0044.
+4. **Every attempt is recorded.** Consulted or not, and why. *Enforced by:*
+   `SourceAttempt` / `attempts_to_value`; ADR-0029, ADR-0043.
+
+### How this changed, and why it is still defensible
+
+The rule this project operated under informally was **"never go beyond what Unpaywall
+reports"**. That was clean and checkable, and it is no longer what the code does. The
+ceiling rose twice, both times deliberately, both times with an ADR, and neither time
+was this document updated to say so:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is asked
+  for the bytes. For `tdm-aps` that returns a PDF. Unpaywall never listed that location.
+- **#445 / ADR-0029** — when the OA chain and the arXiv preprint fallback are both
+  exhausted, the enabled optional sources are asked whether anyone else holds a copy,
+  and the URL they report is tried.
+
+Neither is improper. But the argument for them is **not** "we never exceed Unpaywall" —
+that argument is simply false now. The real argument is the one written above: every
+leg is a publisher-sanctioned API or an index the user switched on, reached at a host
+on the allowlist, under the user's own credential where one is required, with the
+attempt recorded.
+
+**A change that widens (a) or (b) amends this section in the same PR.** That is the
+point of writing it down: ADR-0044 could not have been reviewed against a ceiling that
+existed only as a shared belief.
+
 ## 3. Tool-neutrality framing
 
 doiget is positioned as a **general-purpose automation tool** in the sense familiar from


### PR DESCRIPTION
Closes #471. Stacked on #514 — merge that first.

Three lines carry the #459 diagnostics onto the wire, and **none of them had a test behind it**:

| wiring point | inserts |
|---|---|
| `batch.rs::classify_joined` | the only place a real `FetchPaperOutcome`'s `attempts` reaches `build_jsonl_failure` |
| `mcp/lib.rs::fetch_paper_success_envelope` | the only place `"attempts"` enters the envelope |
| `mcp/lib.rs::pdf_leg_json` | the only place `"remediation"` does |

Every assertion about those fields called the **leaf helper directly** with hand-built arguments. Revert any of the three and the whole suite stayed green while the trace or the remediation silently vanished from the wire — the exact regression #459 exists to prevent.

## The batch one could not be tested at all

The single test that *did* drive `classify_joined` with a `Blocked` outcome built it with `for_test_synthetic`, which hard-codes `attempts: Vec::new()`. It could not have observed a trace even if it had looked. `FetchPaperOutcome::for_test_synthetic_with_attempts` is what makes the assertion possible.

Both new tests drive the **production function** rather than a leaf helper, and assert on #470's `required_env` — a shape a `&[]` cannot fake.

## Mutation-checked, including the exact revert #471 names

| severed | fails |
|---|---|
| `&outcome.attempts` → `&[]` in `batch.rs` | the batch test |
| the `"attempts"` insertion in the MCP envelope | the MCP test |
| the `"remediation"` insertion in `pdf_leg_json` | the MCP test |

## One thing found while doing it

Inserting a test immediately above an existing `fn` line puts the new block **between that function's `#[test]` and its `fn`**. The attribute then lands on the new test — duplicated, since it has its own — and the old test loses it.

`classify_joined_blocked_pdf_emits_failure_with_denial_context` and `attempts_json_distinguishes_no_trace_from_an_empty_one` had both silently stopped being tests.

`cargo clippy -D warnings` caught it (`duplicated attribute` + `function is never used`). **`cargo test` did not** — a test that is no longer a test simply does not appear in the list, so the run looks clean and one line shorter. Both are restored and both run; the batch file is back to 6 passing tests.

That is the same shape as the issue itself, one level down: the suite was green and two tests were gone.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` across `oa-only`, `oa-only,citation`, and the full `oa-only,metadata,tdm-*` set.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features oa-only,citation`.
- `cargo test --workspace --all-targets --no-default-features --features oa-only` — 0 failures.
- `scripts/version-bump-gate.sh` — will pass at `0.8.10-beta.14` once #514 lands.

Refs #459, #462, #468, #470
