### PR TITLE
Promotion: next → main for 0.8.10

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
-      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad  # v2.85.10
+      - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
           tool: cargo-llvm-cov
       - name: Generate workspace coverage (lcov)

--- a/.github/workflows/tos-links.yml
+++ b/.github/workflows/tos-links.yml
@@ -1,0 +1,139 @@
+name: tos-links
+
+# #495 — the ToS column of `docs/SOURCES.md` §1 rots silently.
+#
+# Five of sixteen links were dead or pointing at the wrong document when the
+# 2026-08-25 audit checked them, and nothing had noticed. `docs/SOURCES.md` is
+# `Status: NORMATIVE (user responsibility advisory)`: its whole job is telling a
+# user where each source states its terms, so a 404 there is a broken promise
+# rather than a cosmetic defect.
+#
+# SCHEDULE ONLY, deliberately. A per-PR check would turn an unrelated PR red
+# because a publisher reorganised their website overnight — the wrong failure
+# mode, and the one that trains people to ignore a check. On a schedule, rot
+# opens an issue instead.
+#
+# Third-party Actions are SHA-pinned (repo invariant / ADR-0013 supply-chain).
+
+on:
+  schedule:
+    # Monthly, 1st at 07:15 UTC. Offset from audit.yml (weekly Mon 07:00),
+    # supply-chain.yml (Wed) and codeql.yml (Tue) so the scans do not pile up.
+    # Monthly rather than weekly: publisher sites move on a scale of months,
+    # and every run is outbound traffic to people who did not ask for it.
+    - cron: "15 7 1 * *"
+  # Manual trigger, so a row can be re-checked after a fix without waiting a
+  # month.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tos-links
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: ToS links in SOURCES.md resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      report: ${{ steps.check.outputs.report }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
+
+      - name: Request every link in the source matrix
+        id: check
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Only the §1 matrix: start at its header row, stop at the first
+          # line that is not a table row.
+          mapfile -t urls < <(
+            awk '/^\| Source \| Tier \|/{inmatrix=1; next}
+                 inmatrix && !/^\|/{exit}
+                 inmatrix' docs/SOURCES.md \
+              | grep -oE '<https://[^>]+>' \
+              | tr -d '<>' \
+              | sort -u
+          )
+
+          if [ "${#urls[@]}" -eq 0 ]; then
+            # Fail loudly rather than report a clean sweep of nothing. A table
+            # reformat that silently emptied this list would otherwise look
+            # exactly like "every link is healthy".
+            echo "::error::extracted zero URLs from the SOURCES.md matrix — the table shape changed and this check is no longer looking at anything"
+            exit 1
+          fi
+
+          echo "checking ${#urls[@]} links"
+          bad=""
+          for u in "${urls[@]}"; do
+            # Follow redirects: a 301 to the vendor's new canonical page is
+            # fine. The FINAL status and FINAL url are both reported, so a
+            # link that now lands somewhere unrelated is visible even at 200.
+            out=$(curl -sSL --max-time 30 --retry 2 --retry-delay 5 \
+                    -o /dev/null -w '%{http_code} %{url_effective}' "$u" || echo "000 -")
+            code=${out%% *}
+            final=${out#* }
+            if [ "$code" = "200" ]; then
+              printf '  ok   %s\n' "$u"
+              if [ "$final" != "$u" ]; then
+                printf '       -> redirected to %s\n' "$final"
+              fi
+            else
+              printf '  FAIL %s (%s)\n' "$u" "$code"
+              bad="${bad}- \`${u}\` -> HTTP ${code}"$'\n'
+            fi
+          done
+
+          if [ -n "$bad" ]; then
+            {
+              echo "report<<REPORT_EOF"
+              echo "$bad"
+              echo "REPORT_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "::error::one or more ToS links in docs/SOURCES.md did not return 200"
+            exit 1
+          fi
+
+  notify-cron-failure:
+    name: notify (cron failure)
+    needs: [check]
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPORT: ${{ needs.check.outputs.report }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          body=$(cat <<BODY
+          The scheduled \`tos-links\` check found a link in the \`docs/SOURCES.md\` source
+          matrix that did not return 200.
+
+          ${REPORT}
+
+          Run: ${RUN_URL}
+
+          \`docs/SOURCES.md\` is NORMATIVE and its stated job is to point at each source's
+          terms, so a dead entry is a broken promise rather than a cosmetic defect (#495).
+          Replace it with a page that states the terms — prefer a terms or policy page
+          over API docs or a schema URL.
+
+          Opened automatically; close it once the row is corrected.
+          BODY
+          )
+          gh issue create \
+            --title "docs: a ToS link in SOURCES.md no longer resolves ($(date -u +%Y-%m-%d))" \
+            --label "documentation,automated" \
+            --body "$body" \
+            --repo "${{ github.repository }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[orchestrator]** A Tier-3 TDM source is consulted when the **content leg** is
+  blocked, not only when Crossref missed. It was asked the metadata question all
+  along, and Crossref answers that question readily for a publisher's own DOIs — so
+  for exactly the DOIs these sources exist to serve, the chain recorded `NotNeeded`
+  and no request ever went out. Signing an agreement, obtaining a key and building
+  with the feature produced byte-identical output (#458, ADR-0044).
+
+### Added
+
+- **[source]** `tdm-aps` returns the article PDF. APS documents single-request
+  retrieval with `Accept: application/pdf`, which makes it the only Tier-3
+  publisher whose full-text contract is both public and PDF-shaped — Elsevier does
+  not permit non-open-access PDF retrieval through its APIs at all (#458, ADR-0044).
+- **[core]** `Source::fetch_content`, defaulted to `Ok(None)`. "Metadata-only" was
+  previously expressed by setting `pdf_bytes: None` and saying so in a doc-comment,
+  which the orchestrator could not read — so it could not tell a source with nothing
+  to offer from one it had never asked.
+- **[transport]** `HttpClient::fetch_pdf_with_headers`. The magic-byte check is not
+  optional on a credentialed endpoint: publisher error pages and WAF holding
+  responses are 200s with a body.
+
+### Changed
+
+- **[errors]** `PdfLegStatus::TdmFetched` is distinct from `Fetched`, and the stored
+  source label names the publisher rather than `oa-publisher`. A TDM copy did not
+  come from an OA host and carries an agreement's terms.
+- **[core]** A TDM-retrieved artifact reports `license = "unknown"`. Unpaywall's
+  licence describes an OA location that was never reached; carrying it forward would
+  put an open-licence claim on a file obtained by a route it does not describe.
+- **[docs]** ADR-0044, which also records that ADR-0041's rejection of
+  Crossref-based publisher routing rested on a premise this change removes.
+
 ### Retracted
 
 - **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+
+- **[legal]** `docs/LEGAL.md` §2a states the **access ceiling** — what doiget may
+  attempt for a given ref, and what bounds it. §1 and §2 said only what doiget does
+  *not* do, so the positive limit existed as a shared belief: *"never go beyond what
+  Unpaywall reports"*. That belief is false. The ceiling rose twice, deliberately and
+  with ADRs — ADR-0044's Tier-3 content leg and #445's optional-source fall-through —
+  and neither could be reviewed against a limit that was never written down. Every
+  clause names the code that enforces it (#497, ADR-0048).
+
 ### Fixed
 
 - **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[legal]** arXiv is fetched at the rate its Terms of Use publish — one request
+  every three seconds over a single connection — instead of 15x that rate and 5x
+  the concurrency. `RateLimits` had no per-source dimension at all, and three
+  places in the tree, including `docs/SOURCES.md`, asserted the global 5/sec cap
+  "comfortably respects" the guideline. §6 of the same document promised doiget
+  would adopt a stricter vendor value per source; the promise was real and the
+  mechanism did not exist (#493, ADR-0045).
+
 - **[cli]** Every ref-taking command emits the `docs/ERRORS.md` §3 contract
   line — `error[INVALID_REF]: invalid ref: …` — for an unparsable input.
   #119 gave `fetch` the contract and nothing generalised it, so `info`,
@@ -84,6 +92,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[core]** `SOURCE_RATE_OVERRIDES` plus `RateLimits::backoff_ms_for` /
+  `max_concurrent_for`. Library constants keyed by source name — never
+  caller-supplied, since `docs/LEGAL.md` §6a safeguard 5 makes `RateLimits`
+  unsynthesizable on purpose. An entry can only ever TIGHTEN: the accessors take
+  the stricter of the global value and the entry, and a test pins the table so an
+  entry that would be silently ignored fails the build (#493, ADR-0045).
+- **[core]** `RateLimiter::pace` for additional requests inside one attempt.
+  arXiv's terms cap requests and one arXiv attempt issues two — the Atom feed,
+  then the PDF — so the second was previously unpaced (#493).
 - **[cli]** `list-recent --missing-pdf` lists only the metadata-only entries —
   "which of my batch need retrying?" without reading a fifty-row table by eye
   (#481).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Retracted
+
+- **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers. It
+  does not. `resolve_tdm_chain` still short-circuits every entry to `NotNeeded` the moment
+  `crossref_answered` is true, so a configured TDM key still yields byte-identical output
+  for the DOIs the chain exists to serve, and #458 is open. The bullet is struck from
+  `## [0.8.9]` below and the GitHub Release body carries a correction; the `v0.8.9` tag
+  annotation is immutable and still states it. The notes were assembled by grepping
+  `main..next` for `Closes` and `Refs` and reading both as "fixed" — PR #466 wrote
+  `Refs #458` about an adjacent `cfg`-gate fix, deliberately and correctly. The two
+  keywords are not interchangeable when assembling release notes (#472).
+
 ## [0.8.9] - 2026-08-25
 
 0.8.8 shipped five optional sources that were never called. 0.8.9 is what happened
@@ -22,6 +34,9 @@ reached?** The answer was no, four more times.
 | #454 | their transport allowlists | all passed | **no** — never registered in the production client |
 | #458 | the Tier-3 chain | all passed | **no** — skipped whenever Crossref answered |
 | #441 | `[store] root` in `config.toml` | all passed | **no** — the config rung did not exist |
+
+Three of the four are fixed below. **#458 is diagnosed but not fixed** and remains open;
+this release originally claimed otherwise — see the retraction under `## [Unreleased]`.
 
 Every one was documented as working. `SOURCES.md` described the three gates that make
 a TDM source available; ADR-0036 stated the store-root resolution order; `config init`
@@ -41,9 +56,6 @@ All true on paper, all false in the binary.
   source would otherwise have failed `UnknownSource`; the unit tests could not see it,
   because the test client registers the key itself — the same trap DataCite nearly hit
   in 0.8.8 (#454).
-- **[orchestrator]** The Tier-3 chain runs even when Crossref answers. A publisher's own
-  record is the entire point of holding its credentials, and Crossref resolves those
-  DOIs readily, so the chain never ran for the DOIs it exists to serve (#458).
 - **[config]** `[store] root` in `config.toml` is honoured, between the env var and the
   cwd default (#441, ADR-0036 Amendment 1). `config doctor` now names which rung
   answered: a setting that is present but unread resolves to the cwd default, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
+- **[source]** The #445 content-leg fall-through asks OpenAlex too. OpenAlex reports
+  every location it knows of, where Unpaywall reports one — so for a hybrid-OA article
+  whose publisher leg is refused, it is the source likeliest to name the institutional
+  repository copy that actually satisfies the fetch. `OpenalexSource` was compiled in and
+  reachable from `doiget graph`, but absent from the optional chain, so the accessor was
+  not "the only missing piece": the wiring was missing too (#461).
 - **[legal]** `docs/LEGAL.md` §2a states the **access ceiling** — what doiget may
   attempt for a given ref, and what bounds it. §1 and §2 said only what doiget does
   *not* do, so the positive limit existed as a shared belief: *"never go beyond what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 ### Fixed
 
 - **[cli]** Every ref-taking command emits the `docs/ERRORS.md` §3 contract
-  line — `error[INVALID_REF]: invalid ref: …` — for an unparseable input.
+  line — `error[INVALID_REF]: invalid ref: …` — for an unparsable input.
   #119 gave `fetch` the contract and nothing generalised it, so `info`,
   `link`, `cite`, `text`, `tag`, `bib`, `csl` and `source` each printed a raw
   `anyhow` dump: a bare `Error:` plus a `Caused by:` chain leaking internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.
+  It said "Crossref, Unpaywall, arXiv"; a default `oa-only` build also registers
+  `oa_publisher_allowlist` (~20 publisher/repository patterns), `api.openalex.org`
+  (discovery, ADR-0031, always-on) and `ar5iv.labs.arxiv.org` (ADR-0032, always-on).
+  **OpenAlex was absent entirely** — a third-party service contacted by the shipped
+  binary with no opt-in — and the one document written for publisher legal teams was
+  the one that did not say so (#494, ADR-0047).
+- **[legal]** `docs/LEGAL.md` lists all four TDM features. `tdm-ieee` landed with
+  ADR-0042 and was missing from §2 and §6a.3; `SOURCES.md` had it (#494).
+- **[legal]** §6a.1 no longer claims credentials are read from
+  `~/.config/doiget/credentials.toml`. They are not — the resolver reads
+  `std::env::var` and nothing else, and no code path opens that file. `CONFIG.md` §6
+  specifies it in full regardless, which is #509 (#494, ADR-0047).
+- **[legal]** §6a.1's "*Enforced by: CI grep for embedded key patterns*" is removed.
+  **No such check exists.** §6a is defined as controls a machine enforces, as opposed
+  to §6b policy commitments, so an enforcement clause naming nothing was in the wrong
+  section — the same defect as the §6 safeguard-8 citation in #496 (#494, ADR-0047).
+
 - **[docs]** Five of the sixteen ToS links in `docs/SOURCES.md` §1 no longer led to
   terms — two 404s, one redirect to a docs-domain root, one to a Swagger schema, one
   to a portal root. The Elsevier entry was wrong before it died: `legal/tdmrep` is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[docs]** Five of the sixteen ToS links in `docs/SOURCES.md` §1 no longer led to
+  terms — two 404s, one redirect to a docs-domain root, one to a Swagger schema, one
+  to a portal root. The Elsevier entry was wrong before it died: `legal/tdmrep` is the
+  W3C TDM **Reservation** Protocol, by which a rightsholder signals an opt-out *from*
+  mining, not Elsevier's API terms. All sixteen now resolve, measured (#495, ADR-0046).
+- **[docs]** `docs/SOURCES.md` no longer implies Springer restricts full text. Springer
+  publishes a Full Text (TDM) API and an Open Access API; staying metadata-only there
+  is doiget's conservative choice. The old sentence named Elsevier, Springer and IEEE
+  together with only Elsevier's reason attached, so the weaker cases inherited the
+  stronger one's justification (#496).
+- **[docs]** CORE's key is no longer called "optional". Unregistered use is a
+  token-cost tier — roughly a hundred simple queries a day — so a run can stop working
+  and "optional" gave the reader nothing to diagnose that with (#496).
+- **[docs]** The rate cap cites `LEGAL.md` §6a safeguard 5, the enforced control,
+  instead of §6b safeguard 8, which is marketing-language self-policing. The old
+  citation sent a reader looking for the enforcement basis to the section that has
+  none (#496).
+
 - **[legal]** arXiv is fetched at the rate its Terms of Use publish — one request
   every three seconds over a single connection — instead of 15x that rate and 5x
   the concurrency. `RateLimits` had no per-source dimension at all, and three
@@ -92,6 +110,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[docs]** `docs/SOURCES.md` §6.1 records what each vendor publishes as a rate limit
+  and what doiget does about it. §6 promised doiget adopts a stricter vendor guideline
+  per source while recording no vendor's limit anywhere, so the promise could not be
+  checked against anything. Springer's figures are left **blank and labelled** rather
+  than guessed — their page renders through JavaScript and the audit could not read
+  them, and a plausible wrong number destroys the table's only value (#496, ADR-0046).
+- **[ci]** `tos-links.yml` requests every §1 link monthly and opens an issue on any
+  non-200. Schedule-only by design: a publisher reorganising their site overnight must
+  not turn an unrelated PR red. It fails loudly if it extracts zero URLs, because a
+  table reformat that emptied the list would otherwise look exactly like a clean sweep
+  (#495, ADR-0046).
 - **[core]** `SOURCE_RATE_OVERRIDES` plus `RateLimits::backoff_ms_for` /
   `max_concurrent_for`. Library constants keyed by source name — never
   caller-supplied, since `docs/LEGAL.md` §6a safeguard 5 makes `RateLimits`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[cli]** `config path` and `config show` print when stdout is not a terminal.
+  They were absent from the ADR-0017 artifact classification, so an implicit
+  non-TTY Quiet silenced them: `doiget config path` from a pipe produced zero
+  bytes and exited 0, which made the documented way to locate your config file
+  answer a script, a CI step or an agent with silence *and* success. Explicit
+  Quiet still silences them (#476, ADR-0017 Amendment 1/2).
+- **[cli]** The human denial help names the one trust flag that covers the
+  attempted host, and says so when neither does. It listed both unconditionally
+  while `remediation::for_denial` — the MCP and `batch --json` path — already
+  computed which one applied, so the agent got a better diagnostic than the
+  human. `*.strath.ac.uk` is covered by `trust_academic_repos` only; following
+  `trust_oa_registries` there cost a round (#478).
+- **[cli]** `widening_suggestions` describes `*.parent` as "the whole domain".
+  It said "the whole publisher", which is wrong for the case that fires most
+  often: every host in the built-in academic list is a university (#478).
+
 - **[diagnostics]** A per-source attempt row keeps its `DenialContext`, so
   `remediation` is reachable from it. `classify_attempt` flattened everything that
   was not a `NotFound` or an access refusal into `Failed { detail: "<prose>" }` —
@@ -44,6 +60,11 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[docs]** `batch --json` record order is stated in `docs/ERRORS.md` §3.2a and
+  in `batch --help`: records are emitted as refs complete, not in input order, and
+  `ref` is the key. Nothing said so, and zipping stdout against the input file
+  positionally is the obvious thing to write — it works until one fetch is slow,
+  then attaches a result to the wrong DOI with no error anywhere (#479).
 - **[errors]** `AttemptOutcome::Disabled` carries `&'static [&'static str]` and the
   wire gains `required_env`. Tier 3 needs two variables and the code joined them
   into `"A + B"`, which put a separator on the #459 wire that a consumer had to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[diagnostics]** A per-source attempt row keeps its `DenialContext`, so
+  `remediation` is reachable from it. `classify_attempt` flattened everything that
+  was not a `NotFound` or an access refusal into `Failed { detail: "<prose>" }` —
+  so a redirect denial, oversized body or not-a-PDF on a *metadata-chain* source,
+  the richest and most actionable failures, became an untyped string on a surface
+  #459 advertises as machine-readable. The blocked PDF leg had carried the same
+  structure end to end since #459; the two mechanisms now agree (#470, ADR-0023,
+  ADR-0043).
+
 - **[orchestrator]** A Tier-3 TDM source is consulted when the **content leg** is
   blocked, not only when Crossref missed. It was asked the metadata question all
   along, and Crossref answers that question readily for a publisher's own DOIs — so
@@ -35,6 +44,11 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[errors]** `AttemptOutcome::Disabled` carries `&'static [&'static str]` and the
+  wire gains `required_env`. Tier 3 needs two variables and the code joined them
+  into `"A + B"`, which put a separator on the #459 wire that a consumer had to
+  split on — the thing the `detail()` / `wire()` split exists to avoid. `detail`
+  still carries the joined form, so nothing that reads it today breaks (#470).
 - **[errors]** `PdfLegStatus::TdmFetched` is distinct from `Fetched`, and the stored
   source label names the publisher rather than `oa-publisher`. A TDM copy did not
   come from an OA host and carries an agreement's terms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.10] - 2026-08-26
+
 ### Added
 
 - **[source]** The #445 content-leg fall-through asks OpenAlex too. OpenAlex reports
@@ -2934,4 +2936,4 @@ harden the wire contracts the previous commits introduced:
   `doiget-mcp/tests/initialize_handshake.rs` (renamed test),
   ERRORS.md §1 + §2 (new variant + semantics row).
 
-[Unreleased]: https://github.com/sotashimozono/doiget/compare/main...HEAD
+[Unreleased]: https://github.com/QAtlasHub/doiget/compare/main...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[cli]** Every ref-taking command emits the `docs/ERRORS.md` §3 contract
+  line — `error[INVALID_REF]: invalid ref: …` — for an unparseable input.
+  #119 gave `fetch` the contract and nothing generalised it, so `info`,
+  `link`, `cite`, `text`, `tag`, `bib`, `csl` and `source` each printed a raw
+  `anyhow` dump: a bare `Error:` plus a `Caused by:` chain leaking internal
+  error types that are in no contract, on a surface whose callers are told
+  they can key off `error[CODE]:`. One renderer now, and a table-driven e2e
+  that fails by naming the command that regressed (#477).
+- **[cli]** `verify` renders a missing input file as `error: failed to read
+  reference file …` with exit 2 rather than an `anyhow` dump. It takes a path,
+  not a ref, and the closed `ErrorCode` set describes fetch outcomes — so it
+  gets the misuse form the CLI already uses elsewhere (#477).
+- **[core]** An input with neither a scheme nor a `10.` prefix reports
+  `RefParseError::UnrecognisedShape` — "neither a DOI … nor an arXiv id" —
+  instead of the arXiv parser's verdict. `Ref::parse` falls through to arXiv,
+  so someone who mistyped a DOI was told about arXiv id shapes (#477).
+
 - **[cli]** `list-recent` and `search --local` show whether a PDF was actually
   stored. A metadata-only entry — what a blocked content leg leaves behind —
   rendered identically to a fetched paper, and the inventory command is the only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[cli]** `list-recent` and `search --local` show whether a PDF was actually
+  stored. A metadata-only entry — what a blocked content leg leaves behind —
+  rendered identically to a fetched paper, and the inventory command is the only
+  one that answers "what do I have?" without being told the ref in advance. Batch
+  fifty refs with ten blocked, come back later, and the natural conclusion is
+  fifty papers (#481, #118).
+
 - **[cli]** `config path` and `config show` print when stdout is not a terminal.
   They were absent from the ADR-0017 artifact classification, so an implicit
   non-TTY Quiet silenced them: `doiget config path` from a pipe produced zero
@@ -60,6 +67,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[cli]** `list-recent --missing-pdf` lists only the metadata-only entries —
+  "which of my batch need retrying?" without reading a fifty-row table by eye
+  (#481).
+- **[core]** `EntryInfo` gains `size_bytes: Option<u64>` and `has_pdf()`. The
+  `list-recent --mode json` envelope carries both: `0` and `null` both mean "no
+  PDF" while meaning different things about the entry, and a consumer should not
+  have to know that. The `pdf` column is APPENDED to the human table, not
+  inserted — column order is stable for `cut(1)` by contract (#481).
 - **[docs]** `batch --json` record order is stated in `docs/ERRORS.md` §3.2a and
   in `batch --help`: records are emitted as refs complete, not in input order, and
   `ref` is the key. Nothing said so, and zipping stdout against the input file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   citation sent a reader looking for the enforcement basis to the section that has
   none (#496).
 
+- **[tdm-aps]** The source requests the URL APS documents. It built
+  `/v2/article/<percent-encoded DOI>`; APS Harvest serves
+  `/v2/journals/articles/<raw DOI>`, so a reached source would have 404'd. Both wiremock
+  stubs asserted the path the implementation produced, so they could never have caught
+  it — they are now pinned to a constant transcribed from the vendor's own curl example
+  (#484).
 - **[legal]** arXiv is fetched at the rate its Terms of Use publish — one request
   every three seconds over a single connection — instead of 15x that rate and 5x
   the concurrency. `RateLimits` had no per-source dimension at all, and three
@@ -155,6 +161,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[deps]** `rmcp` 2.2 → **3.1.4**, a semver-major of the MCP SDK. One breaking change
+  reaches this repo: `InitializeResult::server_info` is now `Option<Implementation>`.
+  `schemars` stays at 1.2.1, so every tool's generated input schema is byte-identical,
+  and `ProtocolVersion::V_2024_11_05` is pinned explicitly, so the advertised protocol
+  version does not move with the SDK. ADR-0001's stdio-only invariant holds — no `axum`,
+  `oauth2`, `jsonwebtoken` or streamable-http crate enters the tree (#452).
+- **[deps]** `serial_test` 3.5 → **4.0.1** (its MSRV rises to 1.93.1, which does not reach
+  the MSRV jobs — they build without `--all-targets`, so dev-dependencies are never
+  compiled at 1.86), plus `async-trait`, `clap`, `thiserror`, `uuid`, and the CI action
+  bumps (#450, #451, #453).
+- **[test]** `tools_list_carries_the_safety_annotations`. The 22 safety annotations
+  shipped in 0.8.6 are consumed entirely by the rmcp macro and read back by nothing, so a
+  macro or model change in a major could have dropped every one of them with the build
+  green and every other test passing (#452, #406).
 - **[docs]** `docs/SOURCES.md` §6.1 records what each vendor publishes as a rate limit
   and what doiget does about it. §6 promised doiget adopts a stricter vendor guideline
   per source while recording no vendor's limit anywhere, so the promise could not be
@@ -204,15 +224,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Retracted
 
-- **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers. It
-  does not. `resolve_tdm_chain` still short-circuits every entry to `NotNeeded` the moment
-  `crossref_answered` is true, so a configured TDM key still yields byte-identical output
-  for the DOIs the chain exists to serve, and #458 is open. The bullet is struck from
+- **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers.
+  **In 0.8.9 it did not.** `resolve_tdm_chain` short-circuited every entry to `NotNeeded`
+  the moment `crossref_answered` was true, so a configured TDM key yielded byte-identical
+  output for exactly the DOIs the chain exists to serve. The bullet is struck from
   `## [0.8.9]` below and the GitHub Release body carries a correction; the `v0.8.9` tag
-  annotation is immutable and still states it. The notes were assembled by grepping
-  `main..next` for `Closes` and `Refs` and reading both as "fixed" — PR #466 wrote
-  `Refs #458` about an adjacent `cfg`-gate fix, deliberately and correctly. The two
-  keywords are not interchangeable when assembling release notes (#472).
+  annotation is immutable and still states it.
+
+  **#458 is fixed in this release** — see the Tier-3 content-leg entry above (ADR-0044).
+  The retraction stands anyway, because it is about what 0.8.9 *shipped*: a reader on
+  0.8.9 was told a feature worked when it did not, and a later fix does not unsay that.
+
+  Cause: the notes were assembled by grepping `main..next` for `Closes` and `Refs` and
+  reading both as "fixed". PR #466 wrote `Refs #458` about an adjacent `cfg`-gate fix,
+  deliberately and correctly. The two keywords are not interchangeable when assembling
+  release notes (#472).
+
+  This entry itself said "#458 is open" in the present tense until the 0.8.10 promotion
+  review caught it contradicting the Fixed section three screens above. A retraction that
+  goes stale is still a false statement.
 
 ## [0.8.9] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[test]** The three diagnostic wiring points would have survived being
+  disconnected. `batch --json`'s one line threading a real outcome's trace into the
+  record, and the MCP envelope's `attempts` and `remediation` insertions, each had
+  every nearby assertion calling the leaf helper directly with hand-built arguments —
+  so reverting any of them left the whole suite green while the trace or the
+  remediation vanished from the wire, which is the regression #459 exists to prevent.
+  `FetchPaperOutcome::for_test_synthetic_with_attempts` makes the first testable at
+  all: the plain constructor hard-codes `attempts: Vec::new()`, so the one test that
+  did drive `classify_joined` could not have observed a trace even if it had looked
+  (#471, #459).
+
 - **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.
   It said "Crossref, Unpaywall, arXiv"; a default `oa-only` build also registers
   `oa_publisher_allowlist` (~20 publisher/repository patterns), `api.openalex.org`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.10"
+version = "0.8.10-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.10"
+version = "0.8.10-beta.11"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.10"
+version = "0.8.10-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.6"
+version = "0.8.10-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.6"
+version = "0.8.10-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.6"
+version = "0.8.10-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.4"
+version = "0.8.10-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.4"
+version = "0.8.10-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.4"
+version = "0.8.10-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.9"
+version = "0.8.10-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.9"
+version = "0.8.10-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.9"
+version = "0.8.10-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.1"
+version = "0.8.10-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.1"
+version = "0.8.10-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.1"
+version = "0.8.10-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -631,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1781,7 +1781,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1838,7 +1838,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2030,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -2044,13 +2044,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2235,7 +2235,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2246,18 +2246,18 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,9 +2623,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2844,7 +2844,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.8"
+version = "0.8.10-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.8"
+version = "0.8.10-beta.9"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.8"
+version = "0.8.10-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -433,26 +433,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.2"
+version = "0.8.10-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.2"
+version = "0.8.10-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.2"
+version = "0.8.10-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1723,13 +1723,13 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
- "async-trait",
  "chrono",
  "futures",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
@@ -1741,19 +1741,20 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.14"
+version = "0.8.10-beta.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.14"
+version = "0.8.10-beta.15"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.14"
+version = "0.8.10-beta.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.15"
+version = "0.8.10-beta.16"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.15"
+version = "0.8.10-beta.16"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.15"
+version = "0.8.10-beta.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.16"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.16"
+version = "0.8.10"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.16"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.5"
+version = "0.8.10-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.5"
+version = "0.8.10-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.5"
+version = "0.8.10-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.9"
+version = "0.8.10-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.9"
+version = "0.8.10-beta.10"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.9"
+version = "0.8.10-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.11"
+version = "0.8.10-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.11"
+version = "0.8.10-beta.12"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.11"
+version = "0.8.10-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.9"
+version       = "0.8.10-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.9" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.9" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.9" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.1"
+version       = "0.8.10-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [
@@ -180,7 +180,7 @@ proptest    = "1"
 # DOIGET_STORE_ROOT, etc.) within a single test binary. Lifted to
 # workspace deps in #228 review pass A6 so the three member crates
 # (core / cli / mcp) cannot drift on the major version.
-serial_test = "3"
+serial_test = "4"
 
 # Phase 4 (citation graph)
 petgraph = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.2"
+version       = "0.8.10-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [
@@ -201,7 +201,7 @@ petgraph = "0.6"
 # `deny.toml` bans `axum` / `hyper::Server` / `openssl` / `native-tls`.
 # A `cargo tree -p doiget-mcp` after the edit must NOT show any of those
 # crates; `cargo deny check` enforces this in CI.
-rmcp = { version = "2.2", default-features = false, features = [
+rmcp = { version = "3.1", default-features = false, features = [
     "server", "macros", "transport-io", "schemars",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.15"
+version       = "0.8.10-beta.16"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.15" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.15" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.15" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.16" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.16" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.16" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.3"
+version       = "0.8.10-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.11"
+version       = "0.8.10-beta.12"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.11" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.11" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.11" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.12" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.12" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.12" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.5"
+version       = "0.8.10-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.10"
+version       = "0.8.10-beta.11"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.10" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.10" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.10" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.11" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.11" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.11" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.16"
+version       = "0.8.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.16" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.16" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.16" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.7"
+version       = "0.8.10-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.12"
+version       = "0.8.10-beta.13"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.12" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.12" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.12" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.13" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.13" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.13" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.14"
+version       = "0.8.10-beta.15"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.14" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.14" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.14" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.15" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.15" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.15" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.4"
+version       = "0.8.10-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.13"
+version       = "0.8.10-beta.14"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.13" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.13" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.13" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.14" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.14" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.14" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.8"
+version       = "0.8.10-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.9" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.9" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.9" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.6"
+version       = "0.8.10-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.6" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.6" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.6" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.9"
+version       = "0.8.10-beta.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.9" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.9" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.9" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.10" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.10" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.10" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -972,6 +972,71 @@ mod tests {
         );
     }
 
+    /// #471. The ONE line that threads a real outcome's trace into the
+    /// `--json` record had no test behind it: every assertion about
+    /// `attempts` called `build_jsonl_failure` directly with hand-built
+    /// arguments, and the only test that went through `classify_joined`
+    /// built its outcome with `for_test_synthetic`, which hard-codes
+    /// `attempts: Vec::new()` -- so it could not have observed a trace even
+    /// if it had looked.
+    ///
+    /// Reverting `batch.rs`'s `&outcome.attempts` to `&[]` left the whole
+    /// suite green while silently dropping the trace from `--json`, which is
+    /// the regression #459 exists to prevent.
+    #[test]
+    fn classify_joined_threads_the_real_outcomes_trace_into_the_json_record() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        use doiget_core::ErrorCode as Ec;
+
+        let blocked = PdfLegStatus::Blocked {
+            code: Ec::NetworkError,
+            message: "publisher refused".to_string(),
+            denial: None,
+            suggested_arxiv_id: None,
+        };
+        // A trace with something in it, and something a `&[]` cannot fake.
+        let attempts = vec![
+            SourceAttempt::new("crossref", AttemptOutcome::Resolved),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_HAL"],
+                },
+            ),
+        ];
+
+        let outcome = classify_joined(
+            Ok(TaskOutcome {
+                input: "10.1234/foo".to_string(),
+                result: Ok(FetchPaperOutcome::for_test_synthetic_with_attempts(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    blocked,
+                    attempts,
+                )),
+            }),
+            true,
+        );
+
+        let rec = outcome
+            .json_record
+            .unwrap_or_else(|| panic!("json mode must produce a record"));
+
+        let rows = rec["error"]["attempts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the trace must reach the wire; record: {rec}"));
+        assert_eq!(rows.len(), 2, "record: {rec}");
+        assert_eq!(rows[0]["source"], serde_json::json!("crossref"));
+        assert_eq!(rows[1]["source"], serde_json::json!("hal"));
+        // #470's structured form travels with it -- which is what proves this
+        // is the real outcome's trace rather than a placeholder.
+        assert_eq!(
+            rows[1]["required_env"],
+            serde_json::json!(["DOIGET_ENABLE_HAL"]),
+            "record: {rec}"
+        );
+    }
+
     #[test]
     fn classify_joined_blocked_pdf_emits_failure_with_denial_context() {
         // #210: a `PdfLegStatus::Blocked` outcome is reported as a

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -864,7 +864,7 @@ mod tests {
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
             SourceAttempt::new("core", AttemptOutcome::NoRecord),

--- a/crates/doiget-cli/src/commands/bib.rs
+++ b/crates/doiget-cli/src/commands/bib.rs
@@ -19,7 +19,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use doiget_core::refs::{self, Format};
 use doiget_core::store::{render, FsStore, Metadata, Store};
-use doiget_core::{Ref, Safekey};
+use doiget_core::Safekey;
 
 use super::fetch::CliExit;
 use super::output::print_err;
@@ -64,7 +64,7 @@ pub fn run(
         Some(r) => r,
         None => bail!("specify a ref, `--all`, or `--from-file <FILE>`"),
     };
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let safekey = ref_.safekey();
     match store.read(&safekey)? {
         Some(m) => write_all(&render::to_bibtex(safekey.as_str(), &m)),

--- a/crates/doiget-cli/src/commands/cite.rs
+++ b/crates/doiget-cli/src/commands/cite.rs
@@ -59,7 +59,7 @@ use super::resolve_store_root;
 /// `--quiet` does NOT suppress it. A total miss (no live resolve and no
 /// store entry) returns an error so the CLI exits non-zero.
 pub async fn run(input: String, offline: bool, _mode: super::output::OutputMode) -> Result<()> {
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
 
     // `--offline`: render straight from the store, no network at all.
     if offline {

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -142,12 +142,26 @@ pub async fn run(
     mode: super::output::OutputMode,
     network: bool,
     force: bool,
+    quiet_was_explicit: bool,
 ) -> Result<()> {
-    // `mode` honors ADR-0017: `Quiet` suppresses the TOML dump (`show`)
-    // and the path println! (`path`); `doctor` is unaffected because its
-    // per-check output is on stderr and only the failure/success exit
-    // code is the user-visible signal (#203). Json body for `show` is
-    // tracked in #204.
+    // `mode` honors ADR-0017, per ACTION rather than per command -- like
+    // `audit-log`, `config` is not uniformly one class:
+    //
+    //   * `path` / `show` are ARTIFACT. Their stdout IS the thing the
+    //     caller asked for, so only an EXPLICIT Quiet silences them. The
+    //     implicit non-TTY Quiet must not, which is #476: `doiget config
+    //     path` from a pipe printed zero bytes and exited 0, so the
+    //     documented way to find your config file (`docs/CONFIG.md` SS4,
+    //     SS12) answered a script, a CI step or an agent with silence AND
+    //     success. Third time the ADR-0017 classification was found
+    //     incomplete, after #219/#220 and #301.
+    //   * `init` is a STATUS report about a write that happened. Quiet of
+    //     either kind silences it; the exit code carries the outcome.
+    //   * `doctor` is unaffected either way -- its per-check output is on
+    //     stderr and the exit code is the signal (#203).
+    //
+    // Json body for `show` is tracked in #204.
+    let artifact_quiet = mode == super::output::OutputMode::Quiet && quiet_was_explicit;
     let cfg = ResolvedConfig::from_env()?;
     if network && action != "doctor" {
         eprintln_err("error: --network applies to `config doctor` only");
@@ -158,8 +172,14 @@ pub async fn run(
         return Err(anyhow::Error::new(CliExit(2)));
     }
     match action.as_str() {
+        "show" if artifact_quiet => {}
         "show" => match mode {
-            super::output::OutputMode::Quiet => {}
+            super::output::OutputMode::Quiet => {
+                // Implicit (non-TTY) Quiet: `show` is artifact-class, so
+                // render rather than suppress (#476).
+                let s = toml::to_string_pretty(&cfg)?;
+                print!("{s}");
+            }
             super::output::OutputMode::Json => {
                 // #204: `ResolvedConfig` is `Serialize` (already used for
                 // the TOML branch).
@@ -173,8 +193,12 @@ pub async fn run(
             }
         },
         "init" => init_config(&cfg, force, mode)?,
+        "path" if artifact_quiet => {}
         "path" => match mode {
-            super::output::OutputMode::Quiet => {}
+            super::output::OutputMode::Quiet => {
+                // Implicit (non-TTY) Quiet: naming the file IS the job.
+                println!("{}", cfg.config_path);
+            }
             super::output::OutputMode::Json => {
                 // Minimal JSON object so callers can parse the path
                 // uniformly; no trailing-newline ambiguity vs the raw
@@ -1003,6 +1027,7 @@ mod tests {
             crate::commands::output::OutputMode::Human,
             false,
             false,
+            false,
         )
         .await
         .expect_err("doctor should fail when DOIGET_CONTACT_EMAIL is unset");
@@ -1025,6 +1050,7 @@ mod tests {
         run(
             "doctor".into(),
             crate::commands::output::OutputMode::Human,
+            false,
             false,
             false,
         )
@@ -1080,6 +1106,7 @@ mod tests {
             crate::commands::output::OutputMode::Human,
             false,
             false,
+            false,
         )
         .await
         .expect_err("doctor should fail when user-extension config is malformed");
@@ -1119,6 +1146,7 @@ mod tests {
         let err = run(
             "bogus".into(),
             crate::commands::output::OutputMode::Human,
+            false,
             false,
             false,
         )

--- a/crates/doiget-cli/src/commands/csl.rs
+++ b/crates/doiget-cli/src/commands/csl.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 
 use doiget_core::refs::{self, Format};
 use doiget_core::store::{render, FsStore, Metadata, Store};
-use doiget_core::{Ref, Safekey};
+use doiget_core::Safekey;
 
 use super::fetch::CliExit;
 use super::output::print_err;
@@ -65,7 +65,7 @@ pub fn run(
         Some(r) => r,
         None => bail!("specify a ref, `--all`, or `--from-file <FILE>`"),
     };
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let safekey = ref_.safekey();
     match store.read(&safekey)? {
         Some(m) => write_array(&render::to_csl_array(safekey.as_str(), &m)),

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -597,6 +597,18 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
                 label, outcome.size_bytes, arxiv_id, outcome.path
             ));
         }
+        // #458: the publisher served its own copy under the user's TDM
+        // agreement. Named explicitly rather than left to the `_` arm
+        // below, which would have printed the same line as a plain OA
+        // fetch -- the user needs to know the open route failed and which
+        // agreement was drawn on, because that is the one with terms
+        // attached.
+        PdfLegStatus::TdmFetched { source, .. } => {
+            print_success(format_args!(
+                "fetched {} ({} bytes) via {} under your TDM agreement (no open copy available) -> {}",
+                label, outcome.size_bytes, source, outcome.path
+            ));
+        }
         // Issue #145: `Blocked` is NO LONGER a success outcome. It is
         // intercepted in `fetch_one` BEFORE `emit_success_line` is
         // called and rendered via `render_blocked_error` with a
@@ -814,7 +826,9 @@ fn emit_link_result(ref_: &Ref, outcome: &FetchPaperOutcome, dir: &Utf8Path) {
     };
     if !matches!(
         outcome.pdf_leg,
-        PdfLegStatus::Fetched | PdfLegStatus::PreprintFallback { .. }
+        PdfLegStatus::Fetched
+            | PdfLegStatus::PreprintFallback { .. }
+            | PdfLegStatus::TdmFetched { .. }
     ) {
         print_success(format_args!(
             "note: --link skipped for {label} (no PDF — metadata-only fetch)"

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -725,10 +725,7 @@ pub async fn run_with_options(
     let ref_ = match Ref::parse(&input) {
         Ok(r) => r,
         Err(e) => {
-            print_err(format_args!(
-                "error[{}]: invalid ref: {e}",
-                ErrorCode::InvalidRef.as_wire()
-            ));
+            super::render_ref_parse_error(&e);
             return Err(anyhow::Error::new(CliExit(cli_exit_code(
                 ErrorCode::InvalidRef,
             ))));

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -2059,7 +2059,7 @@ host = "*.uj.edu.pl"
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
         ];
@@ -2087,13 +2087,13 @@ host = "*.uj.edu.pl"
             SourceAttempt::new(
                 "core",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_CORE",
+                    env: &["DOIGET_ENABLE_CORE"],
                 },
             ),
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
         ];

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1100,14 +1100,50 @@ fn denial_note_lines(dc: &DenialContext, config_path: Option<&camino::Utf8Path>)
     out.push(format!(
         "  = help: that host is not on the allowlist yet; widen it in {where_}"
     ));
-    out.push(
-        "          [network] trust_academic_repos = true   # 15 curated academic suffixes"
-            .to_string(),
-    );
-    out.push(
-        "          [network] trust_oa_registries  = true   # DOAJ, SciELO, Zenodo, OSF, HAL"
-            .to_string(),
-    );
+    // #478: name the ONE flag that covers this host, not both.
+    //
+    // `trust_flag_for_host` already computes it, and
+    // `remediation::for_denial` calls it -- so MCP and `batch --json`
+    // consumers were getting the precise answer while the human was shown
+    // two flags with nothing to choose between them, and following the
+    // wrong one cost a round. The human has less context than the agent,
+    // not more.
+    //
+    // `None` means neither flag covers the host (a genuine publisher). The
+    // machine path offers no flag there; so does this one now, rather than
+    // suggesting two settings that cannot possibly help.
+    //
+    // Three cases, and "we did not compute it" is not the same answer as
+    // "we computed it and neither applies":
+    match dc.attempted.as_deref() {
+        // Known host, one flag covers it. Name that one.
+        Some(h) => match doiget_core::remediation::trust_flag_for_host(h) {
+            Some((flag, pattern, note)) => out.push(format!(
+                "          [network] {flag} = true   # covers {pattern} ({note})"
+            )),
+            // Known host, neither flag covers it -- a genuine publisher.
+            // The machine path offers no flag here (there is a test for
+            // it: `a_publisher_host_offers_no_trust_flag`), so neither
+            // does this one. Suggesting two settings that cannot help is
+            // worse than saying so.
+            None => out.push(
+                "          # neither trust_academic_repos nor trust_oa_registries covers this host"
+                    .to_string(),
+            ),
+        },
+        // No host to test. Both flags stay listed, because the reason for
+        // narrowing is absent rather than resolved.
+        None => {
+            out.push(
+                "          [network] trust_academic_repos = true   # 15 curated academic suffixes"
+                    .to_string(),
+            );
+            out.push(
+                "          [network] trust_oa_registries  = true   # DOAJ, SciELO, Zenodo, OSF, HAL"
+                    .to_string(),
+            );
+        }
+    }
     if dc.attempted.is_some() {
         for (pattern, why) in doiget_core::remediation::widening_suggestions(attempted) {
             out.push(format!(
@@ -1807,6 +1843,72 @@ host = "*.uj.edu.pl"
         assert!(
             joined.contains("docs/CONFIG.md §3.1"),
             "the schema section must be named; got:\n{joined}"
+        );
+    }
+
+    /// #478. Only ONE of the two flags covers any given host, and
+    /// `remediation::trust_flag_for_host` already computes which -- so the
+    /// MCP and `batch --json` consumers got the precise answer while the
+    /// human was shown both with nothing to choose between them.
+    #[test]
+    fn the_help_names_only_the_trust_flag_that_covers_the_host() {
+        let mut dc = denial(DenialReason::RedirectNotInAllowlist);
+        dc.attempted = Some("strathprints.strath.ac.uk".to_string());
+        let joined = denial_note_lines(&dc, None).join(
+            "
+",
+        );
+
+        assert!(
+            joined.contains("trust_academic_repos = true"),
+            "an *.ac.uk host is covered by the academic list; got:
+{joined}"
+        );
+        assert!(
+            !joined.contains("trust_oa_registries"),
+            "trust_oa_registries does nothing for this host and must not be offered; got:
+{joined}"
+        );
+        assert!(
+            joined.contains("*.ac.uk"),
+            "naming the pattern is what makes the suggestion checkable; got:
+{joined}"
+        );
+    }
+
+    /// And when neither covers it -- a genuine publisher host -- the human
+    /// is told so rather than handed two settings that cannot help. The
+    /// machine path already behaved this way
+    /// (`a_publisher_host_offers_no_trust_flag` in `doiget-core`).
+    #[test]
+    fn a_publisher_host_is_offered_no_trust_flag_in_the_human_help() {
+        let mut dc = denial(DenialReason::RedirectNotInAllowlist);
+        dc.attempted = Some("link.springer.com".to_string());
+        let joined = denial_note_lines(&dc, None).join(
+            "
+",
+        );
+
+        assert!(
+            !joined.contains("trust_academic_repos = true"),
+            "neither flag covers a publisher host; got:
+{joined}"
+        );
+        assert!(
+            !joined.contains("trust_oa_registries = true"),
+            "neither flag covers a publisher host; got:
+{joined}"
+        );
+        assert!(
+            joined.contains("neither trust_academic_repos nor trust_oa_registries"),
+            "saying so is the point -- silence would read as an omission; got:
+{joined}"
+        );
+        // The per-host escape hatch is still the real answer here.
+        assert!(
+            joined.contains("additional_hosts]] host = \"link.springer.com\""),
+            "got:
+{joined}"
         );
     }
 

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -58,12 +58,12 @@ pub async fn run(
     let ref_ = match Ref::parse(&input) {
         Ok(r) => r,
         Err(e) => {
-            // Bad ref string is user misuse → `docs/ERRORS.md` §4 exit 2
-            // (issue #149), consistent with `fetch`'s INVALID_REF path.
-            print_err(format_args!(
-                "error[{}]: invalid ref: {e}",
-                ErrorCode::InvalidRef.as_wire()
-            ));
+            // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2
+            // (issue #149). NOTE: `fetch` exits 1 for the same input; §4
+            // says misuse is 2, so they disagree and this is the one
+            // following the table. Not reconciled in #477 -- see
+            // `commands::render_ref_parse_error`.
+            super::render_ref_parse_error(&e);
             return Err(anyhow::Error::new(CliExit(2)));
         }
     };

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -12,7 +12,6 @@ use std::io::Write;
 use anyhow::{bail, Context, Result};
 
 use doiget_core::store::{FsStore, Store};
-use doiget_core::Ref;
 
 use super::resolve_store_root;
 
@@ -34,7 +33,7 @@ pub fn run(input: String, mode: super::output::OutputMode, quiet_was_explicit: b
     // caller needs. `Json` serialises `Metadata` directly (it carries
     // `Serialize`); the wire form is the field-name JSON of the on-disk
     // TOML (#204).
-    let ref_ = Ref::parse(&input).with_context(|| format!("invalid ref: {input}"))?;
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let safekey = ref_.safekey();
 
     let store_root = resolve_store_root()?;

--- a/crates/doiget-cli/src/commands/info.rs
+++ b/crates/doiget-cli/src/commands/info.rs
@@ -1,6 +1,7 @@
 //! `doiget info <ref>` subcommand — read-only metadata inspection.
 //!
-//! Reads the metadata TOML for a given [`Ref`] from the [`FsStore`] and
+//! Reads the metadata TOML for a given [`Ref`](doiget_core::Ref) from the
+//! [`FsStore`] and
 //! prints it on stdout. Network access is never required.
 //!
 //! Per [`docs/PUBLIC_API.md`](../../../../docs/PUBLIC_API.md) §2 the read goes
@@ -18,7 +19,8 @@ use super::resolve_store_root;
 /// Run the `info` subcommand against the configured store.
 ///
 /// `input` is the user-supplied ref string (e.g. `"10.1234/example"`,
-/// `"arxiv:2401.12345"`, or any of the schemes accepted by [`Ref::parse`]).
+/// `"arxiv:2401.12345"`, or any of the schemes accepted by
+/// [`Ref::parse`](doiget_core::Ref::parse)).
 ///
 /// On success, the entry's [`Metadata`](doiget_core::store::Metadata) is
 /// written to stdout as TOML. On a missing entry, the function returns an

--- a/crates/doiget-cli/src/commands/link.rs
+++ b/crates/doiget-cli/src/commands/link.rs
@@ -33,7 +33,7 @@ const OPENALEX_DEFAULT_BASE: &str = "https://api.openalex.org";
 /// [`ErrorCode`] as a process exit code via [`CliExit`] (e.g. a DOI with no
 /// OpenAlex work → `NOT_FOUND`).
 pub async fn run(ref_: String, mode: OutputMode, quiet_was_explicit: bool) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let doi = match parsed {
         Ref::Doi(d) => d,
         Ref::Arxiv(_) => {

--- a/crates/doiget-cli/src/commands/list_recent.rs
+++ b/crates/doiget-cli/src/commands/list_recent.rs
@@ -6,9 +6,16 @@
 //! most-recent first by `[doiget].fetched_at`. Network access is never
 //! required.
 //!
-//! Output is a tab-separated table with a header line. The four columns
+//! Output is a tab-separated table with a header line. The five columns
 //! match [`EntryInfo`](doiget_core::store::EntryInfo): `safekey`, `year`,
-//! `title`, `fetched_at`. Missing `year` / `fetched_at` render as `-`.
+//! `title`, `fetched_at`, `pdf`. Missing `year` / `fetched_at` render as
+//! `-`.
+//!
+//! `pdf` is #481. Without it this command -- the only one that answers
+//! "what do I have?" without knowing the ref in advance -- showed a
+//! metadata-only entry identically to a fetched paper. Batch fifty refs
+//! with ten blocked, come back later, and the natural conclusion is fifty
+//! papers.
 
 use std::io::Write;
 
@@ -28,7 +35,12 @@ const FETCHED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// Emits a tab-separated table on stdout. The column order is intentionally
 /// stable for `cut(1)` consumption; future fields will be APPENDED, not
 /// inserted.
-pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bool) -> Result<()> {
+pub fn run(
+    limit: usize,
+    missing_pdf: bool,
+    mode: super::output::OutputMode,
+    quiet_was_explicit: bool,
+) -> Result<()> {
     // `mode` honors ADR-0017: explicit `Quiet` suppresses the TSV table
     // but the store read still runs (so I/O failures surface as exit 1)
     // (#203). The non-TTY *implicit* Quiet does NOT suppress —
@@ -36,9 +48,15 @@ pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bo
     // listing IS the requested output. Json body is tracked in #204.
     let store_root = resolve_store_root()?;
     let store = FsStore::new(store_root)?;
-    let entries = store
+    let mut entries = store
         .list_recent(limit)
         .context("failed to list recent store entries")?;
+    // #481: "which of my fifty need retrying?" is the question the pdf
+    // column creates, and scanning a fifty-row table by eye is the thing a
+    // flag exists to avoid.
+    if missing_pdf {
+        entries.retain(|e| !e.has_pdf());
+    }
 
     if mode == super::output::OutputMode::Quiet && quiet_was_explicit {
         return Ok(());
@@ -47,19 +65,34 @@ pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bo
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     if mode == super::output::OutputMode::Json {
+        // `EntryInfo` serialises `size_bytes` directly. `has_pdf` is
+        // derived and added beside it, because a consumer should not have
+        // to know that `0` and `null` both mean "no PDF" while meaning
+        // different things about the entry.
+        let entries_json: Vec<serde_json::Value> = entries
+            .iter()
+            .map(|e| {
+                let mut v = serde_json::to_value(e)
+                    .unwrap_or_else(|_| serde_json::json!({ "safekey": e.safekey.as_str() }));
+                if let Some(o) = v.as_object_mut() {
+                    o.insert("has_pdf".into(), serde_json::json!(e.has_pdf()));
+                }
+                v
+            })
+            .collect();
         let envelope = serde_json::json!({
             "ok": true,
-            "count": entries.len(),
-            "entries": entries,
+            "count": entries_json.len(),
+            "entries": entries_json,
         });
         let s = serde_json::to_string_pretty(&envelope)
             .context("failed to serialize list-recent entries to JSON")?;
         writeln!(out, "{s}").context("failed to write list-recent JSON to stdout")?;
         return Ok(());
     }
-    writeln!(out, "safekey\tyear\ttitle\tfetched_at")
+    writeln!(out, "safekey\tyear\ttitle\tfetched_at\tpdf")
         .context("failed to write list-recent header to stdout")?;
-    for e in entries {
+    for e in &entries {
         let year = e.year.map(|y| y.to_string()).unwrap_or_else(|| "-".into());
         let fetched = e
             .fetched_at
@@ -67,13 +100,40 @@ pub fn run(limit: usize, mode: super::output::OutputMode, quiet_was_explicit: bo
             .unwrap_or_else(|| "-".into());
         writeln!(
             out,
-            "{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}",
             e.safekey.as_str(),
             year,
             e.title,
-            fetched
+            fetched,
+            pdf_cell(e)
         )
         .context("failed to write list-recent row to stdout")?;
     }
     Ok(())
+}
+
+/// Render the `pdf` column: the stored PDF size, or a dash for a
+/// metadata-only entry.
+///
+/// #481. APPENDED rather than inserted before `title`, because this
+/// module's contract is explicit that column order is stable for `cut(1)`
+/// and new fields go on the end. The issue suggested inserting it; that
+/// would break every existing `cut -f3` in the wild.
+///
+/// The size rather than a bare boolean: "1.0 MB" and "-" answer "did I get
+/// it?" equally well, and the size additionally answers "is this the paper
+/// or a one-page stub?", which is the next question and costs nothing.
+pub(crate) fn pdf_cell(e: &doiget_core::store::EntryInfo) -> String {
+    match e.size_bytes {
+        // `None` is "no `[doiget]` table", a different unknown from
+        // "0 bytes stored". Both mean no PDF; only one means the entry
+        // lacks the table that would say so.
+        None => "?".to_string(),
+        Some(0) => "-".to_string(),
+        #[allow(clippy::cast_precision_loss)]
+        Some(n) if n >= 1_048_576 => format!("{:.1} MB", n as f64 / 1_048_576.0),
+        #[allow(clippy::cast_precision_loss)]
+        Some(n) if n >= 1024 => format!("{:.1} kB", n as f64 / 1024.0),
+        Some(n) => format!("{n} B"),
+    }
 }

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -21,6 +21,57 @@
 //!
 //! Other subcommands (`serve`) land in separate PRs.
 
+/// Parse a ref, or render the failure in the `docs/ERRORS.md` §3
+/// "Researcher (CLI human)" form and return the CLI exit error.
+///
+/// #477. `error[CODE]: message` held on `fetch` alone -- #119 did it there
+/// and nowhere else -- while `info`, `link`, `cite`, `text`, `tag`, `bib`,
+/// `csl` and `source` each wrote their own `with_context("invalid ref: …")`
+/// and let `anyhow` print a bare `Error:` plus a `Caused by:` chain. The
+/// closed error-code set is a load-bearing promise of this project: a
+/// caller is told it can key off `error[CODE]:`, and on eight of nine
+/// commands there was no code to key off, while the `Caused by:` chain
+/// leaked internal error types that are in no contract.
+///
+/// Same shape as `render_fetch_error` and for the same reason -- one
+/// renderer, so a future change to the contract cannot reach some call
+/// sites and miss others.
+///
+/// # Errors
+///
+/// Always, when parsing fails: an [`anyhow::Error`] wrapping
+/// [`CliExit`](fetch::CliExit) with the `INVALID_REF` exit code. The
+/// message has already been written to stderr.
+pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
+    match doiget_core::Ref::parse(input) {
+        Ok(r) => Ok(r),
+        Err(e) => {
+            render_ref_parse_error(&e);
+            Err(anyhow::Error::new(fetch::CliExit(fetch::cli_exit_code(
+                doiget_core::ErrorCode::InvalidRef,
+            ))))
+        }
+    }
+}
+
+/// The renderer on its own, for the two call sites that already choose
+/// their own exit code.
+///
+/// `fetch` exits 1 (`cli_exit_code(InvalidRef)`) and `graph` exits 2,
+/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparseable
+/// argument is misuse, so they disagree and `graph` is the one following
+/// the table. Filed separately rather than changed here: #477 is about the
+/// message, `fetch`'s exit 1 is pinned by a named test, and quietly moving
+/// an exit code is how a script breaks without anyone noticing.
+///
+/// One renderer either way, which is the part that was missing.
+pub fn render_ref_parse_error(e: &doiget_core::RefParseError) {
+    output::print_err(format_args!(
+        "error[{}]: invalid ref: {e}",
+        doiget_core::ErrorCode::InvalidRef.as_wire()
+    ));
+}
+
 pub mod audit_log;
 pub mod batch;
 pub mod bib;

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -58,7 +58,7 @@ pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
 /// their own exit code.
 ///
 /// `fetch` exits 1 (`cli_exit_code(InvalidRef)`) and `graph` exits 2,
-/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparseable
+/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparsable
 /// argument is misuse, so they disagree and `graph` is the one following
 /// the table. Filed separately rather than changed here: #477 is about the
 /// message, `fetch`'s exit 1 is pinned by a named test, and quietly moving

--- a/crates/doiget-cli/src/commands/output.rs
+++ b/crates/doiget-cli/src/commands/output.rs
@@ -162,9 +162,23 @@ pub struct ResolvedOutput {
 ///   particular is almost always piped (`doiget text arxiv:… > paper.txt`),
 ///   so the implicit-Quiet fallback would otherwise blank the output.
 ///
-/// `audit-log` is omitted on purpose: it is *informational* in Human
-/// mode and *artifact* in Json mode; the command checks the resolved
-/// mode rather than its name, so this classifier doesn't apply.
+/// Two commands are omitted on purpose, because a name-level predicate
+/// cannot express them and pretending otherwise would be worse than the
+/// omission:
+///
+/// - `audit-log` is *informational* in Human mode and *artifact* in Json
+///   mode; the command checks the resolved mode rather than its name.
+/// - `config` is artifact-class in `path` and `show` (their stdout is the
+///   requested value) and status-class in `init`; `doctor` writes to
+///   stderr and is unaffected either way. It takes `quiet_was_explicit`
+///   and decides per action (#476).
+///
+/// This is the third time the list has been found incomplete (#219/#220,
+/// #301, #476), and the reason is visible above: it is a hand-maintained
+/// enumeration of a property no type carries. Deriving it from the command
+/// definition would end the pattern. Until then, a new subcommand that
+/// writes a *value* to stdout has to be added here or handled per action,
+/// or it is silent to every non-interactive caller.
 pub fn is_artifact_command(name: &str) -> bool {
     matches!(
         name,

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -165,9 +165,11 @@ fn run_local(
         write_json(&mut out, &local_envelope(query, &entries))?;
         return Ok(());
     }
-    writeln!(out, "safekey\tyear\ttitle\tfetched_at")
+    // Same column as `list-recent` (#481): `search --local` lists store
+    // entries too, so it had the same gap.
+    writeln!(out, "safekey\tyear\ttitle\tfetched_at\tpdf")
         .context("failed to write search header to stdout")?;
-    for e in entries {
+    for e in &entries {
         let year = dash_or(e.year);
         let fetched = e
             .fetched_at
@@ -175,11 +177,12 @@ fn run_local(
             .unwrap_or_else(|| "-".into());
         writeln!(
             out,
-            "{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}",
             e.safekey.as_str(),
             year,
             e.title,
-            fetched
+            fetched,
+            super::list_recent::pdf_cell(e)
         )
         .context("failed to write search row to stdout")?;
     }

--- a/crates/doiget-cli/src/commands/source.rs
+++ b/crates/doiget-cli/src/commands/source.rs
@@ -48,7 +48,7 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let id: ArxivId = match parsed {
         Ref::Arxiv(a) => a,
         Ref::Doi(_) => {

--- a/crates/doiget-cli/src/commands/tag.rs
+++ b/crates/doiget-cli/src/commands/tag.rs
@@ -14,7 +14,6 @@ use std::io::Write;
 use anyhow::{bail, Context, Result};
 
 use doiget_core::store::{FsStore, Store};
-use doiget_core::Ref;
 
 use super::output::OutputMode;
 use super::resolve_store_root;
@@ -37,7 +36,7 @@ pub fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let ref_ = Ref::parse(&ref_str).with_context(|| format!("invalid ref: {ref_str}"))?;
+    let ref_ = super::parse_ref_or_exit(&ref_str)?;
     let safekey = ref_.safekey();
 
     let store_root = resolve_store_root()?;
@@ -136,7 +135,7 @@ pub fn run_annotate(ref_str: String, text: Option<String>, clear: bool) -> Resul
         bail!("provide annotation <text> or --clear");
     }
 
-    let ref_ = Ref::parse(&ref_str).with_context(|| format!("invalid ref: {ref_str}"))?;
+    let ref_ = super::parse_ref_or_exit(&ref_str)?;
     let safekey = ref_.safekey();
 
     let store_root = resolve_store_root()?;

--- a/crates/doiget-cli/src/commands/text.rs
+++ b/crates/doiget-cli/src/commands/text.rs
@@ -45,7 +45,7 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let id: ArxivId = match parsed {
         Ref::Arxiv(a) => a,
         Ref::Doi(_) => {

--- a/crates/doiget-cli/src/commands/verify.rs
+++ b/crates/doiget-cli/src/commands/verify.rs
@@ -146,8 +146,22 @@ impl VerifyStatus {
 /// Entry point for `doiget verify <path> [--format] [--strict]`.
 pub async fn run(path: String, format: String, cli_strict: bool, mode: OutputMode) -> Result<()> {
     let fmt = parse_format(&format)?;
-    let text = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read reference file {path}"))?;
+    // #477: the misuse form, not a raw `anyhow` dump. `docs/ERRORS.md` §4
+    // classes an unusable argument as misuse (exit 2), and the closed
+    // `ErrorCode` set has no member for "your input file is missing" -- it
+    // describes fetch outcomes. Inventing one would be a wire change to a
+    // NORMATIVE closed set and deserves its own decision, so this uses the
+    // bare `error:` misuse shape the CLI already uses elsewhere (e.g.
+    // `config --network` applied to the wrong action).
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            super::output::print_err(format_args!(
+                "error: failed to read reference file {path}: {e}"
+            ));
+            return Err(anyhow::Error::new(super::fetch::CliExit(2)));
+        }
+    };
     let entries = parse_input(&text, fmt, Some(Utf8Path::new(&path)));
 
     // Resolve effective policy: CLI `--strict` is the strictest setting,

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -295,6 +295,13 @@ enum Command {
         /// Number of entries to show.
         #[arg(default_value_t = 10)]
         limit: usize,
+        /// Show only entries with no stored PDF -- the metadata-only ones.
+        ///
+        /// Answers "which of my batch need retrying?" without reading a
+        /// fifty-row table by eye. The `pdf` column carries the same
+        /// information for every row (#481).
+        #[arg(long)]
+        missing_pdf: bool,
     },
     /// Search for papers. Default: external discovery over OpenAlex
     /// (`/works?search=`, ADR-0031) — turn a topic into ranked candidate
@@ -782,8 +789,8 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Info { ref_ }) => {
             doiget_cli::commands::info::run(ref_, mode, out.quiet_was_explicit)
         }
-        Some(Command::ListRecent { limit }) => {
-            doiget_cli::commands::list_recent::run(limit, mode, out.quiet_was_explicit)
+        Some(Command::ListRecent { limit, missing_pdf }) => {
+            doiget_cli::commands::list_recent::run(limit, missing_pdf, mode, out.quiet_was_explicit)
         }
         Some(Command::Search {
             query,

--- a/crates/doiget-cli/src/main.rs
+++ b/crates/doiget-cli/src/main.rs
@@ -253,6 +253,12 @@ enum Command {
         link: Option<Utf8PathBuf>,
     },
     /// Fetch many refs from a newline-separated text file.
+    ///
+    /// With `--json`, records are written as each ref COMPLETES, not in
+    /// input order: up to 5 fetches run concurrently and a parse error
+    /// returns instantly where a 1 MB PDF does not. Key on the `ref` field
+    /// of each record; zipping stdout against the input file positionally
+    /// attaches results to the wrong DOI (#479).
     Batch {
         /// Path to a file containing one ref per line.
         path: String,
@@ -769,7 +775,10 @@ async fn run_dispatch(cli: Cli) -> anyhow::Result<()> {
             action,
             network,
             force,
-        }) => doiget_cli::commands::config::run(action, mode, network, force).await,
+        }) => {
+            doiget_cli::commands::config::run(action, mode, network, force, out.quiet_was_explicit)
+                .await
+        }
         Some(Command::Info { ref_ }) => {
             doiget_cli::commands::info::run(ref_, mode, out.quiet_was_explicit)
         }

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -33,7 +33,7 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
 // ---- #477: the contract is not "fetch has a code", it is "the CLI has" ---
 
 /// Every ref-taking command emits an `error[CODE]:` first stderr line for
-/// an unparseable input.
+/// an unparsable input.
 ///
 /// This is the assertion that matters. #119 gave `fetch` the contract and
 /// nothing generalised it, so eight sibling commands spent four releases
@@ -46,32 +46,37 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
 #[test]
 fn every_ref_taking_command_emits_the_error_code_contract() {
     // `verify` is excluded: it takes a FILE PATH, not a ref, so an
-    // unparseable value is a missing file rather than a bad ref. It gets
+    // unparsable value is a missing file rather than a bad ref. It gets
     // the `error:` misuse form instead -- see the test below.
-    const COMMANDS: &[&[&str]] = &[
-        &["fetch"],
-        &["info"],
-        &["link"],
-        &["cite"],
-        &["text"],
-        &["bib"],
-        &["csl"],
+    let mut commands: Vec<Vec<&str>> = vec![
+        vec!["fetch"],
+        vec!["info"],
+        vec!["link"],
+        vec!["cite"],
+        vec!["text"],
+        vec!["bib"],
+        vec!["csl"],
         // `source` needs `--out`; the ref is still the last positional.
-        &["source", "--out", "."],
-        &["graph"],
-        &["tag"],
+        vec!["source", "--out", "."],
+        vec!["tag"],
     ];
+    // `graph` only exists in a `citation` build, and CI's default job runs
+    // plain `oa-only` -- where the subcommand is absent and clap answers
+    // "unrecognized subcommand", which is not this contract's business.
+    if cfg!(feature = "citation") {
+        commands.push(vec!["graph"]);
+    }
 
     let td = TempDir::new().expect("tempdir");
     let root = td.path().to_str().expect("utf-8");
 
     let mut broken: Vec<String> = Vec::new();
-    for argv in COMMANDS {
+    for argv in &commands {
         let mut cmd = Command::cargo_bin("doiget").expect("doiget binary built");
         cmd.env("DOIGET_STORE_ROOT", root)
             .env("DOIGET_LOG_PATH", "")
             .env("DOIGET_CONTACT_EMAIL", "test@example.com")
-            .args(*argv)
+            .args(argv)
             .arg("not a doi");
         let out = cmd.output().expect("run doiget");
         let stderr = String::from_utf8_lossy(&out.stderr);

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -29,3 +29,108 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
         // stdout MUST stay clean (ADR-0001 stdio rule).
         .stdout(predicate::str::is_empty());
 }
+
+// ---- #477: the contract is not "fetch has a code", it is "the CLI has" ---
+
+/// Every ref-taking command emits an `error[CODE]:` first stderr line for
+/// an unparseable input.
+///
+/// This is the assertion that matters. #119 gave `fetch` the contract and
+/// nothing generalised it, so eight sibling commands spent four releases
+/// printing a raw `anyhow` dump -- `Error:` plus a `Caused by:` chain that
+/// leaks internal error types belonging to no contract -- while the docs
+/// told callers they could key off `error[CODE]:`.
+///
+/// Table-driven on purpose: a new ref-taking subcommand is added to this
+/// list or it is not covered, and the failure names which one regressed.
+#[test]
+fn every_ref_taking_command_emits_the_error_code_contract() {
+    // `verify` is excluded: it takes a FILE PATH, not a ref, so an
+    // unparseable value is a missing file rather than a bad ref. It gets
+    // the `error:` misuse form instead -- see the test below.
+    const COMMANDS: &[&[&str]] = &[
+        &["fetch"],
+        &["info"],
+        &["link"],
+        &["cite"],
+        &["text"],
+        &["bib"],
+        &["csl"],
+        // `source` needs `--out`; the ref is still the last positional.
+        &["source", "--out", "."],
+        &["graph"],
+        &["tag"],
+    ];
+
+    let td = TempDir::new().expect("tempdir");
+    let root = td.path().to_str().expect("utf-8");
+
+    let mut broken: Vec<String> = Vec::new();
+    for argv in COMMANDS {
+        let mut cmd = Command::cargo_bin("doiget").expect("doiget binary built");
+        cmd.env("DOIGET_STORE_ROOT", root)
+            .env("DOIGET_LOG_PATH", "")
+            .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+            .args(*argv)
+            .arg("not a doi");
+        let out = cmd.output().expect("run doiget");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let first = stderr.lines().next().unwrap_or("");
+
+        if !first.starts_with("error[") {
+            broken.push(format!("{}: {first}", argv.join(" ")));
+        }
+        // The `Caused by:` chain is the anyhow dump the contract replaces.
+        if stderr.contains("Caused by:") {
+            broken.push(format!("{}: leaked a `Caused by:` chain", argv.join(" ")));
+        }
+    }
+
+    assert!(
+        broken.is_empty(),
+        "these commands do not honour the error[CODE] contract for an invalid ref:\n  {}",
+        broken.join("\n  ")
+    );
+}
+
+/// `verify` takes a path, so its failure is a missing file. It still must
+/// not dump anyhow: `docs/ERRORS.md` §4 classes an unusable argument as
+/// misuse, and the closed `ErrorCode` set describes fetch outcomes, so
+/// there is no code for "your input file is missing" (#477).
+#[test]
+fn verify_renders_a_missing_input_file_as_misuse_not_an_anyhow_dump() {
+    let td = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .env("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8"))
+        .env("DOIGET_LOG_PATH", "")
+        .args(["verify", "no-such-file.bib"])
+        .assert()
+        .code(2)
+        .stderr(
+            predicate::str::starts_with("error: failed to read reference file")
+                .and(predicate::str::contains("Caused by:").not()),
+        )
+        .stdout(predicate::str::is_empty());
+}
+
+/// A mistyped DOI must not be told about arXiv.
+///
+/// `Ref::parse` falls through to the arXiv parser for anything without a
+/// scheme or a `10.` prefix, and reported that parser's failure verbatim --
+/// so `doiget fetch 10-1109-tsp` answered "input does not match any known
+/// arXiv id shape" to someone who was clearly aiming at a DOI (#477).
+#[test]
+fn an_unrecognised_ref_names_neither_shape_rather_than_arxiv() {
+    let td = TempDir::new().expect("tempdir");
+    Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .env("DOIGET_STORE_ROOT", td.path().to_str().expect("utf-8"))
+        .env("DOIGET_LOG_PATH", "")
+        .args(["fetch", "not-a-doi"])
+        .assert()
+        .stderr(
+            predicate::str::contains("neither a DOI")
+                .and(predicate::str::contains("nor an arXiv id")),
+        );
+}

--- a/crates/doiget-cli/tests/info_list_recent_e2e.rs
+++ b/crates/doiget-cli/tests/info_list_recent_e2e.rs
@@ -226,9 +226,114 @@ fn list_recent_on_empty_store_prints_only_header() {
     let stdout = String::from_utf8(assert.get_output().stdout.clone())
         .expect("doiget list-recent stdout was not UTF-8");
     assert_eq!(
-        stdout, "safekey\tyear\ttitle\tfetched_at\n",
+        stdout, "safekey\tyear\ttitle\tfetched_at\tpdf\n",
         "empty store should produce header-only stdout, got:\n{stdout}"
     );
+}
+
+// ---- #481: the inventory must distinguish a stub from a paper ----------
+
+/// Seed one entry with a stored PDF and one metadata-only entry
+/// (`size_bytes = 0`), which is exactly what a blocked content leg leaves
+/// behind.
+fn store_with_one_stub() -> (TempDir, Utf8PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = utf8_path(&dir).join("papers");
+    let store = FsStore::new(root.clone()).expect("FsStore::new");
+
+    let (k1, m1) = fixture("gotpdf", "A Paper We Actually Have", 2024, 2024);
+    store.write(&k1, &m1, None).expect("seed fetched entry");
+
+    let (k2, mut m2) = fixture("nopdf", "A Paper We Only Know About", 2023, 2023);
+    if let Some(d) = m2.doiget.as_mut() {
+        // What `fetch` writes when the content leg was blocked: the record
+        // is real, the bytes are not.
+        d.size_bytes = 0;
+    }
+    store
+        .write(&k2, &m2, None)
+        .expect("seed metadata-only entry");
+
+    (dir, root)
+}
+
+/// #481. Two entries, one with a PDF and one without, must not render
+/// alike. Before the `pdf` column they did -- and `list-recent` is the only
+/// command that answers "what do I have?" without being told the ref, so it
+/// was the one place the distinction was unrecoverable.
+#[test]
+fn list_recent_distinguishes_a_metadata_only_entry_from_a_fetched_one() {
+    let (_guard, root) = store_with_one_stub();
+    let assert = doiget(&root).args(["list-recent"]).assert().success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+
+    let have = stdout
+        .lines()
+        .find(|l| l.contains("A Paper We Actually Have"))
+        .unwrap_or_else(|| panic!("missing fetched row in:\n{stdout}"));
+    let stub = stdout
+        .lines()
+        .find(|l| l.contains("A Paper We Only Know About"))
+        .unwrap_or_else(|| panic!("missing metadata-only row in:\n{stdout}"));
+
+    assert!(
+        have.ends_with("1.2 kB"),
+        "a stored PDF must show its size; got:\n{have}"
+    );
+    assert!(
+        stub.ends_with('-'),
+        "a metadata-only entry must be visibly different; got:\n{stub}"
+    );
+}
+
+/// The column answers "which are stubs?" one row at a time. `--missing-pdf`
+/// answers it for a fifty-ref batch, which is the case that produced the
+/// report.
+#[test]
+fn list_recent_missing_pdf_lists_only_the_stubs() {
+    let (_guard, root) = store_with_one_stub();
+    let assert = doiget(&root)
+        .args(["list-recent", "--missing-pdf"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+
+    assert!(
+        stdout.contains("A Paper We Only Know About"),
+        "the stub must be listed; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("A Paper We Actually Have"),
+        "a fetched paper is not missing its PDF; got:\n{stdout}"
+    );
+}
+
+/// The JSON surface carries it too, and carries `has_pdf` beside
+/// `size_bytes` so a consumer does not have to know that `0` and `null`
+/// both mean "no PDF" while meaning different things about the entry.
+#[test]
+fn list_recent_json_carries_size_bytes_and_has_pdf() {
+    let (_guard, root) = store_with_one_stub();
+    let assert = doiget(&root)
+        .args(["--mode", "json", "list-recent"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let entries = v["entries"].as_array().expect("entries array");
+
+    let stub = entries
+        .iter()
+        .find(|e| e["title"].as_str() == Some("A Paper We Only Know About"))
+        .unwrap_or_else(|| panic!("stub missing from {stdout}"));
+    assert_eq!(stub["size_bytes"], serde_json::json!(0));
+    assert_eq!(stub["has_pdf"], serde_json::json!(false));
+
+    let have = entries
+        .iter()
+        .find(|e| e["title"].as_str() == Some("A Paper We Actually Have"))
+        .unwrap_or_else(|| panic!("fetched entry missing from {stdout}"));
+    assert_eq!(have["has_pdf"], serde_json::json!(true));
 }
 
 // ---- #204 JSON-mode coverage --------------------------------------------

--- a/crates/doiget-cli/tests/quiet_honoring_e2e.rs
+++ b/crates/doiget-cli/tests/quiet_honoring_e2e.rs
@@ -115,6 +115,42 @@ fn config_path_quiet_produces_no_stdout() {
         .stdout(predicate::str::is_empty());
 }
 
+// ---- #476: implicit (non-TTY) Quiet must NOT silence `config` ---------
+//
+// `assert_cmd` always gives the child a pipe, never a terminal, so these
+// exercise exactly the state the bug was reported in: no mode flag, no
+// `DOIGET_MODE`, stdout not a TTY. Before #476 both printed zero bytes and
+// exited 0 -- the documented way to locate your config file answering a
+// script, a CI step or an agent with silence AND success.
+//
+// The pair above (explicit `--mode quiet`) is what must keep working; these
+// are what must stop being suppressed. Both halves matter: fixing this by
+// making `config` unconditionally loud would break #203.
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn config_path_prints_when_stdout_is_not_a_tty() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+        .args(["config", "path"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("config.toml"));
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn config_show_prints_when_stdout_is_not_a_tty() {
+    let dir = TempDir::new().expect("tempdir");
+    doiget(&dir)
+        .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+        .args(["config", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
 // ---- audit-log Quiet + chain issues: exit non-zero, stdout empty ------
 //
 // Self-review for #207 §2: tampered-log under Quiet must still raise

--- a/crates/doiget-cli/tests/search_e2e.rs
+++ b/crates/doiget-cli/tests/search_e2e.rs
@@ -169,7 +169,7 @@ fn search_returns_no_match_for_unknown_query() {
         .expect("doiget search stdout was not UTF-8");
     // Header only, no data rows.
     assert_eq!(
-        stdout, "safekey\tyear\ttitle\tfetched_at\n",
+        stdout, "safekey\tyear\ttitle\tfetched_at\tpdf\n",
         "no-match search should produce header-only stdout, got:\n{stdout}"
     );
 }

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -883,6 +883,31 @@ impl HttpClient {
         self.fetch_inner(source, url, &[], true).await
     }
 
+    /// [`Self::fetch_pdf`] with request headers, for sources that
+    /// authenticate by header rather than by query parameter.
+    ///
+    /// This is the pairing the Tier-3 content leg needs (#458): APS Harvest
+    /// wants `X-API-Key` *and* `Accept: application/pdf` on the same request
+    /// that must be magic-byte checked. `fetch_bytes_with_headers` would
+    /// send the headers and skip the check, which is exactly how a
+    /// publisher error page or a WAF holding response — both 200s with a
+    /// body — would end up written to `<safekey>.pdf`.
+    ///
+    /// Header values are sent on the wire only; they are never logged and
+    /// never echoed into an error message (#146).
+    ///
+    /// # Errors
+    ///
+    /// Any [`HttpError`] variant including [`HttpError::NotAPdf`].
+    pub async fn fetch_pdf_with_headers(
+        &self,
+        source: &str,
+        url: Url,
+        headers: &[(&str, &str)],
+    ) -> Result<(Bytes, Url), HttpError> {
+        self.fetch_inner(source, url, headers, true).await
+    }
+
     /// Single diagnostic request against `url`, reporting what came back
     /// instead of turning it into an error.
     ///

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1007,9 +1007,89 @@ impl RateLimits {
     }
 
     /// Per-source backoff in milliseconds between consecutive requests.
+    ///
+    /// The floor that applies to every source. A source whose vendor
+    /// publishes something stricter gets that instead -- see
+    /// [`Self::backoff_ms_for`].
     pub const fn per_source_backoff_ms(&self) -> u64 {
         self.per_source_backoff_ms
     }
+
+    /// The minimum gap between two requests to `source`, in milliseconds.
+    ///
+    /// [`Self::per_source_backoff_ms`] unless [`SOURCE_RATE_OVERRIDES`]
+    /// names a stricter value, in which case the stricter one wins. Never
+    /// looser: `docs/SOURCES.md` promises doiget adopts a stricter vendor
+    /// guideline at the per-source level rather than relaxing the global
+    /// cap, and `max` here is what makes that promise structural instead of
+    /// a matter of getting every table entry right.
+    #[must_use]
+    pub fn backoff_ms_for(&self, source: &str) -> u64 {
+        match source_rate(source) {
+            Some(r) => r.min_interval_ms.max(self.per_source_backoff_ms),
+            None => self.per_source_backoff_ms,
+        }
+    }
+
+    /// The concurrency ceiling for `source`.
+    ///
+    /// Clamped to [`Self::max_concurrent_fetches`], so a table entry can
+    /// only ever tighten the global cap.
+    #[must_use]
+    pub fn max_concurrent_for(&self, source: &str) -> u32 {
+        match source_rate(source) {
+            Some(r) => r.max_concurrent.min(self.max_concurrent_fetches),
+            None => self.max_concurrent_fetches,
+        }
+    }
+}
+
+/// A vendor-published rate guideline stricter than the global cap.
+///
+/// Library constants selected by source key, never caller-supplied:
+/// `docs/LEGAL.md` §6a safeguard 5 makes [`RateLimits`] unsynthesizable by
+/// downstream code on purpose, and a per-source table that took values from
+/// a caller would hand back exactly what that safeguard withholds.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct SourceRate {
+    /// Minimum milliseconds between two requests to this source.
+    pub min_interval_ms: u64,
+    /// Maximum simultaneous requests to this source.
+    pub max_concurrent: u32,
+}
+
+/// Sources whose published terms are stricter than the global cap.
+///
+/// #493. The global cap is 5 requests/second and 5 concurrent, against
+/// arXiv's published *"make no more than one request every three seconds,
+/// and limit requests to a single connection at a time"* -- 15x the rate
+/// and 5x the concurrency. Three places in the tree asserted the global cap
+/// "comfortably respects" it.
+///
+/// A table rather than a config knob, and consulted through
+/// [`RateLimits::backoff_ms_for`] rather than read directly, so an entry can
+/// only ever tighten.
+///
+/// Keys are [`crate::source::Source::name`] values.
+pub const SOURCE_RATE_OVERRIDES: &[(&str, SourceRate)] = &[(
+    // <https://info.arxiv.org/help/api/tou.html>, read 2026-08-25. The
+    // limit is collective across every machine under the caller's control,
+    // and circumventing it may have access blocked.
+    "arxiv",
+    SourceRate {
+        min_interval_ms: 3_000,
+        max_concurrent: 1,
+    },
+)];
+
+/// The override for `source`, if any.
+#[must_use]
+pub fn source_rate(source: &str) -> Option<SourceRate> {
+    SOURCE_RATE_OVERRIDES
+        .iter()
+        .find(|(k, _)| *k == source)
+        .map(|(_, r)| *r)
 }
 
 /// A successful TDM grant.

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -2313,10 +2313,25 @@ mod tests {
     }
 
     #[test]
-    fn ref_parse_bare_without_10_prefix_uses_arxiv_errors() {
-        // Bare ambiguous fallback: ArxivId parser is dispatched and its
-        // error surfaces. `1.2.3` is neither a DOI nor an arXiv shape.
-        assert_eq!(Ref::parse("1.2.3"), Err(RefParseError::InvalidArxivShape));
+    fn ref_parse_bare_without_10_prefix_reports_neither_shape() {
+        // The comment on this test always said the right thing -- "`1.2.3`
+        // is neither a DOI nor an arXiv shape" -- while the assertion said
+        // `InvalidArxivShape`, which is the fallback parser's verdict
+        // rather than the truth about the input (#477). Someone who
+        // mistyped a DOI was told about arXiv id shapes.
+        assert_eq!(Ref::parse("1.2.3"), Err(RefParseError::UnrecognisedShape));
+    }
+
+    #[test]
+    fn an_explicit_arxiv_scheme_still_reports_the_arxiv_shape_error() {
+        // The narrowing in #477 applies ONLY to the ambiguous fall-through.
+        // When the caller declared `arxiv:`, the arXiv parser's verdict IS
+        // the truth about the input, and generalising it there would lose
+        // information rather than gain it.
+        assert_eq!(
+            Ref::parse("arxiv:1.2.3"),
+            Err(RefParseError::InvalidArxivShape)
+        );
     }
 
     #[test]

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -263,7 +263,13 @@ impl Ref {
         if s.starts_with("10.") {
             return Doi::parse(s).map(Ref::Doi);
         }
-        ArxivId::parse(s).map(Ref::Arxiv)
+        // Last resort. The input declared no scheme and has no `10.`
+        // prefix, so trying arXiv is a guess -- and reporting the guess's
+        // failure verbatim tells a user who mistyped a DOI about arXiv
+        // (#477). Report what is actually known: it matched neither.
+        ArxivId::parse(s)
+            .map(Ref::Arxiv)
+            .map_err(|_| RefParseError::UnrecognisedShape)
     }
 }
 
@@ -524,6 +530,14 @@ pub enum RefParseError {
     /// Input matched neither the new-style nor old-style arXiv shape.
     #[error("input does not match any known arXiv id shape")]
     InvalidArxivShape,
+    /// Input carried no scheme and no `10.` prefix, so it could have been
+    /// either kind of ref, and it was neither.
+    ///
+    /// #477: the fall-through used to report [`Self::InvalidArxivShape`],
+    /// so someone who mistyped a DOI was told about arXiv. The input names
+    /// no shape, so neither should the error.
+    #[error("input is neither a DOI (expected '10.<registrant>/<suffix>') nor an arXiv id")]
+    UnrecognisedShape,
 }
 
 impl From<RefParseError> for ErrorCode {

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4786,9 +4786,14 @@ mod tdm_chain_tests {
             .iter()
             .map(|r| r.url.path().to_string())
             .collect();
+        // The prefix APS publishes, not the one this repo happens to
+        // build. #484 shipped `/v2/article/` past every test in the tree
+        // precisely because each of them was written from the
+        // implementation's output.
+        const APS_DOCUMENTED_PREFIX: &str = "/v2/journals/articles/";
         assert!(
-            paths.iter().any(|p| p.contains("/v2/article/")),
-            "fetch_paper never reached tdm-aps; paths were {paths:?}"
+            paths.iter().any(|p| p.contains(APS_DOCUMENTED_PREFIX)),
+            "fetch_paper never reached tdm-aps at its documented endpoint; paths were {paths:?}"
         );
 
         // Evidence 2: and the trace says so, in terms an operator can act

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4086,6 +4086,58 @@ mod attempt_denial_tests {
         assert_eq!(outcome.wire(), "consulted_failed");
     }
 
+    /// The accessors are a narrowing, so the negative case matters as much
+    /// as the positive one: a caller that treated `denial()` as
+    /// "is this a failure" would mis-handle every `Failed` row.
+    #[test]
+    fn the_accessors_narrow_rather_than_generalise() {
+        let failed = AttemptOutcome::Failed {
+            detail: "connection reset".to_string(),
+        };
+        assert!(failed.denial().is_none());
+        assert!(failed.required_env().is_none());
+        assert!(failed.detail().is_some());
+
+        let disabled = AttemptOutcome::Disabled {
+            env: &["DOIGET_ENABLE_HAL"],
+        };
+        assert!(disabled.denial().is_none());
+        assert!(
+            disabled.detail().is_none(),
+            "`Disabled` carries structure; the joined string is built at the wire"
+        );
+        assert!(!disabled.was_consulted());
+        assert_eq!(
+            disabled.render(),
+            "not consulted (set DOIGET_ENABLE_HAL to enable)"
+        );
+    }
+
+    /// `attempted` is optional on a `DenialContext`, and the size cap has
+    /// no host to name. The prose has to hold either way.
+    #[test]
+    fn a_denial_without_an_attempted_host_still_renders() {
+        let outcome = AttemptOutcome::Denied {
+            denial: DenialContext {
+                reason: DenialReason::SizeCapExceeded,
+                source: Some("core".to_string()),
+                attempted: None,
+                expected: None,
+                hop_index: None,
+                cap: None,
+                actual: None,
+            },
+        };
+        assert_eq!(outcome.render(), "consulted: refused (SizeCapExceeded)");
+
+        // No config channel for a size cap, so no remediation key -- as
+        // opposed to an empty array, which would read as "we looked and
+        // there is nothing you can do" without saying so.
+        let v = attempts_to_value(&[SourceAttempt::new("core", outcome)]);
+        assert!(v[0].get("remediation").is_none(), "row: {}", v[0]);
+        assert!(v[0].get("denial_context").is_some(), "row: {}", v[0]);
+    }
+
     /// #470's second half. Tier 3 needs two variables, and joining them
     /// into `"A + B"` meant a consumer had to split on the separator --
     /// exactly what the `detail()` / `wire()` split exists to avoid.

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1596,6 +1596,10 @@ async fn fetch_paper_doi(
 #[cfg(feature = "metadata")]
 fn optional_source_oa_url<'a>(source: &str, meta: &'a Value) -> Option<&'a str> {
     match source {
+        // #461: OpenAlex reports every location it knows of, not just a
+        // best one, so it is the source most likely to name a repository
+        // copy for a hybrid-OA article whose publisher refused.
+        "openalex" => crate::sources::openalex::open_access_pdf_url(meta),
         "core" => crate::sources::core_oa::open_access_pdf_url(meta),
         "hal" => crate::sources::hal::open_access_pdf_url(meta),
         "europe-pmc" => crate::sources::europepmc::open_access_pdf_url(meta),
@@ -4266,6 +4270,16 @@ async fn resolve_optional_chain(
         crate::sources::core_oa::CoreSource::new,
         crate::sources::core_oa::CoreSource::with_base,
     );
+    // #461: `OpenalexSource` was compiled in and reachable from `doiget
+    // graph`, but absent from THIS chain -- so the #445 content-leg
+    // fall-through could never ask the one source that reports more than one
+    // location per work. The issue said the accessor was "the only missing
+    // piece"; the wiring was missing too.
+    let openalex_contact = contact_email_from_env();
+    let openalex = match optional_base("DOIGET_OPENALEX_BASE") {
+        Some(base) => crate::sources::openalex::OpenalexSource::with_base(base, openalex_contact),
+        None => crate::sources::openalex::OpenalexSource::new(openalex_contact),
+    };
 
     // The name is carried explicitly rather than read from `src.name()`:
     // that borrows the source, while a `SourceAttempt` holds a `'static`
@@ -4285,6 +4299,7 @@ async fn resolve_optional_chain(
         ("openaire", &["DOIGET_ENABLE_OPENAIRE"], &openaire),
         ("hal", &["DOIGET_ENABLE_HAL"], &hal),
         ("core", &["DOIGET_ENABLE_CORE"], &core),
+        ("openalex", &["DOIGET_ENABLE_OPENALEX"], &openalex),
     ];
 
     let mut resolved: Option<(&'static str, Value)> = None;
@@ -4573,6 +4588,7 @@ mod chain_tests {
                 "DOIGET_OPENAIRE_BASE",
                 "DOIGET_HAL_BASE",
                 "DOIGET_CORE_BASE",
+                "DOIGET_OPENALEX_BASE",
             ];
             Self(
                 VARS.iter()
@@ -4605,6 +4621,12 @@ mod chain_tests {
             ("openaire", host),
             ("hal", host),
             ("core", host),
+            // #461. Production registers this unconditionally via
+            // `discovery_allowlist` (ADR-0031, and there is a test in
+            // `commands/fetch.rs` guarding exactly that), so omitting it
+            // here would fail the source at `UnknownSource` for a reason
+            // production does not have.
+            ("openalex", host),
         ]));
         let session_id = "01J0000000000000000000TEST".to_string();
         let log = Arc::new(
@@ -4644,6 +4666,7 @@ mod chain_tests {
         p.metadata.openaire = true;
         p.metadata.core = true;
         p.metadata.europe_pmc = true;
+        p.metadata.openalex = true;
         p
     }
 
@@ -4653,6 +4676,83 @@ mod chain_tests {
             .find(|a| a.source == name)
             .unwrap_or_else(|| panic!("no attempt recorded for {name}; got {attempts:?}"))
             .outcome
+    }
+
+    /// Every source in the optional chain that can name an OA document URL
+    /// has an `optional_source_oa_url` arm, and each arm reads the field its
+    /// vendor actually uses.
+    ///
+    /// #461 caught this the hard way: adding `"openalex"` to the chain and
+    /// then DELETING its dispatch arm broke nothing -- no test, no clippy
+    /// warning. The chain entry and the arm are two halves of one wiring and
+    /// only the first half was pinned. Same shape as #471.
+    ///
+    /// Table-driven, so a new source is added here or is not covered, and a
+    /// failure names which one.
+    #[test]
+    fn every_oa_url_bearing_source_has_a_dispatch_arm() {
+        // Each case carries the field its vendor actually uses.
+        // Deliberately different per source: a shared shape would let one
+        // arm accidentally serve another and still look green.
+        let cases: &[(&str, serde_json::Value, &str)] = &[
+            (
+                "core",
+                serde_json::json!({ "downloadUrl": "https://core.example/1.pdf" }),
+                "https://core.example/1.pdf",
+            ),
+            (
+                "hal",
+                serde_json::json!({
+                    "openAccess_bool": true,
+                    "fileMain_s": "https://hal.example/2.pdf"
+                }),
+                "https://hal.example/2.pdf",
+            ),
+            (
+                "europe-pmc",
+                serde_json::json!({
+                    "fullTextUrlList": {
+                        "fullTextUrl": [{
+                            "documentStyle": "pdf",
+                            "availabilityCode": "OA",
+                            "url": "https://epmc.example/3.pdf"
+                        }]
+                    }
+                }),
+                "https://epmc.example/3.pdf",
+            ),
+            (
+                "openalex",
+                serde_json::json!({
+                    "locations": [
+                        { "is_oa": true, "pdf_url": "https://repo.example.ac.uk/4.pdf" }
+                    ]
+                }),
+                "https://repo.example.ac.uk/4.pdf",
+            ),
+        ];
+
+        let mut broken: Vec<String> = Vec::new();
+        for (source, meta, expected) in cases {
+            let got = optional_source_oa_url(source, meta);
+            if got != Some(*expected) {
+                broken.push(format!("{source}: expected {expected:?}, got {got:?}"));
+            }
+        }
+        assert!(
+            broken.is_empty(),
+            "these sources are in the optional chain but their document URL never reaches the \
+             content leg -- a missing or wrong `optional_source_oa_url` arm:\n  {}",
+            broken.join("\n  ")
+        );
+
+        // A source with no arm returns None rather than something else's
+        // URL, which is what keeps the dispatch honest as it grows.
+        assert_eq!(
+            optional_source_oa_url("datacite", &serde_json::json!({ "downloadUrl": "x" })),
+            None,
+            "datacite reports no document URL; it must not fall through to another arm"
+        );
     }
 
     /// THE regression for the bug this whole change exists to fix.
@@ -4684,7 +4784,14 @@ mod chain_tests {
         let names: Vec<&str> = attempts.iter().map(|a| a.source).collect();
         assert_eq!(
             names,
-            vec!["datacite", "europe-pmc", "openaire", "hal", "core"],
+            vec![
+                "datacite",
+                "europe-pmc",
+                "openaire",
+                "hal",
+                "core",
+                "openalex"
+            ],
             "the trace must list every source, in chain order"
         );
         for a in &attempts {
@@ -4697,7 +4804,7 @@ mod chain_tests {
         }
         assert_eq!(
             server.received_requests().await.expect("recorded").len(),
-            5,
+            6,
             "each enabled source must issue exactly one request"
         );
     }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4088,7 +4088,7 @@ mod attempt_denial_tests {
 
     /// The accessors are a narrowing, so the negative case matters as much
     /// as the positive one: a caller that treated `denial()` as
-    /// "is this a failure" would mis-handle every `Failed` row.
+    /// "is this a failure" would mishandle every `Failed` row.
     #[test]
     fn the_accessors_narrow_rather_than_generalise() {
         let failed = AttemptOutcome::Failed {

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -25,6 +25,7 @@ use crate::sources::arxiv::ArxivSource;
 use crate::sources::crossref::CrossrefSource;
 use crate::sources::unpaywall::UnpaywallSource;
 use crate::store::{DoigetExtension, Metadata, Store};
+use crate::DenialContext;
 use crate::{ArxivId, CapabilityProfile, Doi, Ref, Safekey, MAX_BATCH_REFS, SCHEMA_VERSION};
 
 /// Outcome of a successful [`metadata_only`] call.
@@ -1725,7 +1726,7 @@ async fn try_tdm_content_fallback(
     struct ContentEntry<'a> {
         name: &'static str,
         /// What the user must set, rendered verbatim into the trace.
-        enable_hint: &'static str,
+        enable_hint: &'static [&'static str],
         /// DOI prefixes this publisher registered (ADR-0041).
         prefixes: &'static [&'static str],
         /// Human name, for the wrong-publisher message.
@@ -1779,7 +1780,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-aps")]
     chain.push(ContentEntry {
         name: "tdm-aps",
-        enable_hint: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+        enable_hint: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"],
         prefixes: crate::sources::tdm_aps::PUBLISHER_PREFIXES,
         publisher: "American Physical Society (APS)",
         src: &aps,
@@ -1787,7 +1788,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-elsevier")]
     chain.push(ContentEntry {
         name: "tdm-elsevier",
-        enable_hint: "DOIGET_KEY_ELSEVIER + DOIGET_AGREE_TDM_ELSEVIER",
+        enable_hint: &["DOIGET_KEY_ELSEVIER", "DOIGET_AGREE_TDM_ELSEVIER"],
         prefixes: crate::sources::tdm_elsevier::PUBLISHER_PREFIXES,
         publisher: "Elsevier BV",
         src: &elsevier,
@@ -1795,7 +1796,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-springer")]
     chain.push(ContentEntry {
         name: "tdm-springer",
-        enable_hint: "DOIGET_KEY_SPRINGER + DOIGET_AGREE_TDM_SPRINGER",
+        enable_hint: &["DOIGET_KEY_SPRINGER", "DOIGET_AGREE_TDM_SPRINGER"],
         prefixes: crate::sources::tdm_springer::PUBLISHER_PREFIXES,
         publisher: "Springer Nature",
         src: &springer,
@@ -1803,7 +1804,7 @@ async fn try_tdm_content_fallback(
     #[cfg(feature = "tdm-ieee")]
     chain.push(ContentEntry {
         name: "tdm-ieee",
-        enable_hint: "DOIGET_KEY_IEEE + DOIGET_AGREE_TDM_IEEE",
+        enable_hint: &["DOIGET_KEY_IEEE", "DOIGET_AGREE_TDM_IEEE"],
         prefixes: crate::sources::tdm_ieee::PUBLISHER_PREFIXES,
         publisher: "IEEE",
         src: &ieee,
@@ -3699,8 +3700,15 @@ pub enum AttemptOutcome {
     /// Runtime flag unset — **not consulted**. Carries the env var so the
     /// message can name the exact thing the user has to change.
     Disabled {
-        /// e.g. `"DOIGET_ENABLE_HAL"`.
-        env: &'static str,
+        /// Every variable that has to be set, e.g.
+        /// `["DOIGET_ENABLE_HAL"]` or
+        /// `["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"]`.
+        ///
+        /// A list rather than a string because Tier 3 needs two, and
+        /// joining them into `"A + B"` put a separator on the #459 wire
+        /// that a consumer would have had to split on — which is the
+        /// thing the `detail()` / `wire()` split exists to avoid (#470).
+        env: &'static [&'static str],
     },
     /// This source cannot serve this kind of ref at all (e.g. an arXiv id
     /// handed to a DOI-only resolver). Not a misconfiguration.
@@ -3727,6 +3735,20 @@ pub enum AttemptOutcome {
         /// Source-specific detail, e.g. the access-rights code observed.
         detail: String,
     },
+    /// **Consulted**, and refused by a policy control with a structured
+    /// reason: a redirect off the allowlist, an insecure redirect, an
+    /// oversized body, a not-a-PDF (ADR-0023).
+    ///
+    /// Distinct from [`Self::Failed`] because the [`DenialContext`] is what
+    /// [`crate::remediation::for_denial`] consumes. `PdfLegStatus::Blocked`
+    /// kept it end to end and the MCP layer turned it into a remediation;
+    /// per-source rows flattened the same information to prose, so the
+    /// richest and most actionable case degraded to text on a wire that
+    /// #459 advertises as machine-readable (#470).
+    Denied {
+        /// The structured denial, verbatim.
+        denial: DenialContext,
+    },
     /// **Consulted.** The request itself failed (transport, auth, schema).
     Failed {
         /// Rendered error.
@@ -3747,7 +3769,11 @@ impl AttemptOutcome {
     pub fn was_consulted(&self) -> bool {
         matches!(
             self,
-            Self::NoRecord | Self::NotOpenAccess { .. } | Self::Failed { .. } | Self::Resolved
+            Self::NoRecord
+                | Self::NotOpenAccess { .. }
+                | Self::Denied { .. }
+                | Self::Failed { .. }
+                | Self::Resolved
         )
     }
 
@@ -3770,6 +3796,7 @@ impl AttemptOutcome {
             Self::NotNeeded => "not_consulted_not_needed",
             Self::NoRecord => "consulted_no_record",
             Self::NotOpenAccess { .. } => "consulted_not_open_access",
+            Self::Denied { .. } => "consulted_denied",
             Self::Failed { .. } => "consulted_failed",
             Self::Resolved => "consulted_resolved",
         }
@@ -3783,10 +3810,34 @@ impl AttemptOutcome {
     #[must_use]
     pub fn detail(&self) -> Option<&str> {
         match self {
-            Self::Disabled { env } => Some(env),
+            // `Disabled` and `Denied` carry structure, not a string.
+            // See `required_env` and `denial`; `attempts_to_value` renders
+            // both, and still emits a joined `detail` for each so the #459
+            // wire stays backwards compatible.
+            Self::Disabled { .. } | Self::Denied { .. } => None,
             Self::WrongPublisher { detail }
             | Self::NotOpenAccess { detail }
             | Self::Failed { detail } => Some(detail),
+            _ => None,
+        }
+    }
+
+    /// The variables a `Disabled` row needs set, in the order the user
+    /// should set them. `None` for every other outcome.
+    #[must_use]
+    pub fn required_env(&self) -> Option<&'static [&'static str]> {
+        match self {
+            Self::Disabled { env } => Some(env),
+            _ => None,
+        }
+    }
+
+    /// The structured denial behind a `Denied` row, which is what
+    /// [`crate::remediation::for_denial`] takes. `None` otherwise.
+    #[must_use]
+    pub fn denial(&self) -> Option<&DenialContext> {
+        match self {
+            Self::Denied { denial } => Some(denial),
             _ => None,
         }
     }
@@ -3796,7 +3847,9 @@ impl AttemptOutcome {
     #[must_use]
     pub fn render(&self) -> String {
         match self {
-            Self::Disabled { env } => format!("not consulted (set {env} to enable)"),
+            Self::Disabled { env } => {
+                format!("not consulted (set {} to enable)", env.join(" + "))
+            }
             Self::NotApplicable => "not consulted (cannot serve this ref kind)".to_string(),
             Self::WrongPublisher { detail } => format!("not consulted ({detail})"),
             Self::NotNeeded => "not consulted (an earlier source answered)".to_string(),
@@ -3804,6 +3857,13 @@ impl AttemptOutcome {
             Self::NotOpenAccess { detail } => {
                 format!("consulted: found, not open access ({detail})")
             }
+            // `{:?}` on the reason: `render` is explicitly prose (`wire`
+            // is the stable token), and the attempted host is the part a
+            // human acts on.
+            Self::Denied { denial } => match &denial.attempted {
+                Some(a) => format!("consulted: refused ({:?}, {a})", denial.reason),
+                None => format!("consulted: refused ({:?})", denial.reason),
+            },
             Self::Failed { detail } => format!("consulted: failed ({detail})"),
             Self::Resolved => "consulted: resolved".to_string(),
         }
@@ -3851,6 +3911,21 @@ pub fn attempts_to_value(attempts: &[SourceAttempt]) -> serde_json::Value {
                 o.insert("outcome".into(), serde_json::json!(a.outcome.wire()));
                 if let Some(d) = a.outcome.detail() {
                     o.insert("detail".into(), serde_json::json!(d));
+                }
+                if let Some(env) = a.outcome.required_env() {
+                    // `detail` stays a joined string so a #459-era consumer
+                    // reads the same field it always did; `required_env` is
+                    // the form that does not need splitting.
+                    o.insert("detail".into(), serde_json::json!(env.join(" + ")));
+                    o.insert("required_env".into(), serde_json::json!(env));
+                }
+                if let Some(dc) = a.outcome.denial() {
+                    o.insert("detail".into(), serde_json::json!(a.outcome.render()));
+                    o.insert("denial_context".into(), serde_json::json!(dc));
+                    let rem = crate::remediation::for_denial(dc);
+                    if !rem.is_empty() {
+                        o.insert("remediation".into(), serde_json::json!(rem));
+                    }
                 }
                 o.insert(
                     "consulted".into(),
@@ -3908,9 +3983,134 @@ fn classify_attempt(e: &FetchError) -> AttemptOutcome {
                 detail: hint.clone(),
             }
         }
-        other => AttemptOutcome::Failed {
-            detail: other.to_string(),
+        // A policy refusal before the untyped fallback (#470). The
+        // conversion already exists and yields exactly the reason /
+        // attempted / expected / hop_index that `remediation::for_denial`
+        // consumes; `classify_attempt` used to walk straight past it and
+        // stringify.
+        //
+        // `CapabilityNotGranted` is deliberately excluded. It is produced
+        // by a source's defensive gate BEFORE any request goes out, and
+        // `Denied` reports `was_consulted() == true` — which is the exact
+        // predicate the #442 reachability tests assert on. Routing it here
+        // would make a source that was never contacted claim it was. The
+        // orchestrator already reports that state as `Disabled`, which
+        // also names the variables to set.
+        other => match Option::<DenialContext>::from(other) {
+            Some(denial) if denial.reason != crate::DenialReason::CapabilityNotGranted => {
+                AttemptOutcome::Denied { denial }
+            }
+            _ => AttemptOutcome::Failed {
+                detail: other.to_string(),
+            },
         },
+    }
+}
+
+#[cfg(all(test, feature = "metadata"))]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod attempt_denial_tests {
+    use super::*;
+
+    use crate::http::HttpError;
+    use crate::DenialReason;
+
+    fn redirect_denial() -> FetchError {
+        FetchError::Http(HttpError::RedirectDenied {
+            source_key: "hal".to_string(),
+            host: "cdn.example.org".to_string(),
+            expected_hosts: vec!["hal.science".to_string()],
+        })
+    }
+
+    /// #470. A redirect denial on a metadata-chain source used to flatten
+    /// to `Failed { detail: "..." }` -- an untyped string on a wire #459
+    /// advertises as machine-readable, for the one case that is richest and
+    /// most actionable.
+    #[test]
+    fn a_policy_refusal_keeps_its_denial_context() {
+        let outcome = classify_attempt(&redirect_denial());
+        let denial = outcome
+            .denial()
+            .expect("a redirect denial must survive classification");
+        assert_eq!(denial.reason, DenialReason::RedirectNotInAllowlist);
+        assert_eq!(denial.attempted.as_deref(), Some("cdn.example.org"));
+        assert_eq!(outcome.wire(), "consulted_denied");
+        assert!(
+            outcome.was_consulted(),
+            "a refusal means a request went out"
+        );
+    }
+
+    /// The point of keeping it: `remediation::for_denial` becomes reachable
+    /// from a per-source row, so the row can tell the user what to change.
+    /// `PdfLegStatus::Blocked` could already do this; the rows could not.
+    #[test]
+    fn a_denied_row_carries_a_remediation_on_the_wire() {
+        let attempts = vec![SourceAttempt::new(
+            "hal",
+            classify_attempt(&redirect_denial()),
+        )];
+        let v = attempts_to_value(&attempts);
+        let row = &v[0];
+
+        assert_eq!(row["outcome"], serde_json::json!("consulted_denied"));
+        assert_eq!(
+            row["denial_context"]["reason"],
+            serde_json::json!("redirect_not_in_allowlist"),
+            "row: {row}"
+        );
+        let rem = row["remediation"]
+            .as_array()
+            .unwrap_or_else(|| panic!("a redirect denial has a config channel; row: {row}"));
+        assert!(!rem.is_empty());
+        assert!(
+            row["detail"].is_string(),
+            "`detail` must stay populated for a #459-era consumer; row: {row}"
+        );
+    }
+
+    /// `CapabilityNotGranted` is produced BEFORE any request goes out, so
+    /// routing it to `Denied` would make a source that was never contacted
+    /// report `was_consulted() == true` -- the predicate the #442
+    /// reachability tests rest on.
+    #[test]
+    fn an_ungranted_capability_is_not_reported_as_consulted_and_denied() {
+        let outcome = classify_attempt(&FetchError::NotEligible {
+            source_key: "tdm-aps".into(),
+        });
+        assert!(
+            outcome.denial().is_none(),
+            "got {outcome:?}: this never reached the network"
+        );
+        assert_eq!(outcome.wire(), "consulted_failed");
+    }
+
+    /// #470's second half. Tier 3 needs two variables, and joining them
+    /// into `"A + B"` meant a consumer had to split on the separator --
+    /// exactly what the `detail()` / `wire()` split exists to avoid.
+    #[test]
+    fn a_disabled_row_lists_its_variables_instead_of_joining_them() {
+        let attempts = vec![SourceAttempt::new(
+            "tdm-aps",
+            AttemptOutcome::Disabled {
+                env: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"],
+            },
+        )];
+        let v = attempts_to_value(&attempts);
+        let row = &v[0];
+
+        assert_eq!(
+            row["required_env"],
+            serde_json::json!(["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"]),
+            "row: {row}"
+        );
+        // Unchanged for anyone already reading it.
+        assert_eq!(
+            row["detail"],
+            serde_json::json!("DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS"),
+            "row: {row}"
+        );
     }
 }
 
@@ -3981,12 +4181,20 @@ async fn resolve_optional_chain(
     // that borrows the source, while a `SourceAttempt` holds a `'static`
     // key so the trace can outlive the chain. A test asserts the two agree,
     // so this cannot drift into a lie.
-    let chain: Vec<(&'static str, &'static str, &dyn crate::source::Source)> = vec![
-        ("datacite", "DOIGET_ENABLE_DATACITE", &datacite),
-        ("europe-pmc", "DOIGET_ENABLE_EUROPE_PMC", &epmc),
-        ("openaire", "DOIGET_ENABLE_OPENAIRE", &openaire),
-        ("hal", "DOIGET_ENABLE_HAL", &hal),
-        ("core", "DOIGET_ENABLE_CORE", &core),
+    // `&'static [&'static str]` rather than a single var: `AttemptOutcome::
+    // Disabled` now carries the whole list, because Tier 3 needs two and a
+    // joined string put a separator on the #459 wire (#470). Tier 2 needs
+    // one, which is a one-element list.
+    let chain: Vec<(
+        &'static str,
+        &'static [&'static str],
+        &dyn crate::source::Source,
+    )> = vec![
+        ("datacite", &["DOIGET_ENABLE_DATACITE"], &datacite),
+        ("europe-pmc", &["DOIGET_ENABLE_EUROPE_PMC"], &epmc),
+        ("openaire", &["DOIGET_ENABLE_OPENAIRE"], &openaire),
+        ("hal", &["DOIGET_ENABLE_HAL"], &hal),
+        ("core", &["DOIGET_ENABLE_CORE"], &core),
     ];
 
     let mut resolved: Option<(&'static str, Value)> = None;
@@ -4075,7 +4283,7 @@ async fn resolve_tdm_chain(
     struct Entry<'a> {
         name: &'static str,
         /// What the user must set, rendered verbatim into the trace.
-        enable_hint: &'static str,
+        enable_hint: &'static [&'static str],
         /// DOI prefixes this publisher registered.
         prefixes: &'static [&'static str],
         /// Human name, for the wrong-publisher message.
@@ -4115,7 +4323,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-aps")]
     chain.push(Entry {
         name: "tdm-aps",
-        enable_hint: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+        enable_hint: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"],
         prefixes: crate::sources::tdm_aps::PUBLISHER_PREFIXES,
         publisher: "American Physical Society (APS)",
         src: &aps,
@@ -4123,7 +4331,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-elsevier")]
     chain.push(Entry {
         name: "tdm-elsevier",
-        enable_hint: "DOIGET_KEY_ELSEVIER + DOIGET_AGREE_TDM_ELSEVIER",
+        enable_hint: &["DOIGET_KEY_ELSEVIER", "DOIGET_AGREE_TDM_ELSEVIER"],
         prefixes: crate::sources::tdm_elsevier::PUBLISHER_PREFIXES,
         publisher: "Elsevier BV",
         src: &elsevier,
@@ -4131,7 +4339,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-springer")]
     chain.push(Entry {
         name: "tdm-springer",
-        enable_hint: "DOIGET_KEY_SPRINGER + DOIGET_AGREE_TDM_SPRINGER",
+        enable_hint: &["DOIGET_KEY_SPRINGER", "DOIGET_AGREE_TDM_SPRINGER"],
         prefixes: crate::sources::tdm_springer::PUBLISHER_PREFIXES,
         publisher: "Springer Nature",
         src: &springer,
@@ -4139,7 +4347,7 @@ async fn resolve_tdm_chain(
     #[cfg(feature = "tdm-ieee")]
     chain.push(Entry {
         name: "tdm-ieee",
-        enable_hint: "DOIGET_KEY_IEEE + DOIGET_AGREE_TDM_IEEE",
+        enable_hint: &["DOIGET_KEY_IEEE", "DOIGET_AGREE_TDM_IEEE"],
         prefixes: crate::sources::tdm_ieee::PUBLISHER_PREFIXES,
         publisher: "IEEE",
         src: &ieee,
@@ -4434,7 +4642,7 @@ mod chain_tests {
         assert_eq!(
             outcome(&attempts, "hal"),
             &AttemptOutcome::Disabled {
-                env: "DOIGET_ENABLE_HAL"
+                env: &["DOIGET_ENABLE_HAL"]
             },
             "a disabled source must name the variable that enables it"
         );
@@ -4951,7 +5159,7 @@ mod tdm_chain_tests {
         assert_eq!(
             o,
             &AttemptOutcome::Disabled {
-                env: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS"
+                env: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"]
             },
             "a closed Tier-3 gate must name the key AND the agreement"
         );

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4007,7 +4007,21 @@ fn classify_attempt(e: &FetchError) -> AttemptOutcome {
     }
 }
 
-#[cfg(all(test, feature = "metadata"))]
+// Gated exactly as `classify_attempt` is, not more narrowly. Gating these
+// on `metadata` alone left the new code compiled but untested under the
+// coverage job's feature set (`tdm-*` without `metadata`) -- a smaller copy
+// of the same "is this actually exercised?" question #442/#458 are about,
+// and the reason `codecov/patch` failed on this PR.
+#[cfg(all(
+    test,
+    any(
+        feature = "metadata",
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
+    )
+))]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod attempt_denial_tests {
     use super::*;

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -770,6 +770,23 @@ pub enum PdfLegStatus {
         /// and audit trail context).
         original_block: String,
     },
+    /// The OA chain was blocked and a Tier-3 TDM source served the
+    /// publisher's own copy under the user's TDM agreement (#458).
+    ///
+    /// Distinct from [`Self::Fetched`] on purpose. The bytes did not come
+    /// from an OA host, they are not necessarily openly licensed, and the
+    /// user obtained them under an agreement they signed — provenance
+    /// that says `oa-publisher` here would be wrong in all three
+    /// respects.
+    TdmFetched {
+        /// The Tier-3 source that served it (`"tdm-aps"`, ...). Matches
+        /// [`crate::source::Source::name`].
+        source: String,
+        /// The OA-chain error that triggered the fallback, kept for the
+        /// audit trail — the user still needs to know the open route
+        /// failed even though the fetch succeeded.
+        original_block: String,
+    },
 }
 
 /// What `fetch_paper` wrote to disk and how.
@@ -1373,6 +1390,23 @@ async fn fetch_paper_doi(
         optional_resolved.as_ref().map(|(n, m)| (*n, m)),
     )
     .await;
+
+    // #458: and if even that found nothing, ask the publisher itself.
+    //
+    // This is the second Tier-3 consultation point, and the one that
+    // matters. `resolve_tdm_chain` above runs when *Crossref* missed,
+    // which is a question about metadata. The gap a TDM agreement is
+    // obtained to close is about bytes, and it opens here -- after
+    // Crossref answered perfectly well and the content leg still failed.
+    #[cfg(any(
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
+    ))]
+    let (pdf_leg, pdf_bytes) =
+        try_tdm_content_fallback(doi, pdf_leg, pdf_bytes, profile, ctx, &mut attempts).await;
+
     if let Some(fl) = fallback_license {
         license = fl;
     }
@@ -1407,14 +1441,17 @@ async fn fetch_paper_doi(
         }
     }
 
-    let is_preprint_fallback = matches!(pdf_leg, PdfLegStatus::PreprintFallback { .. });
     let (final_source_label, size_bytes, pdf_path_relative, pdf_staged) = match &pdf_bytes {
         Some(bytes) => {
             let staged = stage_pdf_to_tempfile(bytes)?;
-            let label = if is_preprint_fallback {
-                "arxiv".to_string()
-            } else {
-                "oa-publisher".to_string()
+            // Derived from the leg rather than from a boolean: #458 added a
+            // third way to end up holding bytes, and a two-valued flag
+            // would have quietly labelled the publisher's TDM copy
+            // `oa-publisher`.
+            let label = match &pdf_leg {
+                PdfLegStatus::PreprintFallback { .. } => "arxiv".to_string(),
+                PdfLegStatus::TdmFetched { source, .. } => source.clone(),
+                _ => "oa-publisher".to_string(),
             };
             (
                 label,
@@ -1631,6 +1668,193 @@ async fn try_optional_source_oa_fallback(
             (pdf_leg, pdf_bytes)
         }
     }
+}
+
+/// #458: the publisher's own copy, once the open routes are exhausted.
+///
+/// Triggered by a blocked *content* leg -- the trigger #445 already built
+/// for the optional OA chain, and the one Tier 3 always needed.
+/// `resolve_tdm_chain` fires on a Crossref miss instead, so for the DOIs
+/// these sources exist to serve -- ones Crossref resolves readily -- it
+/// recorded `NotNeeded` for every entry and no request ever went out.
+///
+/// Additive, like its two siblings: on any failure the ORIGINAL block is
+/// kept. The publisher's refusal on the open route is what the user has to
+/// act on; burying it under a second failure from the TDM endpoint would
+/// answer a question they did not ask.
+///
+/// Disclosure stays bounded exactly as ADR-0041 bounds it -- a source is
+/// only ever told about DOIs its own publisher registered. What rises is
+/// the frequency of consultation, not its scope.
+#[cfg(any(
+    feature = "tdm-elsevier",
+    feature = "tdm-aps",
+    feature = "tdm-springer",
+    feature = "tdm-ieee"
+))]
+#[allow(clippy::vec_init_then_push)]
+async fn try_tdm_content_fallback(
+    doi: &Doi,
+    pdf_leg: PdfLegStatus,
+    pdf_bytes: Option<Vec<u8>>,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    attempts: &mut Vec<SourceAttempt>,
+) -> (PdfLegStatus, Option<Vec<u8>>) {
+    struct ContentEntry<'a> {
+        name: &'static str,
+        /// What the user must set, rendered verbatim into the trace.
+        enable_hint: &'static str,
+        /// DOI prefixes this publisher registered (ADR-0041).
+        prefixes: &'static [&'static str],
+        /// Human name, for the wrong-publisher message.
+        publisher: &'static str,
+        src: &'a dyn crate::source::Source,
+    }
+
+    if pdf_bytes.is_some() {
+        return (pdf_leg, pdf_bytes);
+    }
+    let PdfLegStatus::Blocked {
+        message: ref blocked_message,
+        ..
+    } = pdf_leg
+    else {
+        return (pdf_leg, pdf_bytes);
+    };
+    let original_block = blocked_message.clone();
+
+    let ref_ = Ref::Doi(doi.clone());
+
+    #[cfg(feature = "tdm-aps")]
+    let aps = optional_base("DOIGET_APS_BASE").map_or_else(
+        crate::sources::tdm_aps::TdmApsSource::new,
+        crate::sources::tdm_aps::TdmApsSource::with_base,
+    );
+    #[cfg(feature = "tdm-elsevier")]
+    let elsevier = optional_base("DOIGET_ELSEVIER_BASE").map_or_else(
+        crate::sources::tdm_elsevier::TdmElsevierSource::new,
+        crate::sources::tdm_elsevier::TdmElsevierSource::with_base,
+    );
+    #[cfg(feature = "tdm-springer")]
+    let springer = optional_base("DOIGET_SPRINGER_BASE").map_or_else(
+        crate::sources::tdm_springer::TdmSpringerSource::new,
+        crate::sources::tdm_springer::TdmSpringerSource::with_base,
+    );
+    #[cfg(feature = "tdm-ieee")]
+    let ieee = optional_base("DOIGET_IEEE_BASE").map_or_else(
+        crate::sources::tdm_ieee::TdmIeeeSource::new,
+        crate::sources::tdm_ieee::TdmIeeeSource::with_base,
+    );
+
+    // Not a `vec![]` literal: each entry is `#[cfg]`-gated on its own
+    // publisher feature, and attribute-per-element inside a vec literal is
+    // not expressible. Same shape as `resolve_tdm_chain`; the
+    // `vec_init_then_push` allow is on the fn because the lint's span runs
+    // from the `let` across every push, so a statement-level attribute does
+    // not cover it.
+    #[allow(unused_mut)]
+    let mut chain: Vec<ContentEntry<'_>> = Vec::new();
+    #[cfg(feature = "tdm-aps")]
+    chain.push(ContentEntry {
+        name: "tdm-aps",
+        enable_hint: "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+        prefixes: crate::sources::tdm_aps::PUBLISHER_PREFIXES,
+        publisher: "American Physical Society (APS)",
+        src: &aps,
+    });
+    #[cfg(feature = "tdm-elsevier")]
+    chain.push(ContentEntry {
+        name: "tdm-elsevier",
+        enable_hint: "DOIGET_KEY_ELSEVIER + DOIGET_AGREE_TDM_ELSEVIER",
+        prefixes: crate::sources::tdm_elsevier::PUBLISHER_PREFIXES,
+        publisher: "Elsevier BV",
+        src: &elsevier,
+    });
+    #[cfg(feature = "tdm-springer")]
+    chain.push(ContentEntry {
+        name: "tdm-springer",
+        enable_hint: "DOIGET_KEY_SPRINGER + DOIGET_AGREE_TDM_SPRINGER",
+        prefixes: crate::sources::tdm_springer::PUBLISHER_PREFIXES,
+        publisher: "Springer Nature",
+        src: &springer,
+    });
+    #[cfg(feature = "tdm-ieee")]
+    chain.push(ContentEntry {
+        name: "tdm-ieee",
+        enable_hint: "DOIGET_KEY_IEEE + DOIGET_AGREE_TDM_IEEE",
+        prefixes: crate::sources::tdm_ieee::PUBLISHER_PREFIXES,
+        publisher: "IEEE",
+        src: &ieee,
+    });
+
+    // Replace the metadata-stage row rather than appending a second one.
+    // That row says `NotNeeded`, which was true of the metadata question
+    // and is now false of the one being asked.
+    fn record(attempts: &mut Vec<SourceAttempt>, name: &'static str, outcome: AttemptOutcome) {
+        attempts.retain(|a| a.source != name);
+        attempts.push(SourceAttempt::new(name, outcome));
+    }
+
+    for e in chain {
+        debug_assert_eq!(e.name, e.src.name(), "chain name must match Source::name");
+
+        // Prefix BEFORE credentials, per ADR-0041: a DOI this publisher
+        // never registered is not a configuration problem, and reporting
+        // it as one would send the user after an API key that would not
+        // have helped.
+        if !e.prefixes.contains(&doi.prefix()) {
+            record(
+                attempts,
+                e.name,
+                AttemptOutcome::WrongPublisher {
+                    detail: format!("DOI prefix {} is not {}", doi.prefix(), e.publisher),
+                },
+            );
+            continue;
+        }
+        if !e.src.can_serve(profile, &ref_) {
+            record(
+                attempts,
+                e.name,
+                AttemptOutcome::Disabled { env: e.enable_hint },
+            );
+            continue;
+        }
+
+        match e.src.fetch_content(&ref_, profile, ctx).await {
+            // A metadata-only source. It has nothing to say about the
+            // content question, so its metadata-stage row is left alone
+            // rather than overwritten with a verdict it never gave.
+            Ok(None) => {}
+            Ok(Some(bytes)) => {
+                tracing::info!(
+                    source = e.name,
+                    doi = %doi.as_str(),
+                    size = bytes.len(),
+                    "OA routes exhausted; the publisher served its own copy under the user's TDM agreement (#458)"
+                );
+                record(attempts, e.name, AttemptOutcome::Resolved);
+                return (
+                    PdfLegStatus::TdmFetched {
+                        source: e.name.to_string(),
+                        original_block,
+                    },
+                    Some(bytes.to_vec()),
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    source = e.name,
+                    error = %err,
+                    "TDM content leg failed; keeping the original block"
+                );
+                record(attempts, e.name, classify_attempt(&err));
+            }
+        }
+    }
+
+    (pdf_leg, pdf_bytes)
 }
 
 /// Auto preprint fallback (issue #325). Called after the DOI OA PDF chain

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1411,6 +1411,27 @@ async fn fetch_paper_doi(
         license = fl;
     }
 
+    // #458: the licence tracks the artifact that actually landed, not the
+    // work. That is already how the arXiv fallback behaves -- it overwrites
+    // `license` with the preprint's, because a CC-BY record about the
+    // published version says nothing about the file on disk.
+    //
+    // A TDM copy came from the publisher under an agreement the user
+    // signed, by a route the OA licence does not describe; carrying
+    // Unpaywall's `cc-by` forward would put an open-licence claim on it.
+    // doiget does not guess licences (`docs/SOURCES.md` -- Tier-2 sources
+    // report `unknown` rather than infer), and the APS record's licence
+    // field describes the article, not this retrieval. So: `unknown`.
+    #[cfg(any(
+        feature = "tdm-elsevier",
+        feature = "tdm-aps",
+        feature = "tdm-springer",
+        feature = "tdm-ieee"
+    ))]
+    if matches!(pdf_leg, PdfLegStatus::TdmFetched { .. }) {
+        license = "unknown".to_string();
+    }
+
     // Issue #120: Crossref is non-fatal, but if it failed AND the OA
     // PDF leg produced nothing, writing a DOI-only stub entry would
     // mask a total failure and violate the "explain why" promise.
@@ -4693,7 +4714,7 @@ mod tdm_chain_tests {
 
     use camino::Utf8PathBuf;
     use tempfile::TempDir;
-    use wiremock::matchers::method;
+    use wiremock::matchers::{header, method, path, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::http::HttpClient;
@@ -5030,6 +5051,315 @@ mod tdm_chain_tests {
             "the trace must record tdm-aps as consulted; got:
 {hint}"
         );
+    }
+    // -----------------------------------------------------------------
+    // #458 — the CONTENT leg. Everything above this line drives the
+    // metadata stage (Crossref missed); these drive the state #458 was
+    // actually reported in: Crossref answered fine, and the PDF is what
+    // could not be had.
+    // -----------------------------------------------------------------
+
+    /// The mock has to serve Crossref, Unpaywall, the OA host AND the TDM
+    /// endpoint, so every one of those source keys needs an allowlist
+    /// entry. `ctx_for` above registers only the `tdm-*` keys, which is
+    /// why its tests can only ever 404 their way to the chain.
+    fn ctx_for_content(host: &str) -> (TempDir, FetchContext) {
+        let td = TempDir::new().expect("tempdir");
+        let dir = Utf8PathBuf::try_from(td.path().to_path_buf()).expect("utf-8");
+        let http = Arc::new(HttpClient::new_for_tests_allow_http_multi(&[
+            ("crossref", host),
+            ("unpaywall", host),
+            ("oa-publisher", host),
+            ("tdm-aps", host),
+            ("tdm-elsevier", host),
+            ("tdm-springer", host),
+            ("tdm-ieee", host),
+        ]));
+        let session_id = "01J0000000000000000000CNT".to_string();
+        let log = Arc::new(
+            ProvenanceLog::open(dir.join("t.jsonl"), session_id.clone()).expect("log opens"),
+        );
+        (
+            td,
+            FetchContext {
+                http,
+                rate_limiter: Arc::new(RateLimiter::new(RateLimits::HARD_CODED)),
+                log,
+                session_id,
+                cache_root: None,
+            },
+        )
+    }
+
+    /// Minimal Crossref envelope. Its job here is simply to SUCCEED, which
+    /// is what makes `resolve_tdm_chain` record `NotNeeded` for every
+    /// Tier-3 entry — the short circuit #458 is about.
+    fn crossref_body() -> serde_json::Value {
+        serde_json::json!({
+            "status": "ok",
+            "message": {
+                "title": ["A paper APS published"],
+                "author": [{ "family": "Doe", "given": "Jane" }],
+                "issued": { "date-parts": [[2026, 1, 1]] },
+                "container-title": ["Physical Review X"],
+                "type": "journal-article"
+            }
+        })
+    }
+
+    /// Unpaywall reports an OA copy that will turn out to be unreachable.
+    /// `license` is deliberately `cc-by`: if the TDM copy inherited it,
+    /// the store would carry an open-licence claim about a file obtained
+    /// under a signed agreement.
+    fn unpaywall_body(oa_url: &str) -> serde_json::Value {
+        serde_json::json!({
+            "doi": "10.1103/PhysRevX.10.011001",
+            "is_oa": true,
+            "title": "A paper APS published",
+            "best_oa_location": {
+                "url": oa_url,
+                "url_for_pdf": oa_url,
+                "license": "cc-by"
+            }
+        })
+    }
+
+    const PDF_BYTES: &[u8] = b"%PDF-1.7\nthe publisher's own copy\n%%EOF\n";
+
+    /// Mount Crossref (answers), Unpaywall (points at a dead OA URL), the
+    /// dead OA URL itself, and whatever APS should reply with.
+    ///
+    /// Registration order matters: wiremock takes the first mock that
+    /// matches, so the Unpaywall catch-all goes last.
+    async fn mount_oa_blocked(server: &MockServer, aps: ResponseTemplate) {
+        let oa_url = format!("{}/oa/file.pdf", server.uri());
+        Mock::given(method("GET"))
+            .and(path_regex("^/works/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(crossref_body()))
+            .mount(server)
+            .await;
+        // The PDF representation of the APS article endpoint. Matched on
+        // `Accept` so it cannot be confused with the metadata-stage call
+        // to the same path — if the two were conflated this test would
+        // pass without the content leg existing at all.
+        Mock::given(method("GET"))
+            .and(path_regex("^/v2/journals/articles/"))
+            .and(header("accept", "application/pdf"))
+            .respond_with(aps)
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/oa/file.pdf"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(unpaywall_body(&oa_url)))
+            .mount(server)
+            .await;
+    }
+
+    fn aps_pdf_requests(reqs: &[wiremock::Request]) -> usize {
+        reqs.iter()
+            .filter(|r| {
+                r.url.path().starts_with("/v2/journals/articles/")
+                    && r.headers
+                        .get("accept")
+                        .and_then(|v| v.to_str().ok())
+                        .is_some_and(|v| v.contains("application/pdf"))
+            })
+            .count()
+    }
+
+    /// THE regression for #458.
+    ///
+    /// Crossref answers, so the metadata-stage chain records `NotNeeded`
+    /// for every Tier-3 source exactly as it always did. The OA copy is
+    /// refused. Before this change that was the end of it — byte-identical
+    /// output with the TDM gates open and closed, which is the report.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn tdm_content_leg_serves_the_pdf_when_the_oa_route_is_blocked() {
+        let server = MockServer::start().await;
+        mount_oa_blocked(
+            &server,
+            ResponseTemplate::new(200).set_body_bytes(PDF_BYTES),
+        )
+        .await;
+
+        let _bases = BaseGuard::to(&server.uri());
+        let _oa = OaBaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let store_td = TempDir::new().expect("tempdir");
+        let root = Utf8PathBuf::try_from(store_td.path().to_path_buf()).expect("utf-8");
+        let store = crate::store::FsStore::new(root.clone()).expect("store");
+
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("doi"));
+        let outcome = fetch_paper(&ref_, &all_gates_open(), &ctx, &store, &root)
+            .await
+            .expect("the TDM content leg should have supplied the PDF");
+
+        // Evidence 1: a PDF request actually went out to APS. Asserted on
+        // the mock's record rather than on the return value, because
+        // "reached" is the whole question (#442).
+        let reqs = server.received_requests().await.expect("recorded");
+        assert_eq!(
+            aps_pdf_requests(&reqs),
+            1,
+            "expected exactly one Accept: application/pdf request to the APS article endpoint; \
+             paths were {:?}",
+            reqs.iter().map(|r| r.url.path()).collect::<Vec<_>>()
+        );
+
+        // Evidence 2: the leg says where the bytes came from.
+        match &outcome.pdf_leg {
+            PdfLegStatus::TdmFetched {
+                source,
+                original_block,
+            } => {
+                assert_eq!(source, "tdm-aps");
+                assert!(
+                    !original_block.is_empty(),
+                    "the OA refusal must be carried forward, not discarded"
+                );
+            }
+            other => panic!("expected TdmFetched, got {other:?}"),
+        }
+
+        // Evidence 3: provenance names the publisher, not `oa-publisher`.
+        assert_eq!(outcome.source, "tdm-aps");
+        assert_eq!(outcome.size_bytes, PDF_BYTES.len() as u64);
+
+        // Evidence 4: and it does not claim the file is CC-BY. Unpaywall
+        // said `cc-by` about the OA location we never got; this file came
+        // from the publisher under an agreement, by a route that licence
+        // does not describe.
+        assert_eq!(
+            outcome.license, "unknown",
+            "a TDM-retrieved copy must not inherit the OA location's licence"
+        );
+    }
+
+    /// Prefix scoping still holds on the new path (ADR-0041). An Elsevier
+    /// DOI must not cause a request to APS — the disclosure argument for
+    /// the whole feature depends on it, and the new consultation point
+    /// fires far more often than the old one.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn tdm_content_leg_is_not_consulted_for_another_publishers_doi() {
+        let server = MockServer::start().await;
+        mount_oa_blocked(
+            &server,
+            ResponseTemplate::new(200).set_body_bytes(PDF_BYTES),
+        )
+        .await;
+
+        let _bases = BaseGuard::to(&server.uri());
+        let _oa = OaBaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let store_td = TempDir::new().expect("tempdir");
+        let root = Utf8PathBuf::try_from(store_td.path().to_path_buf()).expect("utf-8");
+        let store = crate::store::FsStore::new(root.clone()).expect("store");
+
+        // An Elsevier prefix, with the APS gate wide open.
+        let ref_ = Ref::Doi(Doi::parse("10.1016/j.physrep.2020.01.001").expect("doi"));
+        let _ = fetch_paper(&ref_, &all_gates_open(), &ctx, &store, &root).await;
+
+        let reqs = server.received_requests().await.expect("recorded");
+        assert_eq!(
+            aps_pdf_requests(&reqs),
+            0,
+            "an Elsevier DOI reached the APS content endpoint; paths were {:?}",
+            reqs.iter().map(|r| r.url.path()).collect::<Vec<_>>()
+        );
+    }
+
+    /// The zero-request test above proves nothing reached APS. It cannot
+    /// prove WHICH gate stopped it: `Source::can_serve` checks the prefix
+    /// too, so deleting the orchestrator check leaves that test green.
+    ///
+    /// What only the orchestrator produces is the DISTINCTION. ADR-0041
+    /// checks the prefix before credentials precisely so a foreign DOI
+    /// reads as `WrongPublisher` rather than `Disabled` -- otherwise the
+    /// trace tells the user to go and find an API key that would not have
+    /// helped, which is the failure #438 added the trace to prevent.
+    ///
+    /// Mirrors `a_foreign_doi_is_wrong_publisher_not_disabled`, which
+    /// makes the same assertion about the metadata chain.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn content_leg_reports_a_foreign_doi_as_wrong_publisher_not_disabled() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let doi = Doi::parse("10.1016/j.physrep.2020.01.001").expect("doi");
+        let blocked = PdfLegStatus::Blocked {
+            code: crate::ErrorCode::NetworkError,
+            message: "the open route refused us".to_string(),
+            denial: None,
+            suggested_arxiv_id: None,
+        };
+        let mut attempts: Vec<SourceAttempt> = Vec::new();
+
+        let (leg, bytes) =
+            try_tdm_content_fallback(&doi, blocked, None, &all_gates_open(), &ctx, &mut attempts)
+                .await;
+
+        assert!(bytes.is_none(), "no publisher owns this DOI here");
+        assert!(matches!(leg, PdfLegStatus::Blocked { .. }));
+        assert!(
+            matches!(outcome(&attempts, "tdm-aps"), AttemptOutcome::WrongPublisher { .. }),
+            "an Elsevier DOI must read as WrongPublisher for tdm-aps, not Disabled; got {attempts:?}"
+        );
+    }
+
+    /// A 200 that is not a PDF must not become `<safekey>.pdf`, and must
+    /// not displace the OA refusal the user has to act on.
+    ///
+    /// This is the case `fetch_bytes_with_headers` would have gotten
+    /// wrong: publisher error pages and WAF holding responses are 200s
+    /// with a body.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn tdm_content_leg_rejects_a_non_pdf_body_and_keeps_the_original_block() {
+        let server = MockServer::start().await;
+        mount_oa_blocked(
+            &server,
+            ResponseTemplate::new(200).set_body_string("<html>Access denied</html>"),
+        )
+        .await;
+
+        let _bases = BaseGuard::to(&server.uri());
+        let _oa = OaBaseGuard::to(&server.uri());
+        let (_td, ctx) = ctx_for_content(&server.address().to_string());
+
+        let store_td = TempDir::new().expect("tempdir");
+        let root = Utf8PathBuf::try_from(store_td.path().to_path_buf()).expect("utf-8");
+        let store = crate::store::FsStore::new(root.clone()).expect("store");
+
+        let ref_ = Ref::Doi(Doi::parse("10.1103/PhysRevX.10.011001").expect("doi"));
+        let outcome = fetch_paper(&ref_, &all_gates_open(), &ctx, &store, &root)
+            .await
+            .expect("a metadata-only outcome is still an outcome");
+
+        // The request went out...
+        let reqs = server.received_requests().await.expect("recorded");
+        assert_eq!(aps_pdf_requests(&reqs), 1);
+
+        // ...and the HTML did not become a PDF.
+        match &outcome.pdf_leg {
+            PdfLegStatus::Blocked { message, .. } => {
+                assert!(
+                    !message.is_empty(),
+                    "the ORIGINAL OA refusal must survive, not the TDM failure"
+                );
+            }
+            other => panic!("expected the original Blocked leg to survive, got {other:?}"),
+        }
+        assert_eq!(outcome.size_bytes, 0, "nothing should have been stored");
     }
 }
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -913,6 +913,30 @@ impl FetchPaperOutcome {
             attempts: Vec::new(),
         }
     }
+
+    /// [`Self::for_test_synthetic`] carrying a resolution trace.
+    ///
+    /// #471: the plain constructor hard-codes `attempts: Vec::new()`, so a
+    /// test driving `classify_joined` with a `Blocked` outcome could not
+    /// observe a trace even if it looked -- and none did. Reverting the one
+    /// line that threads `outcome.attempts` into `build_jsonl_failure` left
+    /// the whole suite green, silently dropping the trace from `--json`,
+    /// which is the regression #459 exists to prevent.
+    ///
+    /// `#[doc(hidden)]` for the same reason as its sibling: not a stable
+    /// public API.
+    #[doc(hidden)]
+    pub fn for_test_synthetic_with_attempts(
+        safekey: impl Into<String>,
+        source: impl Into<String>,
+        pdf_leg: PdfLegStatus,
+        attempts: Vec<SourceAttempt>,
+    ) -> Self {
+        Self {
+            attempts,
+            ..Self::for_test_synthetic(safekey, source, pdf_leg)
+        }
+    }
 }
 
 /// Resolve a [`Ref`] to a PDF (or metadata-only fallback) and write it

--- a/crates/doiget-core/src/rate_limiter.rs
+++ b/crates/doiget-core/src/rate_limiter.rs
@@ -41,12 +41,19 @@ pub struct RateLimiter {
     global_starts: Arc<Mutex<Vec<Instant>>>,
     // Earliest-allowed start time per source name.
     per_source_next: Arc<Mutex<HashMap<String, Instant>>>,
+    // #493: per-source concurrency, for sources whose terms cap it below
+    // the global semaphore. Created lazily so a source with no override
+    // costs nothing.
+    per_source_sem: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
 }
 
 /// Held while a fetch is in flight; releases the concurrency slot on drop.
 #[derive(Debug)]
 pub struct Permit {
     _slot: OwnedSemaphorePermit,
+    // #493: held for the same lifetime as the global slot when the source
+    // has a stricter concurrency cap.
+    _source_slot: Option<OwnedSemaphorePermit>,
 }
 
 impl RateLimiter {
@@ -58,7 +65,37 @@ impl RateLimiter {
             sem: Arc::new(Semaphore::new(max)),
             global_starts: Arc::new(Mutex::new(Vec::new())),
             per_source_next: Arc::new(Mutex::new(HashMap::new())),
+            per_source_sem: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Wait out the per-source interval for one ADDITIONAL request inside a
+    /// fetch that already holds a [`Permit`].
+    ///
+    /// #493. arXiv's terms cap *requests*, and one arXiv attempt issues two
+    /// of them -- the Atom feed, then the PDF -- under a single `acquire`.
+    /// The second was previously unpaced, so even a perfectly serialised
+    /// caller sent two requests back to back.
+    ///
+    /// Does not touch the concurrency slots: the caller already holds them,
+    /// and taking them again would deadlock at `max_concurrent_for == 1`,
+    /// which is exactly the arXiv case.
+    pub async fn pace(&self, source: &str) {
+        let backoff = Duration::from_millis(self.limits.backoff_ms_for(source));
+        let mut next_map = self.per_source_next.lock().await;
+        if let Some(&next) = next_map.get(source) {
+            if Instant::now() < next {
+                drop(next_map);
+                sleep_until(next).await;
+                next_map = self.per_source_next.lock().await;
+            }
+        }
+        let start = Instant::now();
+        next_map.insert(source.to_string(), start + backoff);
+        drop(next_map);
+
+        let mut starts = self.global_starts.lock().await;
+        starts.push(start);
     }
 
     /// Block until a slot is available, then return a [`Permit`].
@@ -109,9 +146,38 @@ impl RateLimiter {
             sleep_until(wake).await;
         }
 
+        // Step 2b: per-source concurrency (#493). After the global
+        // semaphore, so the global cap is still the ceiling, and before the
+        // interval wait, so a source capped at one connection serialises
+        // rather than piling up sleepers.
+        let source_slot = {
+            let cap = self.limits.max_concurrent_for(source) as usize;
+            if cap >= self.limits.max_concurrent_fetches() as usize {
+                None
+            } else {
+                let sem = {
+                    let mut map = self.per_source_sem.lock().await;
+                    Arc::clone(
+                        map.entry(source.to_string())
+                            .or_insert_with(|| Arc::new(Semaphore::new(cap))),
+                    )
+                };
+                #[allow(clippy::expect_used)]
+                Some(
+                    sem.acquire_owned()
+                        .await
+                        .expect("per-source semaphore is never closed"),
+                )
+            }
+        };
+
         // Step 3: per-source backoff. Acquire `per_source_next` strictly
         // after dropping `global_starts` above (lock order documented).
-        let backoff = Duration::from_millis(self.limits.per_source_backoff_ms());
+        //
+        // #493: `backoff_ms_for`, not `per_source_backoff_ms` -- the
+        // vendor's published guideline when it is stricter than the global
+        // 200 ms floor.
+        let backoff = Duration::from_millis(self.limits.backoff_ms_for(source));
         let mut next_map = self.per_source_next.lock().await;
         let now = Instant::now();
         if let Some(&next) = next_map.get(source) {
@@ -134,7 +200,10 @@ impl RateLimiter {
         starts.push(start);
         drop(starts);
 
-        Permit { _slot: slot }
+        Permit {
+            _slot: slot,
+            _source_slot: source_slot,
+        }
     }
 
     /// Tell the limiter to delay further starts to `source` by at least
@@ -307,5 +376,89 @@ mod tests {
             elapsed_x,
             delay
         );
+    }
+
+    // ---- #493: a vendor guideline stricter than the global cap ---------
+
+    /// arXiv publishes one request every three seconds. The global cap is
+    /// 5/s, so before #493 two consecutive arXiv requests were 200 ms
+    /// apart -- 15x the permitted rate -- while three places in the tree
+    /// asserted the global cap "comfortably respects" the guideline.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn arxiv_requests_are_three_seconds_apart() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        let t0 = Instant::now();
+        drop(rl.acquire("arxiv").await);
+        drop(rl.acquire("arxiv").await);
+        let elapsed = Instant::now() - t0;
+        assert!(
+            elapsed >= Duration::from_millis(3_000),
+            "arXiv requests must be >= 3 s apart; got {elapsed:?}"
+        );
+    }
+
+    /// The table only ever tightens. A source with no entry keeps the
+    /// global 200 ms floor, so the fix cannot have slowed everything else
+    /// down by accident.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn a_source_without_an_override_keeps_the_global_backoff() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        let t0 = Instant::now();
+        drop(rl.acquire("crossref").await);
+        drop(rl.acquire("crossref").await);
+        let elapsed = Instant::now() - t0;
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "the global floor still applies; got {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(3_000),
+            "crossref has no override and must not inherit arXiv's; got {elapsed:?}"
+        );
+    }
+
+    /// The second request of ONE arXiv attempt is paced too. arXiv caps
+    /// requests, not attempts, and an attempt issues two -- the Atom feed
+    /// and the PDF -- under a single permit (#493).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn pace_spaces_a_second_request_inside_one_attempt() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        let permit = rl.acquire("arxiv").await;
+        let t0 = Instant::now();
+        // Deliberately while the permit is still held: `pace` must not
+        // touch the concurrency slots, or arXiv's cap of one connection
+        // would deadlock against itself.
+        rl.pace("arxiv").await;
+        let elapsed = Instant::now() - t0;
+        drop(permit);
+        assert!(
+            elapsed >= Duration::from_millis(3_000),
+            "the second leg must wait out the interval; got {elapsed:?}"
+        );
+    }
+
+    /// The table is a ceiling-tightener, not a general knob: an entry that
+    /// tried to be *looser* than the global settings must not take effect.
+    #[test]
+    fn an_override_can_only_tighten() {
+        let l = RateLimits::HARD_CODED;
+        assert_eq!(l.backoff_ms_for("arxiv"), 3_000);
+        assert_eq!(l.backoff_ms_for("crossref"), l.per_source_backoff_ms());
+        assert_eq!(l.max_concurrent_for("arxiv"), 1);
+        assert_eq!(l.max_concurrent_for("crossref"), l.max_concurrent_fetches());
+        // Every entry is at least as strict as the global cap on both axes.
+        // `backoff_ms_for` / `max_concurrent_for` enforce it at call time;
+        // this pins the TABLE, so a future entry cannot be added in the
+        // belief that it relaxes something and then silently do nothing.
+        for (name, r) in crate::SOURCE_RATE_OVERRIDES {
+            assert!(
+                r.min_interval_ms >= l.per_source_backoff_ms(),
+                "{name}: an override looser than the global floor is silently ignored"
+            );
+            assert!(
+                r.max_concurrent <= l.max_concurrent_fetches(),
+                "{name}: an override cannot raise the global concurrency cap"
+            );
+        }
     }
 }

--- a/crates/doiget-core/src/rate_limiter.rs
+++ b/crates/doiget-core/src/rate_limiter.rs
@@ -81,6 +81,14 @@ impl RateLimiter {
     /// and taking them again would deadlock at `max_concurrent_for == 1`,
     /// which is exactly the arXiv case.
     pub async fn pace(&self, source: &str) {
+        // The global cap admits this request too. Review of #493 caught the
+        // first draft pushing a start into `global_starts` WITHOUT waiting
+        // on the window -- which inflates the window for every other source
+        // while never being bounded by it. It cannot bite at arXiv's 3 s
+        // interval, and "it cannot bite in practice" is the reasoning that
+        // produced #493 in the first place.
+        self.await_global_rate_window().await;
+
         let backoff = Duration::from_millis(self.limits.backoff_ms_for(source));
         let mut next_map = self.per_source_next.lock().await;
         if let Some(&next) = next_map.get(source) {
@@ -122,29 +130,8 @@ impl RateLimiter {
             .await
             .expect("rate-limiter semaphore is never closed");
 
-        // Step 2: global rate cap. Loop until the rolling-second window has
-        // room, sleeping until the oldest entry ages out if it does not.
-        let max_per_sec = self.limits.max_fetches_per_second() as usize;
-        let one_sec = Duration::from_secs(1);
-        loop {
-            let mut starts = self.global_starts.lock().await;
-            let now = Instant::now();
-            // Prune entries older than 1 s. starts is FIFO so we can drop
-            // a contiguous prefix.
-            let cutoff = now.checked_sub(one_sec).unwrap_or(now);
-            let drop_count = starts.iter().take_while(|t| **t <= cutoff).count();
-            if drop_count > 0 {
-                starts.drain(..drop_count);
-            }
-            if starts.len() < max_per_sec {
-                break;
-            }
-            // Window is full — wake at the moment the oldest entry ages out.
-            // starts.len() >= max_per_sec >= 1 here, so [0] is safe.
-            let wake = starts[0] + one_sec;
-            drop(starts);
-            sleep_until(wake).await;
-        }
+        // Step 2: global rate cap.
+        self.await_global_rate_window().await;
 
         // Step 2b: per-source concurrency (#493). After the global
         // semaphore, so the global cap is still the ceiling, and before the
@@ -203,6 +190,35 @@ impl RateLimiter {
         Permit {
             _slot: slot,
             _source_slot: source_slot,
+        }
+    }
+
+    /// Block until the global rolling-second window has room.
+    ///
+    /// Loops because another task may take the slot between the wake and
+    /// the re-check. Holds only `global_starts`, and never across a sleep,
+    /// so it composes with the documented lock order.
+    async fn await_global_rate_window(&self) {
+        let max_per_sec = self.limits.max_fetches_per_second() as usize;
+        let one_sec = Duration::from_secs(1);
+        loop {
+            let mut starts = self.global_starts.lock().await;
+            let now = Instant::now();
+            // Prune entries older than 1 s. `starts` is FIFO, so this is a
+            // contiguous prefix.
+            let cutoff = now.checked_sub(one_sec).unwrap_or(now);
+            let drop_count = starts.iter().take_while(|t| **t <= cutoff).count();
+            if drop_count > 0 {
+                starts.drain(..drop_count);
+            }
+            if starts.len() < max_per_sec {
+                return;
+            }
+            // Window is full -- wake when the oldest entry ages out.
+            // `starts.len() >= max_per_sec >= 1` here, so `[0]` is safe.
+            let wake = starts[0] + one_sec;
+            drop(starts);
+            sleep_until(wake).await;
         }
     }
 
@@ -434,6 +450,30 @@ mod tests {
         assert!(
             elapsed >= Duration::from_millis(3_000),
             "the second leg must wait out the interval; got {elapsed:?}"
+        );
+    }
+
+    /// `pace` is admitted by the global window, not merely recorded in it.
+    ///
+    /// Found by reading the diff, not by a failing test -- the first draft
+    /// pushed a start into `global_starts` without ever waiting on the
+    /// window, so an extra request inflated the cap for every other source
+    /// while being bounded by none of it. Unreachable at arXiv's 3 s
+    /// interval, which is precisely the argument that let #493 ship.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn pace_is_admitted_by_the_global_window_too() {
+        let rl = RateLimiter::new(RateLimits::HARD_CODED);
+        // Fill the rolling second to the global maximum, on distinct
+        // sources so no per-source interval is in play.
+        for s in ["a", "b", "c", "d", "e"] {
+            drop(rl.acquire(s).await);
+        }
+        let t0 = Instant::now();
+        rl.pace("f").await;
+        let elapsed = Instant::now() - t0;
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "pace must wait for the global window exactly as acquire does; got {elapsed:?}"
         );
     }
 

--- a/crates/doiget-core/src/remediation.rs
+++ b/crates/doiget-core/src/remediation.rs
@@ -177,7 +177,10 @@ pub fn widening_suggestions(host: &str) -> Vec<(String, &'static str)> {
         return out;
     }
     let parent = parent_labels.join(".");
-    out.push((format!("*.{parent}"), "the whole publisher"));
+    // "the whole publisher" was wrong for the dominant case (#478): this
+    // fires most often for institutional repositories, and every host in
+    // the built-in `trust_academic_repos` list is a university.
+    out.push((format!("*.{parent}"), "the whole domain"));
     out.push((parent, "apex too (a wildcard does not match it)"));
     out
 }

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -329,6 +329,47 @@ pub trait Source: Send + Sync {
         profile: &CapabilityProfile,
         ctx: &FetchContext,
     ) -> Result<FetchResult, FetchError>;
+
+    /// Fetch the publisher's own copy of the document itself, when this
+    /// source holds one.
+    ///
+    /// Distinct from [`Self::fetch`], which resolves a *record*. A Tier-3
+    /// TDM source is consulted for two different reasons at two different
+    /// points in the fetch, and conflating them is what #458 was:
+    ///
+    /// - [`fetch`](Self::fetch) answers "who can tell me about this DOI?"
+    ///   and runs when Crossref could not;
+    /// - `fetch_content` answers "who will give me the bytes?" and runs
+    ///   when the content leg was blocked — which is usually *after*
+    ///   Crossref answered perfectly well.
+    ///
+    /// The default is `Ok(None)`: "this source is metadata-only". Stating
+    /// it is the point. Before #458 the same fact was expressed by every
+    /// Tier-3 impl setting `FetchResult.pdf_bytes` to `None` and saying so
+    /// in a doc-comment, which the orchestrator could neither read nor act
+    /// on — so it could not tell a source that had nothing to offer from
+    /// one it had simply never asked.
+    ///
+    /// Implementations that override it MUST use a PDF-validating fetch
+    /// ([`HttpClient::fetch_pdf`] or
+    /// [`HttpClient::fetch_pdf_with_headers`]). A publisher error page or
+    /// a WAF holding response is a 200 with a body, and storing one under
+    /// `<safekey>.pdf` would be worse than returning nothing.
+    ///
+    /// # Errors
+    ///
+    /// Any [`FetchError`]. `Ok(None)` means "not me"; `Err` means "me, and
+    /// it went wrong". The orchestrator keeps the original content-leg
+    /// block either way, but records the two as different attempt
+    /// outcomes.
+    async fn fetch_content(
+        &self,
+        _ref_: &Ref,
+        _profile: &CapabilityProfile,
+        _ctx: &FetchContext,
+    ) -> Result<Option<Bytes>, FetchError> {
+        Ok(None)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -1,8 +1,15 @@
 //! arXiv source — arXiv id → PDF + Atom-feed metadata.
 //!
-//! Spec: `docs/SOURCES.md` §4 arXiv. No auth; the API has a 3-second-per-request
-//! rate guideline that doiget's 5/sec global + 200ms per-source backoff
-//! comfortably respects (no extra source-specific tuning needed).
+//! Spec: `docs/SOURCES.md` §4 arXiv. No auth. The API's Terms of Use cap
+//! requests at **one every three seconds, single connection** — stricter
+//! than the global 5/sec + 200 ms backoff, which this comment previously
+//! claimed "comfortably respects" it. It did not: that was 15x the rate and
+//! 5x the concurrency (#493, ADR-0045).
+//!
+//! The limit now comes from [`crate::SOURCE_RATE_OVERRIDES`], and because
+//! it caps REQUESTS rather than attempts, the PDF leg below calls
+//! [`crate::rate_limiter::RateLimiter::pace`] — one attempt issues two
+//! requests, and only the first was paced by the permit.
 //!
 //! # Fetch flow (full)
 //!
@@ -277,6 +284,14 @@ impl Source for ArxivSource {
         };
 
         // ----- PDF leg -------------------------------------------------
+        //
+        // #493: arXiv's terms cap REQUESTS, not attempts, and this is the
+        // second request of this attempt -- the Atom leg above was the
+        // first. The `acquire` permit paced that one; without this the two
+        // went out back to back, so even a perfectly serialised caller
+        // broke the published interval.
+        ctx.rate_limiter.pace(self.name()).await;
+
         let url = self.pdf_url(id)?;
 
         // `fetch_pdf` enforces the magic-byte check (`%PDF-`) per

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -214,6 +214,47 @@ impl Source for OpenalexSource {
 /// hints. Avoids dumping a multi-KB payload into a single log line
 /// when the response is malformed; 200 chars is enough to identify the
 /// shape (HTML 404 page vs. JSON error envelope vs. truncated work).
+/// Extract an open-access PDF URL from an OpenAlex Work record.
+///
+/// #461. OpenAlex carries a `locations[]` array -- every place it knows the
+/// work exists -- where Unpaywall's `best_oa_location` is one. For a
+/// hybrid-OA article whose publisher leg is refused, the copy that satisfies
+/// the fetch is often an institutional repository sitting in that array and
+/// in no curated list.
+///
+/// Returns the first entry with `is_oa == true` and a non-empty `pdf_url`.
+/// `landing_page_url` is deliberately NOT used: it is a page about the paper,
+/// not the paper, and `try_fetch_oa_pdf` would reject the HTML as `NotAPdf`
+/// after having made the request.
+///
+/// Like the CORE / HAL / Europe PMC accessors, this only SURFACES a
+/// candidate. The fetch is still performed by the `oa-publisher` leg, under
+/// that leg's allowlist and its ADR-0023 denial context -- so a repository
+/// host the user has not trusted is refused exactly as it is today, and the
+/// access ceiling in `LEGAL.md` §2a is unchanged: this is still case (a), a
+/// location an enabled source reported.
+///
+/// Known cost: `locations[0]` is usually the same location Unpaywall already
+/// offered and the chain already failed on, so the first candidate is often a
+/// retry of a request that was just refused. The three existing accessors
+/// share the property. Fixing it means telling the accessor which URL already
+/// failed, which none of them can see.
+#[must_use]
+pub fn open_access_pdf_url(record: &serde_json::Value) -> Option<&str> {
+    record
+        .get("locations")
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .find_map(|loc| {
+            if loc.get("is_oa").and_then(serde_json::Value::as_bool) != Some(true) {
+                return None;
+            }
+            loc.get("pdf_url")
+                .and_then(serde_json::Value::as_str)
+                .filter(|u| !u.is_empty())
+        })
+}
+
 fn truncate_for_hint(body: &[u8]) -> String {
     const MAX: usize = 200;
     let s = String::from_utf8_lossy(body);
@@ -392,5 +433,65 @@ mod tests {
             .await
             .expect_err("missing `id` must surface as SourceSchema");
         assert!(matches!(err, FetchError::SourceSchema { .. }));
+    }
+
+    // ---- #461: locations[] as a candidate source of OA copies ----------
+
+    /// The point of the accessor: OpenAlex reports EVERY location, so the
+    /// repository copy that satisfies a refused hybrid-OA article is in the
+    /// array even when it is not the primary one.
+    #[test]
+    fn open_access_pdf_url_finds_a_repository_copy_past_the_primary() {
+        let work = serde_json::json!({
+            "locations": [
+                // The publisher's own landing page: not OA, and no pdf_url.
+                // This is the one that just refused us.
+                { "is_oa": false, "landing_page_url": "https://ieeexplore.example/doc/1" },
+                // An institutional repository, which is the interesting case.
+                { "is_oa": true, "pdf_url": "https://repo.example.ac.uk/1/paper.pdf" }
+            ]
+        });
+        assert_eq!(
+            open_access_pdf_url(&work),
+            Some("https://repo.example.ac.uk/1/paper.pdf")
+        );
+    }
+
+    /// A location that is open but records only a landing page is skipped.
+    /// Returning it would spend a request to be told the HTML is `NotAPdf`.
+    #[test]
+    fn open_access_pdf_url_skips_a_landing_page_only_location() {
+        let work = serde_json::json!({
+            "locations": [
+                { "is_oa": true, "landing_page_url": "https://repo.example.ac.uk/1" },
+                { "is_oa": true, "pdf_url": "https://other.example.ac.uk/2/paper.pdf" }
+            ]
+        });
+        assert_eq!(
+            open_access_pdf_url(&work),
+            Some("https://other.example.ac.uk/2/paper.pdf")
+        );
+    }
+
+    /// `is_oa: false` is not a candidate even with a `pdf_url`. Offering it
+    /// would send doiget at a copy the index itself says is not open.
+    #[test]
+    fn open_access_pdf_url_ignores_a_non_oa_location() {
+        let work = serde_json::json!({
+            "locations": [
+                { "is_oa": false, "pdf_url": "https://paywall.example/1.pdf" }
+            ]
+        });
+        assert_eq!(open_access_pdf_url(&work), None);
+    }
+
+    /// An empty string is not a URL. Absent `locations` is not an error.
+    #[test]
+    fn open_access_pdf_url_rejects_empty_and_absent() {
+        let empty = serde_json::json!({
+            "locations": [{ "is_oa": true, "pdf_url": "" }]
+        });
+        assert_eq!(open_access_pdf_url(&empty), None);
+        assert_eq!(open_access_pdf_url(&serde_json::json!({})), None);
     }
 }

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -1,5 +1,5 @@
 //! APS Harvest TDM source — DOI metadata via the
-//! `/v2/article/<DOI>` endpoint (Phase 5b / Tier 3).
+//! `/v2/journals/articles/<DOI>` endpoint (Phase 5b / Tier 3).
 //!
 //! Spec: `docs/SOURCES.md` §1 Tier 3 row + §4 "TDM sources (Phase 5)",
 //! `docs/CAPABILITY.md` §2, ADR-0002 (per-publisher Cargo features),
@@ -72,7 +72,7 @@ const DEFAULT_BASE: &str = "https://harvest.aps.org";
 /// from the error message rather than looking like a lookup failure.
 pub(crate) const PUBLISHER_PREFIXES: &[&str] = &["10.1103"];
 
-/// APS Harvest [`Source`] impl — DOI → `/v2/article/<DOI>` JSON
+/// APS Harvest [`Source`] impl — DOI → `/v2/journals/articles/<DOI>` JSON
 /// record.
 #[derive(Clone, Debug)]
 pub struct TdmApsSource {
@@ -97,12 +97,27 @@ impl TdmApsSource {
         Self { base }
     }
 
-    /// Build the `/v2/article/<doi>` URL.
+    /// Build the `/v2/journals/articles/<doi>` URL.
     ///
-    /// APS encodes the DOI directly in the path; the `/` separator
-    /// in the DOI suffix must be percent-encoded.
+    /// The DOI goes into the path with its `/` separators intact. APS
+    /// publishes the shape verbatim:
+    ///
+    /// ```text
+    /// curl -H 'Accept: application/pdf'     ///   http://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001
+    /// ```
+    ///
+    /// Every other byte outside the RFC 3986 unreserved set is still
+    /// percent-encoded, because a DOI suffix may legally contain
+    /// characters (`;`, `<`, spaces) that are not safe in a path even
+    /// though `/` is.
+    ///
+    /// #484: this used to be `/v2/article/<percent-encoded DOI>`, which
+    /// is not an endpoint APS serves — `%2F` and the missing `journals/`
+    /// segment would each have produced a 404 on their own. Nothing
+    /// caught it because the wiremock stubs asserted the path this
+    /// function built rather than the one APS documents.
     fn request_url(&self, doi: &crate::Doi) -> Result<Url, FetchError> {
-        let path = format!("/v2/article/{}", percent_encode_path_segment(doi.as_str()));
+        let path = format!("/v2/journals/articles/{}", encode_doi_path(doi.as_str()));
         self.base.join(&path).map_err(|e| FetchError::SourceSchema {
             hint: format!("tdm-aps URL construction failed: {e}"),
         })
@@ -226,13 +241,13 @@ impl Source for TdmApsSource {
 
 /// Percent-encode a path segment, preserving the RFC 3986 unreserved
 /// set. `/` and other reserved characters are percent-encoded.
-fn percent_encode_path_segment(segment: &str) -> String {
-    let mut out = String::with_capacity(segment.len());
-    for b in segment.bytes() {
-        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+fn encode_doi_path(doi: &str) -> String {
+    let mut out = String::with_capacity(doi.len());
+    for b in doi.bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~' | b'/') {
             out.push(b as char);
         } else {
-            out.push_str(&format!("%{:02X}", b));
+            out.push_str(&format!("%{b:02X}"));
         }
     }
     out
@@ -305,6 +320,12 @@ mod tests {
 
     const TEST_KEY: &str = "aps-test-key-xyz";
 
+    /// The path the stubs match, spelled the way APS documents it rather
+    /// than the way `request_url` happens to build it. See
+    /// [`request_url_matches_the_published_aps_example`] for why the
+    /// distinction is load-bearing (#484).
+    const APS_ARTICLE_PATH: &str = "/v2/journals/articles/10.1103/PhysRevX.10.011001";
+
     fn profile_with_aps_grant() -> CapabilityProfile {
         let mut p = CapabilityProfile::for_tests();
         p.tdm_aps = Some(TdmGrant {
@@ -321,8 +342,7 @@ mod tests {
     async fn fetch_doi_returns_article_object() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            // APS path with percent-encoded DOI (`/` → `%2F`).
-            .and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
+            .and(path(APS_ARTICLE_PATH))
             // Slice 20: X-API-Key header MUST be present on the wire.
             .and(header("x-api-key", TEST_KEY))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_ARTICLE_HIT))
@@ -367,7 +387,7 @@ mod tests {
     async fn fetch_non_object_returns_source_schema() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/v2/article/10.1103%2FPhysRevX.10.011001"))
+            .and(path(APS_ARTICLE_PATH))
             .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_BAD_SHAPE))
             .mount(&server)
             .await;
@@ -411,5 +431,49 @@ mod tests {
                 "declared prefix {p} must be served"
             );
         }
+    }
+
+    /// The request URL is what APS publishes, byte for byte.
+    ///
+    /// This is the check the two wiremock tests below cannot make. A stub
+    /// written from `request_url`'s output asserts only that the
+    /// implementation agrees with itself — it stays green for any path, as
+    /// long as both sides move together. That is how `/v2/article/<DOI>`
+    /// survived to be shipped (#484).
+    ///
+    /// So the expectation here is a constant transcribed from the vendor's
+    /// own example, and it is deliberately not built from anything in this
+    /// module.
+    #[test]
+    fn request_url_matches_the_published_aps_example() {
+        // Verbatim from <https://harvest.aps.org/docs/harvest-api>:
+        //
+        //   curl -D - -H 'Accept: application/pdf'         //     http://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001
+        //
+        // Transcribed to https because `DEFAULT_BASE` pins TLS; the path
+        // and the DOI encoding are unchanged.
+        const PUBLISHED: &str =
+            "https://harvest.aps.org/v2/journals/articles/10.1103/PhysRevX.5.021001";
+
+        let src = TdmApsSource::new();
+        let doi = Doi::parse("10.1103/PhysRevX.5.021001").expect("DOI parses");
+
+        assert_eq!(
+            src.request_url(&doi).expect("URL builds").as_str(),
+            PUBLISHED,
+            "the URL must match APS's published example, not this module's idea of it"
+        );
+    }
+
+    /// A DOI suffix may carry characters that are not path-safe. `/` stays,
+    /// everything outside the RFC 3986 unreserved set does not.
+    #[test]
+    fn encode_doi_path_keeps_slashes_and_escapes_the_rest() {
+        assert_eq!(
+            encode_doi_path("10.1103/PhysRevX.5.021001"),
+            "10.1103/PhysRevX.5.021001"
+        );
+        assert_eq!(encode_doi_path("10.1103/a b"), "10.1103/a%20b");
+        assert_eq!(encode_doi_path("10.1103/x;y"), "10.1103/x%3By");
     }
 }

--- a/crates/doiget-core/src/sources/tdm_aps.rs
+++ b/crates/doiget-core/src/sources/tdm_aps.rs
@@ -44,6 +44,8 @@ use secrecy::ExposeSecret;
 use url::Url;
 
 use crate::provenance::{Capability, LogEvent, LogResult, RowInput};
+use bytes::Bytes;
+
 use crate::source::{FetchContext, FetchError, FetchResult, Source};
 use crate::{CapabilityProfile, Ref};
 
@@ -237,10 +239,74 @@ impl Source for TdmApsSource {
             metadata_json: Some(envelope),
         })
     }
+
+    /// APS serves the article PDF from the same endpoint as the JSON
+    /// record; `Accept` selects the representation. Both are documented
+    /// against `/v2/journals/articles/{id}` (#484).
+    ///
+    /// Returns `Ok(None)` — "not me" — rather than an error whenever a
+    /// gate is shut, so the orchestrator can tell "APS declined" apart
+    /// from "APS was never eligible". The gates are re-checked here even
+    /// though the caller checks them: a source that trusts its caller is
+    /// one refactor away from not being checked at all, which is the
+    /// double-gate pattern the other Tier-3 entry points already use.
+    async fn fetch_content(
+        &self,
+        ref_: &Ref,
+        profile: &CapabilityProfile,
+        ctx: &FetchContext,
+    ) -> Result<Option<Bytes>, FetchError> {
+        let Ref::Doi(doi) = ref_ else {
+            return Ok(None);
+        };
+        // Grant present AND the DOI is one APS registered (ADR-0041).
+        if !self.can_serve(profile, ref_) {
+            return Ok(None);
+        }
+        let Some(grant) = profile.tdm_aps.as_ref() else {
+            return Ok(None);
+        };
+        let api_key = grant.api_key.expose_secret();
+        if api_key.is_empty() {
+            return Ok(None);
+        }
+
+        let _permit = ctx.rate_limiter.acquire(self.name()).await;
+
+        let url = self.request_url(doi)?;
+        // `fetch_pdf_with_headers`, not `fetch_bytes_with_headers`: the
+        // magic-byte check is the only thing standing between an APS
+        // error page and a file called `<safekey>.pdf`.
+        let (bytes, _final_url) = ctx
+            .http
+            .fetch_pdf_with_headers(
+                self.name(),
+                url,
+                &[("X-API-Key", api_key), ("Accept", "application/pdf")],
+            )
+            .await?;
+
+        let canonical = ref_.promote(self.name(), None).digest_hex();
+        ctx.log.append(RowInput {
+            event: LogEvent::Fetch,
+            result: LogResult::Ok,
+            capability: Capability::TdmAps,
+            ref_: Some(doi.as_str()),
+            source: Some(self.name()),
+            error_code: None,
+            size_bytes: Some(bytes.len() as u64),
+            license: None,
+            store_path: None,
+            canonical_digest: Some(&canonical),
+        })?;
+
+        Ok(Some(bytes))
+    }
 }
 
-/// Percent-encode a path segment, preserving the RFC 3986 unreserved
-/// set. `/` and other reserved characters are percent-encoded.
+/// Percent-encode a DOI for use as a URL path, preserving the RFC 3986
+/// unreserved set **and** `/`, which APS carries raw (#484). Every other
+/// reserved or non-ASCII byte is escaped.
 fn encode_doi_path(doi: &str) -> String {
     let mut out = String::with_capacity(doi.len());
     for b in doi.bytes() {

--- a/crates/doiget-core/src/store/fs_store.rs
+++ b/crates/doiget-core/src/store/fs_store.rs
@@ -165,6 +165,7 @@ impl FsStore {
                 title: md.title,
                 year: md.year,
                 fetched_at: md.doiget.as_ref().map(|d| d.fetched_at),
+                size_bytes: md.doiget.as_ref().map(|d| d.size_bytes),
             });
             if hits.len() >= limit {
                 break;
@@ -289,6 +290,7 @@ impl Store for FsStore {
                     title: md.title,
                     year: md.year,
                     fetched_at: md.doiget.as_ref().map(|d| d.fetched_at),
+                    size_bytes: md.doiget.as_ref().map(|d| d.size_bytes),
                 });
                 if hits.len() >= limit {
                     break;
@@ -783,7 +785,8 @@ fn read_all_entries(metadata_dir: &Utf8Path) -> Result<Vec<EntryInfo>, StoreErro
             safekey,
             title: md.title,
             year: md.year,
-            fetched_at: md.doiget.map(|d| d.fetched_at),
+            fetched_at: md.doiget.as_ref().map(|d| d.fetched_at),
+            size_bytes: md.doiget.as_ref().map(|d| d.size_bytes),
         });
     }
     Ok(out)

--- a/crates/doiget-core/src/store/mod.rs
+++ b/crates/doiget-core/src/store/mod.rs
@@ -64,6 +64,32 @@ pub struct EntryInfo {
     pub year: Option<i32>,
     /// `fetched_at` from the `[doiget]` table, if any.
     pub fetched_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// `size_bytes` from the `[doiget]` table: the size of the stored PDF,
+    /// `0` for a metadata-only entry, `None` when the entry has no
+    /// `[doiget]` table at all.
+    ///
+    /// #481: without it the inventory commands could not tell a fetched
+    /// paper from a metadata-only stub. Every other surface could -- the
+    /// fetch itself failed loudly, the TOML omits `pdf_path`, the
+    /// provenance log carries an `err` row, `doiget info` shows
+    /// `size_bytes = 0` -- and the one command that answers "what do I
+    /// have?" without knowing the ref in advance was the one that dropped
+    /// it. Fifty refs with ten blocked listed as fifty identical rows.
+    pub size_bytes: Option<u64>,
+}
+
+impl EntryInfo {
+    /// Whether a PDF was actually stored for this entry.
+    ///
+    /// `false` for a metadata-only entry (`size_bytes == 0`) and for one
+    /// with no `[doiget]` table. Deliberately not "is this entry useful" --
+    /// a metadata-only entry is a legitimate result, it is just a different
+    /// one, and #118 is the standing rule that the two must not be
+    /// presented alike.
+    #[must_use]
+    pub fn has_pdf(&self) -> bool {
+        self.size_bytes.is_some_and(|n| n > 0)
+    }
 }
 
 /// Errors emitted by [`Store`] implementations.

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4595,7 +4595,7 @@ mod tests {
             SourceAttempt::new(
                 "hal",
                 AttemptOutcome::Disabled {
-                    env: "DOIGET_ENABLE_HAL",
+                    env: &["DOIGET_ENABLE_HAL"],
                 },
             ),
             SourceAttempt::new("core", AttemptOutcome::NoRecord),

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4582,6 +4582,72 @@ mod tests {
     /// #459: the trace, and the distinction it exists to make. Absent
     /// rather than `[]` when unavailable — #413 was filed because those
     /// two were the same observable.
+    /// #471. `fetch_paper_success_envelope` is the only caller that inserts
+    /// `"attempts"`, and `pdf_leg_json` the only one that inserts
+    /// `"remediation"` -- and neither was called from any test. Every test
+    /// naming those fields called the leaf helpers directly with
+    /// hand-constructed values, so disconnecting either wiring point left
+    /// the suite green while the trace and the remediation vanished from the
+    /// envelope an agent reads.
+    ///
+    /// This drives the ENVELOPE BUILDER, so both insertions are exercised at
+    /// the point where a real outcome meets the wire.
+    #[test]
+    fn the_success_envelope_carries_the_trace_and_the_remediation() {
+        use doiget_core::orchestrator::{AttemptOutcome, FetchPaperOutcome, SourceAttempt};
+        use doiget_core::{DenialContext, DenialReason, ErrorCode};
+
+        let blocked = PdfLegStatus::Blocked {
+            code: ErrorCode::NetworkError,
+            message: "redirect target not in allowlist".to_string(),
+            denial: Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: Some("oa-publisher".to_string()),
+                attempted: Some("cdn.example.org".to_string()),
+                expected: Some(vec!["good.example.org".to_string()]),
+                hop_index: Some(1),
+                cap: None,
+                actual: None,
+            }),
+            suggested_arxiv_id: None,
+        };
+        let outcome = FetchPaperOutcome::for_test_synthetic_with_attempts(
+            "doi__10_1234_foo",
+            "oa-publisher",
+            blocked,
+            vec![
+                SourceAttempt::new("crossref", AttemptOutcome::Resolved),
+                SourceAttempt::new(
+                    "hal",
+                    AttemptOutcome::Disabled {
+                        env: &["DOIGET_ENABLE_HAL"],
+                    },
+                ),
+            ],
+        );
+
+        let env = fetch_paper_success_envelope(&outcome, "doi:10.1234/foo");
+
+        // The trace reached the envelope.
+        let rows = env["attempts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("attempts must be on the envelope; got {env}"));
+        assert_eq!(rows.len(), 2, "{env}");
+        assert_eq!(rows[0]["source"], json!("crossref"));
+        assert_eq!(
+            rows[1]["required_env"],
+            json!(["DOIGET_ENABLE_HAL"]),
+            "the #470 structured form travels with it; got {env}"
+        );
+
+        // And so did the remediation, through `pdf_leg_json`.
+        let rem = env["pdf"]["remediation"]
+            .as_array()
+            .unwrap_or_else(|| panic!("a redirect denial has a config channel; got {env}"));
+        assert!(!rem.is_empty(), "{env}");
+        assert_eq!(env["pdf"]["status"], json!("blocked"), "{env}");
+    }
+
     #[test]
     fn attempts_json_distinguishes_no_trace_from_an_empty_one() {
         use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3242,6 +3242,18 @@ fn pdf_leg_json(leg: &PdfLegStatus) -> Value {
     match leg {
         PdfLegStatus::Fetched => json!({ "status": "fetched" }),
         PdfLegStatus::NoOaUrl => json!({ "status": "no_oa_url" }),
+        // #458. Explicit, because the `_` arm at the bottom renders
+        // `{"status": "unknown"}` -- an agent would be told nothing about
+        // a PDF that exists, came from the publisher rather than an open
+        // host, and carries the terms of a TDM agreement.
+        PdfLegStatus::TdmFetched {
+            source,
+            original_block,
+        } => json!({
+            "status": "tdm_fetched",
+            "source": source,
+            "original_block": original_block,
+        }),
         PdfLegStatus::Blocked {
             code,
             message,

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3953,8 +3953,8 @@ fn resolve_log_path() -> anyhow::Result<Utf8PathBuf> {
 impl ServerHandler for Server {
     fn get_info(&self) -> ServerInfo {
         // Both `ServerInfo` and `Implementation` are `#[non_exhaustive]`
-        // in rmcp 1.6, so we go through the public builders rather than
-        // struct-literal construction.
+        // (since rmcp 1.6, still so in 3.x), so we go through the public
+        // builders rather than struct-literal construction.
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_server_info(Implementation::new("doiget", VERSION))

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -56,9 +56,16 @@ async fn initialize_tools_list_health_roundtrip() -> anyhow::Result<()> {
     let server_info = client
         .peer_info()
         .expect("server_info populated after initialize");
-    assert_eq!(server_info.server_info.name, "doiget");
+    // rmcp 3.x made `InitializeResult::server_info` an `Option<Implementation>`
+    // (2.x had it by value). A server that omits it still initializes, so the
+    // presence assertion has to be explicit or this check evaporates.
+    let implementation = server_info
+        .server_info
+        .as_ref()
+        .expect("server_info populated after initialize");
+    assert_eq!(implementation.name, "doiget");
     assert!(
-        !server_info.server_info.version.is_empty(),
+        !implementation.version.is_empty(),
         "server version must not be empty"
     );
     // `instructions` is set by `Server::get_info`. Assert it mentions
@@ -796,5 +803,90 @@ async fn doiget_metadata_only_network_failure_returns_network_error_envelope() -
     server_handle.await??;
     drop(env);
     drop(td);
+    Ok(())
+}
+
+/// The tool safety annotations shipped in 0.8.6 survive on the wire.
+///
+/// `#[tool(annotations(...))]` is consumed entirely by the rmcp macro and
+/// nothing in this crate reads it back, so a macro-syntax or model change in
+/// an rmcp major (2.x -> 3.x, #452) can drop every hint with the build still
+/// green and every other test still passing. An agent reading `tools/list`
+/// would then see 22 unannotated tools and have to assume the worst of each.
+///
+/// Asserted through `tools/list` over the real transport rather than by
+/// inspecting the router, because the serialised form is what a client sees.
+#[tokio::test]
+async fn tools_list_carries_the_safety_annotations() -> anyhow::Result<()> {
+    let profile = CapabilityProfile::from_env().expect("clean env never errors");
+    let server = Server::new(profile);
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = ().serve(client_transport).await?;
+
+    let tools = client.peer().list_all_tools().await?;
+    assert!(!tools.is_empty(), "tools/list returned nothing");
+
+    let unannotated: Vec<&str> = tools
+        .iter()
+        .filter(|t| t.annotations.is_none())
+        .map(|t| t.name.as_ref())
+        .collect();
+    assert!(
+        unannotated.is_empty(),
+        "these tools reached the wire with no annotations: {unannotated:?}"
+    );
+
+    let hints = |name: &str| {
+        tools
+            .iter()
+            .find(|t| t.name.as_ref() == name)
+            .unwrap_or_else(|| panic!("tools/list is missing {name}"))
+            .annotations
+            .clone()
+            .unwrap_or_else(|| panic!("{name} has no annotations"))
+    };
+
+    // Reads local state only. Asserting the values, not just presence: an
+    // annotations struct that survived as all-`None` fields would pass the
+    // presence check above while telling a client nothing.
+    let health = hints("doiget_health");
+    assert_eq!(
+        health.read_only_hint,
+        Some(true),
+        "doiget_health is read-only (#406)"
+    );
+    assert_eq!(
+        health.open_world_hint,
+        Some(false),
+        "doiget_health touches no network"
+    );
+
+    // Writes into the store and talks to the open internet — the opposite
+    // corner of the same matrix.
+    let fetch = hints("doiget_fetch_paper");
+    assert_eq!(
+        fetch.read_only_hint,
+        Some(false),
+        "doiget_fetch_paper writes to the store"
+    );
+    assert_eq!(
+        fetch.open_world_hint,
+        Some(true),
+        "doiget_fetch_paper resolves against arbitrary publisher hosts"
+    );
+    assert_eq!(
+        fetch.destructive_hint,
+        Some(false),
+        "doiget_fetch_paper never removes stored data"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
     Ok(())
 }

--- a/docs/DECISIONS/0044-tier-3-consulted-on-a-blocked-content-leg.md
+++ b/docs/DECISIONS/0044-tier-3-consulted-on-a-blocked-content-leg.md
@@ -1,0 +1,163 @@
+# 0044 - Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss
+
+- **Date:** 2026-08-25
+- **Status:** Accepted
+- **Supersedes:** -
+- **Amends:** [0041](0041-tdm-sources-scoped-to-publisher-prefixes.md) — its option-(c) rejection rests on a premise this decision removes
+- **Source:** #458 (the chain never ran), #445 (the trigger it should have had), #484 (the endpoint it should have asked)
+
+## Context
+
+Tier 3 was consulted from one place: `resolve_tdm_chain`, which records `NotNeeded`
+for every entry when Crossref answered.
+
+That is the correct trigger for Tier 2. Those sources are *resolution* fallbacks —
+they exist because Crossref sometimes has nothing, and once it has something they
+are genuinely not needed.
+
+Tier 3 was added for a different reason. #407 measured the corpus that motivated it
+as **metadata-resolvable but not fetchable**. The metadata was never the problem.
+So the two conditions were backwards:
+
+| | what it needs | what it got |
+|---|---|---|
+| Tier 2 | run when Crossref found nothing | run when Crossref found nothing |
+| Tier 3 | run when the **content leg** failed | run when Crossref found nothing |
+
+Crossref resolves publisher-registered DOIs readily, so for exactly the DOIs these
+sources exist to serve, the chain was skipped. A user could sign a publisher's TDM
+agreement, obtain a key, build with the feature, and get output byte-identical to
+having done none of it. That is #458, and it is the #442 defect class one level up
+from wiring: every documented gate satisfied, nothing changed.
+
+A second problem sat behind it. Even reached, all four Tier-3 sources were
+metadata-only by construction (`FetchResult.pdf_bytes` is always `None`), and a
+source that cannot return bytes cannot close a gap that is about bytes. #458 was
+explicit that the two halves land together or not at all: half 1 alone buys a
+duplicate metadata record, half 2 alone is unreachable code.
+
+## Decision
+
+**D1 — Tier 3 gains a second consultation point, triggered by a blocked content
+leg.** It is not moved. `resolve_tdm_chain` still answers "who can tell me about
+this DOI?" when Crossref could not; the new `try_tdm_content_fallback` answers "who
+will give me the bytes?" after the open routes are exhausted:
+
+```
+OA PDF chain
+  Blocked -> try_arxiv_preprint_fallback          (#325)
+    Blocked -> try_optional_source_oa_fallback    (#445)
+      Blocked -> try_tdm_content_fallback         (this ADR)
+```
+
+It is additive on the same terms as its two siblings: on any failure the **original**
+block survives. The publisher's refusal on the open route is what the user has to
+act on, and burying it under a second failure from the TDM endpoint would answer a
+question they did not ask.
+
+**D2 — `Source::fetch_content`, defaulted to `Ok(None)`.** The metadata-only
+contract used to be expressed by each impl setting `pdf_bytes: None` and saying so
+in a doc-comment. The orchestrator cannot read a doc-comment, so it could not
+distinguish a source with nothing to offer from one it had never asked. The default
+makes "metadata-only" a stated fact rather than an emergent one, and leaves the
+other sources untouched.
+
+Overriding implementations MUST use a PDF-validating fetch. `HttpClient` gains
+`fetch_pdf_with_headers` for this: publisher error pages and WAF holding responses
+are 200s with a body, and `fetch_bytes_with_headers` would write one to
+`<safekey>.pdf`.
+
+**D3 — APS first.** It is the only Tier-3 publisher whose full-text contract is
+both public and PDF-shaped:
+
+| publisher | what its API grants |
+|---|---|
+| **APS Harvest** | `GET /v2/journals/articles/{doi}` with `Accept: application/pdf`, one request, `X-API-Key`. Published example in the vendor's own documentation. |
+| Elsevier | **Non-OA PDF retrieval via the APIs is not permitted**; a non-OA article yields a first-page *preview*. What an entitlement grants for subscription content is full-text XML. |
+| IEEE | Contract not public — shipped against an inferred one ([ADR-0042](0042-tdm-ieee-inferred-contract.md)). |
+| Springer | Unverified. |
+
+Elsevier was the first choice and was rejected on that evidence. Storing a
+first-page preview as `<safekey>.pdf` and reporting it as fetched would be a worse
+version of the defect this ADR exists to close: not an absent feature, but wrong
+data presented as right. Elsevier remains a good candidate for a later XML-shaped
+instalment under [ADR-0032](0032-fulltext-html-extraction.md); it is the wrong
+publisher for closing a gap about bytes.
+
+**D4 — `PdfLegStatus::TdmFetched { source, original_block }`, distinct from
+`Fetched`.** The bytes did not come from an OA host, are not necessarily openly
+licensed, and were obtained under an agreement the user signed. Provenance reading
+`oa-publisher` would be wrong in all three respects. The stored source label is
+derived from the leg rather than from a two-valued "was this a preprint fallback"
+flag, which would have labelled the publisher's copy `oa-publisher` by default.
+
+**D5 — a TDM-retrieved artifact reports `license = "unknown"`.** The licence tracks
+the artifact that landed, not the work — that is already how the arXiv fallback
+behaves, overwriting the licence with the preprint's. Unpaywall's `cc-by` describes
+an OA location that was never reached; carrying it forward would put an
+open-licence claim on a file obtained under a signed agreement, by a route that
+licence does not describe. doiget does not guess licences, so the honest answer is
+`unknown`.
+
+**D6 — prefix scoping is kept, and is now a choice rather than a forced move.**
+
+ADR-0041 rejected option (c), routing by the publisher named in Crossref metadata,
+because *"it only works when Crossref answered — and the TDM chain runs precisely
+when Crossref did not, so the routing information would be missing exactly when it
+is needed."*
+
+**D1 removes that premise.** The new consultation point runs *after* Crossref
+answered, so (c) is available here in a way it was not in ADR-0041.
+
+It is still not taken. A constant is testable and does not make the publisher
+contacted depend on a prior network response — the second half of ADR-0041's
+reasoning, which survives intact. This is recorded explicitly so the next reader
+does not re-derive the rejection from an argument that no longer holds.
+
+The prefix is checked in the orchestrator **before** credentials, exactly as in
+ADR-0041, so `WrongPublisher` and `Disabled` stay distinguishable in the trace.
+`Source::can_serve` checks it too; the redundancy is the deliberate double gate, and
+only the orchestrator check produces the distinction.
+
+## Consequences
+
+**Positive.**
+
+- A TDM agreement now changes what the user gets. The three gates lead somewhere.
+- The trace distinguishes "consulted for metadata and not needed" from "consulted
+  for content and refused", which are different problems with different fixes.
+- `fetch_content` gives future publishers a defined place to land, and its default
+  states the metadata-only contract for the three that have not.
+
+**Negative, and the one that needs stating plainly.**
+
+**Disclosure scope is unchanged; frequency rises.** ADR-0041's argument was that a
+publisher is only ever told about DOIs it registered, so the disclosure is nil —
+resolving such a DOI goes through them anyway. That still holds exactly: prefix
+scoping is enforced on the new path too.
+
+What changes is how often. The old trigger was "Crossref missed", which for a
+publisher-registered DOI is rare. The new trigger is "the content leg was blocked
+for a DOI this publisher registered", which is common — it is the case the feature
+exists for. A user with `tdm-aps` enabled will contact APS about a meaningful
+fraction of the APS DOIs they fetch, rather than almost never.
+
+That is the cost of the feature working at all, and it is bounded by the same
+prefix rule. It is recorded here rather than left for someone to discover in a
+packet capture.
+
+**Also negative.** The one-shot content attempt has no retry and no caching, so a
+transient failure at the TDM endpoint costs the fetch. Consistent with the OA chain,
+which does the same, and preferable to retry loops against a credentialed endpoint.
+
+## Alternatives rejected
+
+- **Move the trigger instead of adding one.** Tier 3 would stop answering the
+  metadata question it currently answers when Crossref is down, for no gain.
+- **Half 1 alone** (reach Tier 3 on a blocked content leg, stay metadata-only). #458
+  rejected it in advance: it buys a duplicate metadata record for a DOI Crossref
+  already resolved.
+- **Elsevier first.** See D3. Rejected on the vendor's own documented policy, not on
+  preference.
+- **Infer a licence for the TDM copy** from the publisher record. That is a guess
+  about *this retrieval*, and the repo's standing rule is not to guess licences.

--- a/docs/DECISIONS/0045-per-source-rate-limits.md
+++ b/docs/DECISIONS/0045-per-source-rate-limits.md
@@ -1,0 +1,108 @@
+# 0045 - Per-source rate limits, taken as the stricter of the vendor's terms and the global cap
+
+- **Date:** 2026-08-25
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #493 (arXiv fetched at 15x its published rate), #496 (no vendor limit recorded anywhere), #498 (the 2026-08-25 vendor-terms audit)
+
+## Context
+
+`RateLimits` carried three numbers for the whole process: 5 concurrent fetches,
+5 requests per second, 200 ms between consecutive requests to the same source.
+There was no per-source dimension at all.
+
+arXiv's [API Terms of Use](https://info.arxiv.org/help/api/tou.html) say:
+
+> make no more than one request every three seconds, and limit requests to a
+> single connection at a time
+
+That is **15x the permitted rate and 5x the permitted concurrency**, on a Tier-1
+always-on source that ships in every published binary. The page adds that the
+limit is collective across every machine under the caller's control and that
+circumventing it may have access blocked.
+
+Three places asserted the opposite — `sources/arxiv.rs`, `docs/SOURCES.md` §4,
+and, worst, `docs/SOURCES.md` §6:
+
+> If a source publishes a stricter rate guideline, doiget will adopt the stricter
+> value at the per-source level rather than relax the global cap.
+
+arXiv publishes exactly such a guideline. Nothing adopted it. The promise was
+real and the mechanism to keep it did not exist.
+
+A second, quieter problem: arXiv's terms cap **requests**, and one arXiv attempt
+issues **two** — the Atom feed, then the PDF — under a single `acquire`. Even a
+perfectly serialised caller sent those back to back.
+
+## Decision
+
+**D1 — A per-source table of vendor guidelines, as library constants.**
+
+`SOURCE_RATE_OVERRIDES: &[(&str, SourceRate)]`, keyed by `Source::name`, with
+`SourceRate { min_interval_ms, max_concurrent }`. arXiv is 3000 ms / 1.
+
+Constants, not configuration, and not caller-supplied. `docs/LEGAL.md` §6a
+safeguard 5 makes `RateLimits` unsynthesizable by downstream code on purpose;
+a per-source table that accepted caller values would hand back precisely what
+that safeguard withholds.
+
+**D2 — An entry can only tighten.**
+
+Callers go through `RateLimits::backoff_ms_for(source)` and
+`max_concurrent_for(source)`, which return `max(global, entry)` and
+`min(global, entry)` respectively. The global cap stays the ceiling.
+
+This is the load-bearing part. §6's promise was kept by intention before, and
+intention is what failed. Taking the stricter of the two makes it impossible for
+a table entry to relax anything even if someone writes one that tries, and the
+table itself is pinned by a test asserting every entry is at least as strict as
+the global cap on both axes — so an entry that would be silently ignored fails
+the build instead of sitting there looking effective.
+
+**D3 — Concurrency is enforced with a per-source semaphore, after the global one.**
+
+Ordering matters: global semaphore first (the ceiling still binds), then the
+per-source one, then the interval wait. A source capped at one connection
+therefore serialises rather than accumulating sleepers behind a shared interval.
+
+**D4 — `RateLimiter::pace(source)` for additional requests inside one attempt.**
+
+It waits out the source's interval and records the start, without touching the
+concurrency slots — the caller already holds them, and re-taking them would
+deadlock at `max_concurrent == 1`, which is exactly the arXiv case. The arXiv
+PDF leg calls it.
+
+The alternative — one `acquire` per HTTP request — would have been cleaner in
+the abstract and wrong here: the permit's lifetime is what bounds concurrency
+for the whole attempt, and splitting it would let a second attempt interleave
+between one attempt's two legs.
+
+## Consequences
+
+**arXiv fetches are now ~6 s per paper** (two paced requests), against well under
+a second before. That is the rate the vendor publishes. A batch of arXiv refs is
+correspondingly slower, and there is no opt-out: per D1 there is no knob, and per
+LEGAL.md §6a there should not be one.
+
+**Nothing else changes.** Every source without an entry keeps the 200 ms floor
+and the global concurrency cap; there is a test for that specifically, so this
+change cannot have slowed the rest of the tree by accident.
+
+**The table is now the place vendor limits are recorded.** #496 tracks the ones
+still unwritten (Springer's tier system, CORE's 10/min token bucket, OpenAlex).
+Adding them is an entry each, not a redesign — which is the point of doing the
+mechanism and arXiv together rather than per source.
+
+**`docs/SOURCES.md` is `Status: NORMATIVE`**, so per ADR-0014 this ADR is the
+record for the change to §4 and §6.
+
+## Alternatives rejected
+
+- **Lower the global cap to 1 request / 3 s.** Correct for arXiv, absurd for
+  Crossref, and it would make every other source pay arXiv's price.
+- **A config knob.** Directly against LEGAL.md §6a safeguard 5 and safeguard 8:
+  the rate limit is hard-coded so that it cannot be argued with.
+- **Pace only between attempts, not within one.** Leaves the measured violation
+  in place — arXiv counts requests, and an attempt is two of them.
+- **Per-source `Retry-After` only, reacting to 429s.** Reactive, and the terms
+  are a *guideline to observe*, not a limit to discover by tripping it.

--- a/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
+++ b/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
@@ -1,0 +1,121 @@
+# 0046 - In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Refines:** [0014](0014-docs-class-system.md) — which requires an ADR for changes to NORMATIVE content, without saying whether a URL is content
+- **Source:** #495 (five of sixteen ToS links dead or wrong), #496 (CORE, Springer, rate limits, a mis-aimed cross-reference), #498 (the 2026-08-25 vendor-terms audit)
+
+## Context
+
+`docs/SOURCES.md` is `Status: NORMATIVE (user responsibility advisory)`. A
+2026-08-25 audit requested all sixteen links in its §1 matrix and read the prose
+against each vendor's current documentation. It found two different kinds of
+defect, and they do not want the same treatment.
+
+**Wrong claims.** The document asserted things about vendors that were false:
+
+- CORE's key was called "optional". Requests do resolve without one, at roughly a
+  hundred simple queries a day under a token-cost model — so a run stops working
+  and "optional" gives the reader nothing to diagnose it with.
+- `tdm-elsevier`, `tdm-springer` and `tdm-ieee` were named in one sentence as
+  metadata-only, with only Elsevier's reason attached. Springer publishes a Full
+  Text (TDM) API and an Open Access API; staying metadata-only there is doiget's
+  conservative choice, not a vendor restriction. The weaker case inherited the
+  stronger one's justification.
+- §6 promised doiget adopts a stricter vendor guideline per source, while
+  recording no vendor's published limit anywhere — so the promise could not be
+  checked against anything. (arXiv's, the one measured violation, is ADR-0045.)
+- The rate cap cited "LEGAL.md §6 safeguard 8". Safeguard 8 is marketing-language
+  self-policing in §6b, *policy commitments*. The cap is §6a.5, an *enforced
+  control*. The citation sent a reader looking for the enforcement basis to the
+  section that has none — inverting the meaning of the reference.
+
+**Rotted pointers.** Five links no longer led to terms:
+
+| row | was | result | now |
+|---|---|---|---|
+| Crossref | `crossref.org/services/metadata-retrieval/rest-api/` | 404 | `crossref.org/documentation/retrieve-metadata/rest-api/` |
+| Elsevier | `elsevier.com/legal/tdmrep` | 404 | `elsevier.com/about/policies-and-standards/text-and-data-mining` |
+| OpenAlex | `docs.openalex.org/how-to-use-the-api/api-overview` | 200 → redirects to the `help.openalex.org` root; deep target gone | `help.openalex.org/how-to/` |
+| DOAJ | `doaj.org/api` | 200 → redirects to `swagger.json`, a schema | `doaj.org/terms/` |
+| Springer | `dev.springernature.com/` | 200, portal root | `dev.springernature.com/terms-conditions/` |
+
+The Elsevier one was the worst even before it died: `tdmrep` is the **TDM
+Reservation Protocol**, the W3C-track standard by which a rightsholder
+machine-readably signals an opt-out *from* text and data mining. It is not
+Elsevier's API terms. The sole ToS reference for a Tier-3 source pointed at the
+wrong kind of document.
+
+## Decision
+
+**D1 — A claim about a vendor is NORMATIVE content. Changing one needs an ADR.**
+
+What a source requires, permits and limits is exactly what a user relies on this
+document for. This ADR is the record for the four corrections above.
+
+**D2 — Vendor-published limits are recorded in `SOURCES.md` §6.1, or their absence is.**
+
+§6's promise is only meaningful next to what the vendors actually publish. §6.1 now
+carries a row per source: the vendor's limit, what doiget does about it, and where
+the figure came from. A source running on the global cap says so, rather than leaving
+it to be inferred from silence.
+
+**A figure that could not be read is left blank and labelled.** Springer's
+rate-limit page renders its body through JavaScript and the audit could not extract
+the numbers, so the cell says so. A plausible-looking number would be worse than the
+gap, because the entire value of the table is that a reader can check it against the
+vendor.
+
+**D3 — A URL is a pointer, not a claim. Correcting one does not need an ADR.**
+
+Repointing a link at the same document under its new address changes nothing the
+document asserts. Requiring an ADR per publisher site reorganisation would produce
+ADRs that record no decision, and — worse — would make the correction expensive
+enough to defer, which is how five accumulated.
+
+The boundary: if the replacement is *the same document at a new address*, it is a
+pointer fix. If it is a *different document* — as the Elsevier row was, moving from a
+mis-cited opt-out protocol to the actual API policy — then the claim about where the
+vendor states its terms changed, and that is D1.
+
+**D4 — Rot is made visible on a schedule, not per PR.**
+
+`.github/workflows/tos-links.yml` requests every §1 link monthly and opens an issue
+on any non-200. Deliberately **not** a PR check: a publisher reorganising their site
+overnight would turn an unrelated PR red, which is the wrong failure mode and the one
+that teaches people to ignore a check.
+
+It follows redirects and reports the final URL, so a link that still returns 200 while
+landing somewhere unrelated is visible. It fails loudly when it extracts **zero**
+URLs, because a table reformat that emptied the list would otherwise be
+indistinguishable from a clean sweep — the same "silently checking nothing" shape as
+#442 and #454.
+
+## Consequences
+
+**Positive.** §6's promise is auditable. The Springer row no longer implies a vendor
+restriction that does not exist. A reader chasing the rate cap's enforcement basis
+lands on an enforced control. Link rot surfaces within a month instead of at the next
+audit.
+
+**Negative.** §6.1 is a hand-maintained table of facts held by other people, and it
+will drift. Nothing checks the *numbers* — only that the URLs resolve. The scheduled
+job is the floor, not a guarantee, and the honest position is that a vendor can change
+a limit silently and this document will be wrong until someone looks.
+
+**Also negative.** Monthly outbound requests to sixteen third parties who did not ask
+for them. Monthly rather than weekly is the concession: publisher sites move on a
+scale of months.
+
+## Alternatives rejected
+
+- **An ADR per link fix.** Records no decision, and the cost is what let five
+  accumulate.
+- **Per-PR link checking.** Wrong failure mode; see D4.
+- **Guessing Springer's numbers** from the tier names. The table's only value is
+  being checkable, and a plausible wrong number destroys that more thoroughly than a
+  blank does.
+- **Dropping the ToS column** as unmaintainable. It is the mechanism by which
+  LEGAL.md's "the user holds the rights" posture is actionable at all — without a
+  link, "comply with the source's terms" is advice the user cannot follow.

--- a/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
+++ b/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
@@ -4,7 +4,7 @@
 - **Status:** Accepted
 - **Supersedes:** -
 - **Refines:** [0014](0014-docs-class-system.md) — which requires an ADR for changes to NORMATIVE content, without saying whether a URL is content
-- **Source:** #495 (five of sixteen ToS links dead or wrong), #496 (CORE, Springer, rate limits, a mis-aimed cross-reference), #498 (the 2026-08-25 vendor-terms audit)
+- **Source:** #495 (five of sixteen ToS links dead or wrong), #496 (CORE, Springer, rate limits, a cross-reference pointing at the wrong safeguard), #498 (the 2026-08-25 vendor-terms audit)
 
 ## Context
 

--- a/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
+++ b/docs/DECISIONS/0046-vendor-claims-are-normative-links-are-pointers.md
@@ -76,7 +76,7 @@ enough to defer, which is how five accumulated.
 
 The boundary: if the replacement is *the same document at a new address*, it is a
 pointer fix. If it is a *different document* — as the Elsevier row was, moving from a
-mis-cited opt-out protocol to the actual API policy — then the claim about where the
+wrongly cited opt-out protocol to the actual API policy — then the claim about where the
 vendor states its terms changed, and that is D1.
 
 **D4 — Rot is made visible on a schedule, not per PR.**

--- a/docs/DECISIONS/0047-legal-claims-are-read-off-the-code.md
+++ b/docs/DECISIONS/0047-legal-claims-are-read-off-the-code.md
@@ -1,0 +1,98 @@
+# 0047 - LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0046](0046-vendor-claims-are-normative-links-are-pointers.md) — same audit, same class of defect, applied to claims about *doiget* rather than about vendors
+- **Source:** #494 (network surface under-declared, `tdm-ieee` absent), #509 (a documented credentials file nothing reads)
+
+## Context
+
+`docs/LEGAL.md` is `Status: NORMATIVE` and says of itself that "users,
+contributors, publisher legal teams, and future reviewers" should rely on it.
+The 2026-08-25 audit and the correction pass that followed found four false
+statements in it. They are all the same shape: someone wrote down what the
+system was believed to do, and nothing brought the sentence back to the code.
+
+**The shipped binary's network surface.** §2 said default binaries "include only
+Open Access sources (Crossref, Unpaywall, arXiv)". Reading the production client
+assembly in `crates/doiget-cli/src/commands/fetch.rs`, a default `oa-only` build
+registers four allowlists: `tier_1_allowlist`, `oa_publisher_allowlist` (~20
+publisher and repository patterns), `discovery_allowlist` (`api.openalex.org`,
+ADR-0031, always-on) and `fulltext_allowlist` (`ar5iv.labs.arxiv.org`,
+ADR-0032, always-on). **OpenAlex was absent from the list entirely** — a
+third-party service, not an arXiv subdomain, contacted by the shipped binary with
+no opt-in. `SOURCES.md` had documented both as always-on Tier 1 the whole time.
+
+**`tdm-ieee`.** §2 and §6a.3 both enumerated three TDM features. There are four;
+`tdm-ieee` landed with ADR-0042. `SOURCES.md` listed all four.
+
+**A credentials file nothing reads.** §6a.1 said credentials come from env vars
+"or `~/.config/doiget/credentials.toml`". The TDM resolver reads `std::env::var`
+and nothing else, and no code path opens that file — while `CONFIG.md` §6
+specifies it in full, including a 0600 permission warning that also does not
+exist (#509).
+
+**An enforcement clause naming nothing.** §6a.1 cited "*CI grep for embedded key
+patterns*". There is no secret scanner in the tree; `posture-lint.yml` greps for
+marketing terms, HTTP-server imports, telemetry imports and non-rustls TLS
+backends. §6a is *defined* as "mechanically enforced by code, type system, Cargo,
+or CI" — as distinct from §6b, the policy commitments a contributor could weaken
+without machine-checkable resistance. An item in §6a whose enforcement clause
+names nothing is in the wrong section, and that split is the whole point of
+having two.
+
+## Decision
+
+**D1 — The network-surface claim is derived from the allowlist assembly, not
+written from memory.** §2 now carries a table of the four allowlists the
+production client is built from and names the code they come from, so a reader —
+or a publisher's counsel — can check the claim against one function rather than
+trusting a remembered summary.
+
+This is why the claim rotted: `discovery_allowlist` and `fulltext_allowlist` were
+added by ADR-0031 and ADR-0032, both correctly documented in `SOURCES.md`, and
+nothing connected either to the sentence in LEGAL.md that enumerated hosts.
+
+**D2 — Every item in §6a must name enforcement that exists.** An item whose
+*Enforced by:* clause cites a mechanism that is absent either gets the mechanism
+built or moves to §6b. Citing an imaginary control is worse than admitting a
+policy commitment, because §6a is the half a reader is invited to verify.
+
+The §6a.1 clause is corrected to the two controls that are real (`secrecy::Secret`
+types, the `tracing` redactor). Building the secret scanner is a reasonable
+follow-up; asserting one exists is not.
+
+**D3 — A claim that turns out to describe an unimplemented feature is corrected
+immediately, and the gap is filed separately.** The `credentials.toml` sentence
+is removed from LEGAL.md now, and whether to implement `CONFIG.md` §6 is #509.
+Leaving a known-false statement standing in the legal document while an issue is
+open is what #472 was about.
+
+`CONFIG.md` §6 is deliberately left as it is: editing it *is* the decision, and
+that decision is not this ADR's to make.
+
+## Consequences
+
+**Positive.** The network-surface claim is falsifiable against one function.
+§6a means what it says. A reader chasing an enforcement basis lands on something
+that exists.
+
+**Negative.** The §2 table duplicates knowledge held in `fetch.rs`, and duplicated
+knowledge drifts — which is exactly how this ADR came to be needed. Naming the
+function is a mitigation, not a fix. A CI check that diffs the documented host set
+against the allowlists would be the real answer; it does not exist, and per D2
+this ADR does not claim it does.
+
+**Negative.** §6a.1 is now weaker on paper, having lost an enforcement clause. It
+was always this weak; the clause was decoration.
+
+## Alternatives rejected
+
+- **Fold this into ADR-0046.** That ADR's subject is the vendor-claim / pointer
+  distinction in `SOURCES.md`, a distinct idea. Broadening it to "all normative
+  claims" would blunt the one thing it says sharply.
+- **Leave the `credentials.toml` sentence until #509 is decided.** Ships a false
+  statement in the legal document for the duration.
+- **Move safeguard 1 to §6b** rather than correct its clause. The type-level
+  controls are real and machine-enforced; only the clause was wrong.

--- a/docs/DECISIONS/0048-access-ceiling.md
+++ b/docs/DECISIONS/0048-access-ceiling.md
@@ -1,0 +1,104 @@
+# 0048 - The access ceiling is written down, and widening it amends the written form
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #497 (the operative invariant is not the believed one), #498 (the 2026-08-25 vendor-terms audit)
+
+## Context
+
+`docs/LEGAL.md` §1 and §2 state what doiget does **not** do: no access-control
+circumvention, no proxying across user boundaries, no redistribution. All still
+true, all still verifiable.
+
+What was missing was the positive statement. Given a ref, *what is doiget
+permitted to try, and where does it stop?*
+
+The rule the project operated under informally was **"never go beyond what
+Unpaywall reports"**. Clean, checkable, and no longer what the code does. It rose
+twice:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is
+  asked for the bytes. For `tdm-aps` that returns a PDF from a location Unpaywall
+  never listed.
+- **#445** — when the OA chain and the arXiv preprint fallback are exhausted, the
+  enabled optional sources are asked whether anyone else holds a copy, and the URL
+  they report is tried. Also not from Unpaywall.
+
+Both are opt-in, both have ADRs, both stay inside publisher-sanctioned APIs and
+inside the redirect allowlist, and both record their outcome in the attempt trace.
+**Neither is improper.** The defect is that the rule everyone believed was being
+enforced was not the rule being enforced, and the gap had never been written down —
+so ADR-0044 was reviewed against a ceiling that existed only as a shared belief.
+
+An unstated invariant cannot be checked. That is how both widenings happened
+without anyone deciding the ceiling had moved.
+
+## Decision
+
+**D1 — `LEGAL.md` gains §2a, stating the ceiling positively.** Two kinds of
+location, and no third:
+
+- **(a) a location an enabled source reported** — the URL appears verbatim in a
+  response from a source the build *and* the runtime profile enabled;
+- **(b) an endpoint built from a vendor's own documented URL scheme** for the
+  identifier the user supplied.
+
+Bounded on every request and every redirect hop by the host allowlist, by
+credential-plus-consent for Tier 3, by prefix scoping for Tier 3, and by the
+attempt trace.
+
+**D2 — Every clause names where it is enforced, and is falsifiable by reading
+that code.** §2a cites `optional_source_oa_url`'s dispatch, the `*_url`
+constructors, the `redirect::Policy::custom` closure, `PUBLISHER_PREFIXES`, and
+`SourceAttempt`. A reader who thinks a clause is false can go and check it in one
+place.
+
+**#497 proposed a candidate wording that this ADR rejects**, and the reason is
+instructive. It suggested doiget "never constructs a content URL that no enabled
+source reported". **That is false.** arXiv's `/pdf/<id>.pdf`, ar5iv's `/html/<id>`
+and every Tier-3 TDM endpoint are constructed from an identifier, not reported by
+anyone. Writing that sentence would have replaced an unstated invariant with a
+stated false one — worse, because it reads as verified.
+
+The issue anticipated this: *"That is a guess at the shape, not a proposal — the
+exact wording should be derived by reading `orchestrator.rs` and the allowlist."*
+It was, and the shape came out different.
+
+The distinction that matters is not *reported vs constructed*. It is **documented
+by the vendor vs guessed by us**. Constructing `/pdf/<id>.pdf` against arXiv's
+published scheme is exactly as sanctioned as following a URL Unpaywall handed
+over; inferring a publisher's URL pattern from observation would not be, and
+§2a's "no third kind" is what forbids it.
+
+**D3 — Widening (a) or (b) amends §2a in the same PR.** Not "should" — the ceiling
+is only useful as something a reviewer can hold a diff against.
+
+## Consequences
+
+**Positive.** The argument for the current posture is written and true. It is no
+longer "we never exceed Unpaywall" — which is false — but "every leg is a
+publisher-sanctioned API or an index the user switched on, at an allowlisted host,
+under the user's own credential where one is required, with the attempt recorded".
+That is defensible, and each conjunct is checkable.
+
+**Negative.** §2a is prose asserting properties of code, and nothing mechanically
+ties the two. A change could widen (b) and leave §2a stale exactly as ADR-0044 did.
+D3 is a review discipline, not a control — the honest classification, and the same
+distinction `LEGAL.md` §6a/§6b draws between enforced and committed. Making it
+enforceable would need something like a lint over the `*_url` constructors; that
+does not exist and this ADR does not pretend it does.
+
+**Negative.** Naming code locations in a NORMATIVE document means a refactor that
+renames `optional_source_oa_url` makes §2a wrong. Accepted deliberately: a clause
+citing nothing is unfalsifiable, which is the failure this ADR exists to fix, and
+ADR-0047 D2 made the same trade for §6a.
+
+## Alternatives rejected
+
+- **Restore the Unpaywall-only ceiling** by reverting ADR-0044 and #445. Both are
+  opt-in, sanctioned and useful; the problem was never the widening, only that it
+  was undeclared.
+- **Adopt #497's proposed wording.** False, as above.
+- **Leave the invariant implicit** and rely on ADR review. That was the default for
+  two releases, and it produced this issue.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -64,6 +64,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
+| 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -63,6 +63,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
 | 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
+| 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -62,6 +62,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
 | 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
 | 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
+| 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -61,6 +61,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0042 | `tdm-ieee` ships against an inferred contract, marked unverified | Accepted (0.8.9) | `feat/430-tdm-ieee` | #430 |
 | 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
 | 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
+| 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -60,6 +60,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0041 | Tier-3 TDM sources are scoped to their publisher's DOI prefixes | Accepted (0.8.9) | `fix/442-tier3-orchestrator-wiring` | #442 |
 | 0042 | `tdm-ieee` ships against an inferred contract, marked unverified | Accepted (0.8.9) | `feat/430-tdm-ieee` | #430 |
 | 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
+| 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
 
 ## Conventions
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -132,17 +132,44 @@ The resolution trace introduced in #413/#438, previously CLI text only.
 
 ```jsonc
 "attempts": [
-  { "source": "hal",  "outcome": "not_consulted_disabled", "detail": "DOIGET_ENABLE_HAL", "consulted": false },
-  { "source": "core", "outcome": "consulted_no_record",                                   "consulted": true  }
+  { "source": "hal", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_ENABLE_HAL", "required_env": ["DOIGET_ENABLE_HAL"], "consulted": false },
+  { "source": "tdm-aps", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+    "required_env": ["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"], "consulted": false },
+  { "source": "core", "outcome": "consulted_denied",
+    "detail": "consulted: refused (RedirectNotInAllowlist, cdn.example.org)",
+    "denial_context": { "reason": "redirect_not_in_allowlist", "attempted": "cdn.example.org",
+                        "expected": ["core.ac.uk"], "hop_index": 1 },
+    "remediation": [ /* … */ ], "consulted": true }
 ]
 ```
 
 `outcome` is a **closed** enum:
 `not_consulted_disabled`, `not_consulted_not_applicable`,
 `not_consulted_wrong_publisher`, `not_consulted_not_needed`, `consulted_no_record`,
-`consulted_not_open_access`, `consulted_failed`, `consulted_resolved`.
+`consulted_not_open_access`, `consulted_denied`, `consulted_failed`,
+`consulted_resolved`.
 
 `detail` is present only for the variants carrying one, and is opaque text.
+
+**`required_env`** (#470) accompanies `not_consulted_disabled`: the variables to set,
+as a list. `detail` carries the same set joined with `" + "` and is retained for
+compatibility — do not parse it. Tier-3 sources need two variables and Tier-2 one,
+which is why the joined form was a separator a consumer had to split on.
+
+**`denial_context`** and **`remediation`** (#470) accompany `consulted_denied`, and
+carry the same ADR-0023 structure the blocked PDF leg already carried. Before this,
+a redirect denial, an oversized body or a not-a-PDF on a *metadata-chain* source —
+the richest and most actionable failures — flattened into `consulted_failed` with an
+opaque string, on a surface documented as machine-readable. `remediation` is omitted
+when the denial reason has no configuration channel (`InsecureScheme` has none:
+the fix for an `http://` redirect is not to trust the host).
+
+`consulted_denied` is a *refusal by a policy control*, distinct from
+`consulted_failed` (transport, auth, schema). `CapabilityNotGranted` is **not** a
+`consulted_denied`: it is produced before any request goes out, so reporting it as
+consulted would misstate reach.
 `consulted` is redundant with `outcome` and present anyway: it is the single question
 every consumer has — *did anyone else look?* — and requiring them to memorise which of
 eight tokens implies it invites the confusion the trace exists to end.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -57,7 +57,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 |---|---|
 | Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
-| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). **Records are emitted in completion order, not input order** — see below. |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
 
 ### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
@@ -125,6 +125,22 @@ Emitted only for reasons with a configuration channel — `redirect_not_in_allow
 `host_in_block_list`. A `size_cap_exceeded` or `capability_not_granted` denial carries no
 `remediation`, because offering a host to trust would send the caller after a fix that
 cannot work.
+
+### 3.2a `batch --json` record order (NORMATIVE)
+
+Records are written as each ref **completes**. `batch` runs up to
+`RateLimits::HARD_CODED.max_concurrent_fetches()` fetches at once and emits each
+record when its task finishes, so stdout is in completion order and reordering is
+the normal case rather than a rare one: a parse error returns instantly, a 1 MB PDF
+does not.
+
+**Key on the `ref` field.** Zipping stdout against the input file positionally is the
+obvious thing to write, it works on a small or uniform batch, and the first time a
+fetch is slow it attaches a result to the wrong DOI with no error anywhere (#479).
+
+Input order would cost buffering the whole run before emitting anything, which
+would end streaming for large batches. The order is not going to change; consumers
+that need input order must sort by `ref` themselves.
 
 ### 3.3 Structured `attempts` (NORMATIVE; ADR-0043)
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -30,11 +30,32 @@ boundaries.
 
 This is enforced structurally rather than only by documentation:
 
-- Default released binaries include only Open Access sources (Crossref, Unpaywall, arXiv).
+- Default released binaries (`oa-only`) include only Open Access sources. In full,
+  the hosts a default build is able to contact — read off the allowlists the
+  production client is assembled from in
+  `crates/doiget-cli/src/commands/fetch.rs`, not from memory:
+
+  | allowlist | hosts | what it is for |
+  |---|---|---|
+  | `tier_1_allowlist` | `api.crossref.org`, `*.crossref.org`, `api.unpaywall.org`, `arxiv.org`, `export.arxiv.org` | DOI and arXiv resolution |
+  | `oa_publisher_allowlist` | ~20 publisher and repository patterns (`*.springer.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.plos.org`, `*.mdpi.com`, `*.frontiersin.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.nih.gov`, `*.aps.org`, `scipost.org`, …) | following the OA PDF URL an index reported; the host is wherever the OA copy lives (ADR-0027) |
+  | `discovery_allowlist` | `api.openalex.org` | `doiget search` discovery (ADR-0031 D4), **always-on, no env gate** |
+  | `fulltext_allowlist` | `ar5iv.labs.arxiv.org` | `doiget text` structured full text (ADR-0032), **always-on** |
+
+  This list read "Crossref, Unpaywall, arXiv" until #494. **OpenAlex was absent
+  entirely** — a third-party service, not an arXiv subdomain, reached by the shipped
+  binary with no opt-in. `SOURCES.md` had documented both discovery and ar5iv as
+  always-on Tier 1 the whole time; the one document written for publisher legal teams
+  was the one that did not say so.
+
+  A user-supplied `[[network.additional_hosts]]` entry (ADR-0028) can extend the
+  allowlist at runtime. That is the user's own decision about their own network, and
+  it is the only way the set above grows without a rebuild.
 - Institutional / TDM source code paths are gated by Cargo features (`tdm-elsevier`,
-  `tdm-aps`, `tdm-springer`) and are **not present** in the default published binary; a
-  user wishing to enable them must rebuild from source. See [`SCOPE.md`](SCOPE.md) and
-  ADR-0002.
+  `tdm-aps`, `tdm-springer`, `tdm-ieee`) and are **not present** in the default
+  published binary; a user wishing to enable them must rebuild from source. See
+  [`SCOPE.md`](SCOPE.md) and ADR-0002. (`tdm-ieee` landed with ADR-0042 and was
+  missing from this list until #494 — `SOURCES.md` had all four.)
 - Even when compiled in, TDM sources require both an explicit per-publisher
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
@@ -115,10 +136,24 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from environment variables or
-   `~/.config/doiget/credentials.toml`, wrapped in `secrecy::Secret`, and never
-   logged in raw form. *Enforced by:* `secrecy::Secret` types in
-   `doiget-core`; `tracing` redactor; CI grep for embedded key patterns.
+   binary. Credentials are read at runtime from **environment variables**
+   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
+   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
+   `tracing` redactor.
+
+   Two corrections here (#494):
+
+   - This said credentials are also read from `~/.config/doiget/credentials.toml`.
+     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
+     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
+     specifies it in full anyway, which is tracked as #509. A user following that
+     section today writes a key into a file doiget ignores.
+   - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
+     check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
+     imports, telemetry imports and non-rustls TLS backends; there is no secret
+     scanner in the tree. §6a is defined as controls a machine enforces, so an
+     enforcement clause that names nothing does not belong in it. The safeguard
+     itself stands on the type-level ones that are real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
    the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
@@ -127,8 +162,8 @@ them requires changing source files that are gated by branch protection.
    resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
-   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`). Default builds and crates.io
-   artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
+   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and
+   crates.io artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
    `[features]` declarations; `posture-lint.yml` import-pattern grep;
    ADR-0002.
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -64,6 +64,81 @@ This is enforced structurally rather than only by documentation:
   sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
+## 2a. Access ceiling (binding constraint)
+
+§1 and §2 say what doiget does **not** do. This says what it **may** do, because an
+unstated ceiling cannot be checked — and the next feature that widens the content leg
+would widen it against nothing. Two widenings already shipped without anyone deciding
+the ceiling had moved (see "How this changed", below), which is what #497 is about.
+
+Written to be **falsifiable by reading the code**, not aspirational. Every clause below
+names where it is enforced.
+
+### The ceiling
+
+Given a ref, doiget attempts retrieval from exactly two kinds of location:
+
+**(a) A location an enabled source reported.** The URL appears verbatim in a response
+doiget received from a source that both the build and the runtime capability profile
+have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
+and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+`fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
+behind its own `DOIGET_ENABLE_*` flag.
+*Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
+per-source extractor and returns `None` for any other source name.
+
+**(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
+the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's
+`/html/<id>`; a Tier-3 publisher's documented TDM endpoint for a DOI whose registrant
+prefix says that publisher issued it.
+*Enforced by:* the `*_url` constructors in each source module, each of which is a
+`base.join(<documented path>)` and nothing else.
+
+**There is no third kind.** doiget does not derive a candidate URL from the *content*
+of a document it fetched — no link-following, no scraping, no `href` extraction — and
+does not guess a publisher URL pattern the publisher has not documented.
+
+### What bounds both, on every request and every redirect hop
+
+1. **Host allowlist.** The host must match the per-source allowlist. A redirect to a
+   host off the list fails as `RedirectDenied`; a non-`https` redirect fails as
+   `InsecureRedirect`; hop count is capped. This applies to every hop, not only the
+   first. *Enforced by:* the `reqwest::redirect::Policy::custom` closure in
+   `crates/doiget-core/src/http.rs`; ADR-0027.
+2. **Credential and consent, Tier 3 only.** The Cargo feature must be compiled in, the
+   user must supply their own API key, and the user must separately set
+   `DOIGET_AGREE_TDM_<PUBLISHER>=1`. All three, or the source is unavailable.
+   *Enforced by:* §6a.2, §6a.3, §6a.4.
+3. **Prefix scoping, Tier 3 only.** A publisher's endpoint is asked only about DOIs its
+   own registrant prefix covers, so enabling one TDM source does not disclose an
+   unrelated reading list to that publisher. *Enforced by:* `PUBLISHER_PREFIXES` per
+   source, checked before credentials; ADR-0041, ADR-0044.
+4. **Every attempt is recorded.** Consulted or not, and why. *Enforced by:*
+   `SourceAttempt` / `attempts_to_value`; ADR-0029, ADR-0043.
+
+### How this changed, and why it is still defensible
+
+The rule this project operated under informally was **"never go beyond what Unpaywall
+reports"**. That was clean and checkable, and it is no longer what the code does. The
+ceiling rose twice, both times deliberately, both times with an ADR, and neither time
+was this document updated to say so:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is asked
+  for the bytes. For `tdm-aps` that returns a PDF. Unpaywall never listed that location.
+- **#445 / ADR-0029** — when the OA chain and the arXiv preprint fallback are both
+  exhausted, the enabled optional sources are asked whether anyone else holds a copy,
+  and the URL they report is tried.
+
+Neither is improper. But the argument for them is **not** "we never exceed Unpaywall" —
+that argument is simply false now. The real argument is the one written above: every
+leg is a publisher-sanctioned API or an index the user switched on, reached at a host
+on the allowlist, under the user's own credential where one is required, with the
+attempt recorded.
+
+**A change that widens (a) or (b) amends this section in the same PR.** That is the
+point of writing it down: ADR-0044 could not have been reviewed against a ceiling that
+existed only as a shared belief.
+
 ## 3. Tool-neutrality framing
 
 doiget is positioned as a **general-purpose automation tool** in the sense familiar from

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -39,7 +39,8 @@ This is enforced structurally rather than only by documentation:
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
   runtime. See [`CAPABILITY.md`](CAPABILITY.md).
-- A hard-coded rate limit (5 concurrent fetches, 5/second) prevents bulk-scraping
+- A hard-coded rate limit (5 concurrent fetches, 5/second — stricter still for
+  sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
 ## 3. Tool-neutrality framing
@@ -141,8 +142,22 @@ them requires changing source files that are gated by branch protection.
    `MAX_FETCHES_PER_SECOND = 5.0` are library constants. The struct
    `RateLimits` exposes only `HARD_CODED`; field visibility is `pub(crate)`,
    so external callers cannot synthesize a `RateLimits` with different
-   values. *Enforced by:* `pub(crate)` field visibility,
-   `#[non_exhaustive]` on `RateLimits`, smoke tests in `lib.rs::tests`.
+   values.
+
+   Those two are the **ceiling**, not the whole limit. A source whose vendor
+   publishes something stricter is held to the stricter value, from the
+   `SOURCE_RATE_OVERRIDES` table (ADR-0045) — arXiv, for instance, at one
+   request every three seconds over a single connection. Table entries are
+   library constants for the same reason `RateLimits` is: an override a
+   caller could supply would hand back exactly what this safeguard
+   withholds. `RateLimits::backoff_ms_for` and `max_concurrent_for` return
+   the stricter of the global value and the entry, so an entry can only ever
+   tighten. *Enforced by:* `pub(crate)` field visibility,
+   `#[non_exhaustive]` on `RateLimits`, the `max`/`min` in those two
+   accessors, and smoke tests in `lib.rs::tests` and
+   `rate_limiter.rs::tests` — including one that fails the build if a table
+   entry is looser than the global cap and would therefore be silently
+   ignored.
 
 ### 6b. Policy commitments (3)
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -28,6 +28,10 @@
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
+it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
+not try before amends that section in the same PR (#497, ADR-0048).
+
 ### 1.1 When Tier 3 is consulted (ADR-0044)
 
 Tier-3 sources are asked two different questions at two different points, and the

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -11,21 +11,21 @@
 
 | Source | Tier | Phase | Auth | ToS link | doiget feature |
 |---|---|---|---|---|---|
-| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/services/metadata-retrieval/rest-api/> | always-on |
+| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/documentation/retrieve-metadata/rest-api/> | always-on |
 | Unpaywall | 1 (OA) | 1 | email (polite pool) | <https://unpaywall.org/products/api> | always-on |
 | arXiv | 1 (OA) | 1 | none | <https://info.arxiv.org/help/api/index.html> | always-on |
 | ar5iv (full text) | 1 (OA) | 4 (PR4) | none | <https://ar5iv.labs.arxiv.org/> | always-on |
-| OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
+| OpenAlex | 2 (metadata) | 4 | none | <https://help.openalex.org/how-to/> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
-| DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DOAJ | 2 (metadata) | 4 | none | <https://doaj.org/terms/> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
-| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
+| CORE | 2 (metadata) | 4 | free key (`DOIGET_CORE_API_KEY`); unregistered use is token-tiered, see §6.1 | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
-| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
+| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/terms-conditions/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
-| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
+| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
 ### 1.1 When Tier 3 is consulted (ADR-0044)
@@ -48,10 +48,16 @@ retrieval with `Accept: application/pdf`. The stored file reports
 `license = "unknown"`: it came from the publisher under your agreement, not from the
 OA location whose licence Unpaywall reported, and doiget does not guess licences.
 
-`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
-that is its own policy — retrieval of non-open-access article PDFs through the
-ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
-preview rather than the article.
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only — but for three
+different reasons. This paragraph named them in one sentence with only Elsevier's
+reason attached, so the weaker cases inherited the stronger one's justification
+(#496):
+
+| source | why it is metadata-only |
+|---|---|
+| `tdm-elsevier` | **The vendor's policy.** Retrieval of non-open-access article PDFs through the ScienceDirect APIs is not permitted; a non-OA article yields a first-page preview rather than the article. Full-text **XML** is what an entitlement grants, which is the ADR-0032 `paper_text` route rather than the content leg. |
+| `tdm-springer` | **doiget's choice.** Springer publishes a Full Text (TDM) API and an Open Access API alongside the Meta API, so full text is contractually available. Staying metadata-only is a conservative decision here, not a restriction. |
+| `tdm-ieee` | **The contract is not public.** Shipped against an inferred one (ADR-0042), so the narrower surface is the honest one until it can be checked. |
 
 Disclosure is bounded exactly as before: a source is only ever told about DOIs its
 own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
@@ -68,7 +74,14 @@ hold any credential for any user. Before enabling a source, ensure that you:
 - Are operating from a network and device authorized to use those rights.
 
 doiget enforces a hard rate cap of **5 fetches per second** per process to make polite
-behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
+behavior the default ([`LEGAL.md`](LEGAL.md) §6a safeguard 5), tightened per source
+where a vendor publishes something stricter (§6.1 below, ADR-0045).
+
+This cited "§6 safeguard 8" until #496. Safeguard 8 is marketing-language
+self-policing, and it lives in §6b — *policy commitments*, the ones a contributor
+could violate without CI catching it. The rate cap is §6a.5, an *enforced control*.
+The citation sent a reader looking for the enforcement basis to the section that has
+none.
 
 ## 3. Default release binaries
 
@@ -284,9 +297,26 @@ than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the s
 of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
 only ever tighten (ADR-0045).
 
-| source | interval | connections | published terms |
-|---|---|---|---|
-| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+### 6.1 What each vendor publishes, and what doiget does about it
 
-Every other source uses the global 200 ms floor and the global concurrency cap. Sources
-whose vendor limits are not yet recorded are tracked in #496.
+Recorded so the paragraph above is auditable rather than aspirational (#496). A row
+with no `SOURCE_RATE_OVERRIDES` entry runs on the global cap, and the "doiget" column
+says so rather than leaving it to be inferred.
+
+| source | vendor's published limit | doiget | source of the figure |
+|---|---|---|---|
+| arXiv | 1 request / 3 s, single connection | **enforced per-source** (`SOURCE_RATE_OVERRIDES`) | <https://info.arxiv.org/help/api/tou.html> |
+| CORE | token-cost model: 100 tokens/day and 10/min unregistered, 1 000/day and 25/min registered; a complex query costs 3–5 tokens | global cap; the key is what raises the tier | <https://api.core.ac.uk/docs/v3> |
+| OpenAlex | daily and per-second limits, plus a polite pool keyed on `mailto` | global cap; doiget sends `mailto` when a contact email is set | <https://help.openalex.org/how-to/> |
+| Springer | a rate-limits page, tiered Basic / Premium | global cap | <https://dev.springernature.com/docs/rate-limit-details/rate-limits/> — **figures not recorded**, see below |
+| APS | none found | global cap | <https://harvest.aps.org/docs/harvest-api> |
+| Unpaywall, Crossref, DataCite, DOAJ, HAL, OpenAIRE, Europe PMC, Semantic Scholar, IEEE | none found, or not yet checked | global cap | — |
+
+The Springer figures are **absent rather than guessed**: that page renders its body
+through JavaScript and the audit could not extract the numbers. A plausible-looking
+number here would be worse than the gap, because the point of the table is that it can
+be checked against the vendor. Someone should open it in a browser and fill the cell in.
+
+CORE's row is why the §1 matrix no longer calls its key "optional". Requests do resolve
+without one, at roughly a hundred simple queries a day — so a run that worked yesterday
+can stop working today, and "optional" gives the reader nothing to diagnose that with.

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -120,8 +120,14 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 ### arXiv
 
-- Public, no-auth API, but the API has a 3-second-per-request rate guideline. doiget's
-  global 5/sec cap respects this.
+- Public, no-auth API. Its [Terms of Use](https://info.arxiv.org/help/api/tou.html)
+  cap requests at **one every three seconds, over a single connection**, collectively
+  across every machine under the caller's control.
+- doiget applies that per-source, via `SOURCE_RATE_OVERRIDES` (ADR-0045). One arXiv
+  *attempt* issues two *requests* — the Atom feed, then the PDF — and both are paced,
+  because the guideline counts requests.
+- This page previously claimed the global 5/sec cap "respects this". It did not: the
+  effective rate was 15x the guideline and the concurrency 5x (#493).
 - doiget uses arXiv for: arXiv id → PDF + metadata. The parsed metadata
   also carries the **published DOI** and **journal reference** when the
   submitter supplied them (`<arxiv:doi>` / `<arxiv:journal_ref>`) — the
@@ -272,5 +278,15 @@ doiget's defaults are designed to be on the polite side of every source we know 
 - `User-Agent: doiget/<version> (+https://github.com/QAtlasHub/doiget)`.
 - Honors `Retry-After` headers (treats 429 as `RATE_LIMITED` with the indicated wait).
 
-If a source publishes a stricter rate guideline, doiget will adopt the stricter value at
-the per-source level rather than relax the global cap.
+If a source publishes a stricter rate guideline, doiget adopts the stricter value at
+the per-source level rather than relaxing the global cap. This is now mechanical rather
+than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the stricter
+of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
+only ever tighten (ADR-0045).
+
+| source | interval | connections | published terms |
+|---|---|---|---|
+| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+
+Every other source uses the global 200 ms floor and the global concurrency cap. Sources
+whose vendor limits are not yet recorded are tracked in #496.

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -28,6 +28,22 @@
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+When the content leg is blocked, the enabled optional sources are asked whether anyone
+else holds a copy, and the URL they report is tried (#445). Four can name one:
+
+| source | field | notes |
+|---|---|---|
+| CORE | `downloadUrl` | |
+| HAL | `fileMain_s` | gated on `openAccess_bool` |
+| Europe PMC | `fullTextUrlList` | `documentStyle: pdf` and `availabilityCode` of `F` or `OA` |
+| OpenAlex | `locations[]` | the first entry with `is_oa` and a `pdf_url` (#461) |
+
+OpenAlex is the one that reports **every** location it knows of rather than a single best
+one, which is what makes it the likeliest to name an institutional-repository copy of a
+hybrid-OA article whose publisher refused. That host will not be on any curated list —
+`[network] trust_academic_repos` (ADR-0028) is the existing answer, and the denial help
+names it when it applies.
+
 The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
 it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
 not try before amends that section in the same PR (#497, ADR-0048).

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -24,9 +24,38 @@
 | CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
-| APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
+| APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
+
+### 1.1 When Tier 3 is consulted (ADR-0044)
+
+Tier-3 sources are asked two different questions at two different points, and the
+distinction is what #458 was about:
+
+| point | question | trigger |
+|---|---|---|
+| metadata stage | "who can tell me about this DOI?" | Crossref found nothing |
+| **content stage** | "who will give me the bytes?" | the OA content leg was **blocked** |
+
+The second is the one a TDM agreement is obtained for. Until ADR-0044 it did not
+exist, so for a publisher-registered DOI — which Crossref resolves readily — an
+enabled TDM source was never consulted at all and enabling it changed nothing
+observable.
+
+**`tdm-aps` returns PDF bytes** at the content stage; APS documents single-request
+retrieval with `Accept: application/pdf`. The stored file reports
+`license = "unknown"`: it came from the publisher under your agreement, not from the
+OA location whose licence Unpaywall reported, and doiget does not guess licences.
+
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
+that is its own policy — retrieval of non-open-access article PDFs through the
+ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
+preview rather than the article.
+
+Disclosure is bounded exactly as before: a source is only ever told about DOIs its
+own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
+asked, not what it is told.
 
 ## 2. User responsibility
 

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -63,7 +63,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 |---|---|
 | Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
-| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). |
+| CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). **Records are emitted in completion order, not input order** — see below. |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |
 
 ### 3.1 Structured `denial_context` (NORMATIVE; ADR-0023)
@@ -131,6 +131,22 @@ Emitted only for reasons with a configuration channel — `redirect_not_in_allow
 `host_in_block_list`. A `size_cap_exceeded` or `capability_not_granted` denial carries no
 `remediation`, because offering a host to trust would send the caller after a fix that
 cannot work.
+
+### 3.2a `batch --json` record order (NORMATIVE)
+
+Records are written as each ref **completes**. `batch` runs up to
+`RateLimits::HARD_CODED.max_concurrent_fetches()` fetches at once and emits each
+record when its task finishes, so stdout is in completion order and reordering is
+the normal case rather than a rare one: a parse error returns instantly, a 1 MB PDF
+does not.
+
+**Key on the `ref` field.** Zipping stdout against the input file positionally is the
+obvious thing to write, it works on a small or uniform batch, and the first time a
+fetch is slow it attaches a result to the wrong DOI with no error anywhere (#479).
+
+Input order would cost buffering the whole run before emitting anything, which
+would end streaming for large batches. The order is not going to change; consumers
+that need input order must sort by `ref` themselves.
 
 ### 3.3 Structured `attempts` (NORMATIVE; ADR-0043)
 

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -138,17 +138,44 @@ The resolution trace introduced in #413/#438, previously CLI text only.
 
 ```jsonc
 "attempts": [
-  { "source": "hal",  "outcome": "not_consulted_disabled", "detail": "DOIGET_ENABLE_HAL", "consulted": false },
-  { "source": "core", "outcome": "consulted_no_record",                                   "consulted": true  }
+  { "source": "hal", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_ENABLE_HAL", "required_env": ["DOIGET_ENABLE_HAL"], "consulted": false },
+  { "source": "tdm-aps", "outcome": "not_consulted_disabled",
+    "detail": "DOIGET_KEY_APS + DOIGET_AGREE_TDM_APS",
+    "required_env": ["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"], "consulted": false },
+  { "source": "core", "outcome": "consulted_denied",
+    "detail": "consulted: refused (RedirectNotInAllowlist, cdn.example.org)",
+    "denial_context": { "reason": "redirect_not_in_allowlist", "attempted": "cdn.example.org",
+                        "expected": ["core.ac.uk"], "hop_index": 1 },
+    "remediation": [ /* … */ ], "consulted": true }
 ]
 ```
 
 `outcome` is a **closed** enum:
 `not_consulted_disabled`, `not_consulted_not_applicable`,
 `not_consulted_wrong_publisher`, `not_consulted_not_needed`, `consulted_no_record`,
-`consulted_not_open_access`, `consulted_failed`, `consulted_resolved`.
+`consulted_not_open_access`, `consulted_denied`, `consulted_failed`,
+`consulted_resolved`.
 
 `detail` is present only for the variants carrying one, and is opaque text.
+
+**`required_env`** (#470) accompanies `not_consulted_disabled`: the variables to set,
+as a list. `detail` carries the same set joined with `" + "` and is retained for
+compatibility — do not parse it. Tier-3 sources need two variables and Tier-2 one,
+which is why the joined form was a separator a consumer had to split on.
+
+**`denial_context`** and **`remediation`** (#470) accompany `consulted_denied`, and
+carry the same ADR-0023 structure the blocked PDF leg already carried. Before this,
+a redirect denial, an oversized body or a not-a-PDF on a *metadata-chain* source —
+the richest and most actionable failures — flattened into `consulted_failed` with an
+opaque string, on a surface documented as machine-readable. `remediation` is omitted
+when the denial reason has no configuration channel (`InsecureScheme` has none:
+the fix for an `http://` redirect is not to trust the host).
+
+`consulted_denied` is a *refusal by a policy control*, distinct from
+`consulted_failed` (transport, auth, schema). `CapabilityNotGranted` is **not** a
+`consulted_denied`: it is produced before any request goes out, so reporting it as
+consulted would misstate reach.
 `consulted` is redundant with `outcome` and present anyway: it is the single question
 every consumer has — *did anyone else look?* — and requiring them to memorise which of
 eight tokens implies it invites the confusion the trace exists to end.

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -30,9 +30,38 @@ weight = 200
 | CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
 | Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
-| APS Harvest TDM | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
+| APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
+
+### 1.1 When Tier 3 is consulted (ADR-0044)
+
+Tier-3 sources are asked two different questions at two different points, and the
+distinction is what #458 was about:
+
+| point | question | trigger |
+|---|---|---|
+| metadata stage | "who can tell me about this DOI?" | Crossref found nothing |
+| **content stage** | "who will give me the bytes?" | the OA content leg was **blocked** |
+
+The second is the one a TDM agreement is obtained for. Until ADR-0044 it did not
+exist, so for a publisher-registered DOI — which Crossref resolves readily — an
+enabled TDM source was never consulted at all and enabling it changed nothing
+observable.
+
+**`tdm-aps` returns PDF bytes** at the content stage; APS documents single-request
+retrieval with `Accept: application/pdf`. The stored file reports
+`license = "unknown"`: it came from the publisher under your agreement, not from the
+OA location whose licence Unpaywall reported, and doiget does not guess licences.
+
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
+that is its own policy — retrieval of non-open-access article PDFs through the
+ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
+preview rather than the article.
+
+Disclosure is bounded exactly as before: a source is only ever told about DOIs its
+own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
+asked, not what it is told.
 
 ## 2. User responsibility
 

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -34,6 +34,10 @@ weight = 200
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
+it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
+not try before amends that section in the same PR (#497, ADR-0048).
+
 ### 1.1 When Tier 3 is consulted (ADR-0044)
 
 Tier-3 sources are asked two different questions at two different points, and the

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -17,21 +17,21 @@ weight = 200
 
 | Source | Tier | Phase | Auth | ToS link | doiget feature |
 |---|---|---|---|---|---|
-| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/services/metadata-retrieval/rest-api/> | always-on |
+| Crossref | 1 (OA) | 1 | none | <https://www.crossref.org/documentation/retrieve-metadata/rest-api/> | always-on |
 | Unpaywall | 1 (OA) | 1 | email (polite pool) | <https://unpaywall.org/products/api> | always-on |
 | arXiv | 1 (OA) | 1 | none | <https://info.arxiv.org/help/api/index.html> | always-on |
 | ar5iv (full text) | 1 (OA) | 4 (PR4) | none | <https://ar5iv.labs.arxiv.org/> | always-on |
-| OpenAlex | 2 (metadata) | 4 | none | <https://docs.openalex.org/how-to-use-the-api/api-overview> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
+| OpenAlex | 2 (metadata) | 4 | none | <https://help.openalex.org/how-to/> | `--features metadata` + `DOIGET_ENABLE_OPENALEX` |
 | Semantic Scholar | 2 (metadata) | 4 | API key (optional) | <https://www.semanticscholar.org/product/api> | `--features metadata` + `DOIGET_ENABLE_S2` |
-| DOAJ | 2 (metadata) | 4 | none | <https://www.doaj.org/api> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
+| DOAJ | 2 (metadata) | 4 | none | <https://doaj.org/terms/> | `--features metadata` + `DOIGET_ENABLE_DOAJ` |
 | DataCite | 2 (resolution) | 4 | none | <https://datacite.org/terms-and-conditions/> | `--features metadata` + `DOIGET_ENABLE_DATACITE` |
 | HAL | 2 (metadata) | 4 | none | <https://api.archives-ouvertes.fr/docs> | `--features metadata` + `DOIGET_ENABLE_HAL` |
 | OpenAIRE | 2 (metadata) | 4 | none | <https://graph.openaire.eu/docs/> | `--features metadata` + `DOIGET_ENABLE_OPENAIRE` |
-| CORE | 2 (metadata) | 4 | optional free key (`DOIGET_CORE_API_KEY`) | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
+| CORE | 2 (metadata) | 4 | free key (`DOIGET_CORE_API_KEY`); unregistered use is token-tiered, see §6.1 | <https://core.ac.uk/terms> | `--features metadata` + `DOIGET_ENABLE_CORE` |
 | Europe PMC | 2 (metadata) | 4 | none | <https://europepmc.org/About> | `--features metadata` + `DOIGET_ENABLE_EUROPE_PMC` |
-| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/> | `--features tdm-springer` + key + agree |
+| Springer Nature OA | 3 (institutional) | 5a | API key | <https://dev.springernature.com/terms-conditions/> | `--features tdm-springer` + key + agree |
 | APS Harvest TDM (**serves PDFs**) | 3 (institutional) | 5b | API key | <https://harvest.aps.org/> | `--features tdm-aps` + key + agree |
-| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/legal/tdmrep> | `--features tdm-elsevier` + key + agree |
+| Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
 ### 1.1 When Tier 3 is consulted (ADR-0044)
@@ -54,10 +54,16 @@ retrieval with `Accept: application/pdf`. The stored file reports
 `license = "unknown"`: it came from the publisher under your agreement, not from the
 OA location whose licence Unpaywall reported, and doiget does not guess licences.
 
-`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only. For Elsevier
-that is its own policy — retrieval of non-open-access article PDFs through the
-ScienceDirect APIs is not permitted, and a non-OA article yields a first-page
-preview rather than the article.
+`tdm-elsevier`, `tdm-springer` and `tdm-ieee` remain metadata-only — but for three
+different reasons. This paragraph named them in one sentence with only Elsevier's
+reason attached, so the weaker cases inherited the stronger one's justification
+(#496):
+
+| source | why it is metadata-only |
+|---|---|
+| `tdm-elsevier` | **The vendor's policy.** Retrieval of non-open-access article PDFs through the ScienceDirect APIs is not permitted; a non-OA article yields a first-page preview rather than the article. Full-text **XML** is what an entitlement grants, which is the ADR-0032 `paper_text` route rather than the content leg. |
+| `tdm-springer` | **doiget's choice.** Springer publishes a Full Text (TDM) API and an Open Access API alongside the Meta API, so full text is contractually available. Staying metadata-only is a conservative decision here, not a restriction. |
+| `tdm-ieee` | **The contract is not public.** Shipped against an inferred one (ADR-0042), so the narrower surface is the honest one until it can be checked. |
 
 Disclosure is bounded exactly as before: a source is only ever told about DOIs its
 own publisher registered (ADR-0041). What rises with ADR-0044 is how often it is
@@ -74,7 +80,14 @@ hold any credential for any user. Before enabling a source, ensure that you:
 - Are operating from a network and device authorized to use those rights.
 
 doiget enforces a hard rate cap of **5 fetches per second** per process to make polite
-behavior the default ([`LEGAL.md`](LEGAL.md) §6 safeguard 8).
+behavior the default ([`LEGAL.md`](LEGAL.md) §6a safeguard 5), tightened per source
+where a vendor publishes something stricter (§6.1 below, ADR-0045).
+
+This cited "§6 safeguard 8" until #496. Safeguard 8 is marketing-language
+self-policing, and it lives in §6b — *policy commitments*, the ones a contributor
+could violate without CI catching it. The rate cap is §6a.5, an *enforced control*.
+The citation sent a reader looking for the enforcement basis to the section that has
+none.
 
 ## 3. Default release binaries
 
@@ -290,9 +303,26 @@ than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the s
 of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
 only ever tighten (ADR-0045).
 
-| source | interval | connections | published terms |
-|---|---|---|---|
-| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+### 6.1 What each vendor publishes, and what doiget does about it
 
-Every other source uses the global 200 ms floor and the global concurrency cap. Sources
-whose vendor limits are not yet recorded are tracked in #496.
+Recorded so the paragraph above is auditable rather than aspirational (#496). A row
+with no `SOURCE_RATE_OVERRIDES` entry runs on the global cap, and the "doiget" column
+says so rather than leaving it to be inferred.
+
+| source | vendor's published limit | doiget | source of the figure |
+|---|---|---|---|
+| arXiv | 1 request / 3 s, single connection | **enforced per-source** (`SOURCE_RATE_OVERRIDES`) | <https://info.arxiv.org/help/api/tou.html> |
+| CORE | token-cost model: 100 tokens/day and 10/min unregistered, 1 000/day and 25/min registered; a complex query costs 3–5 tokens | global cap; the key is what raises the tier | <https://api.core.ac.uk/docs/v3> |
+| OpenAlex | daily and per-second limits, plus a polite pool keyed on `mailto` | global cap; doiget sends `mailto` when a contact email is set | <https://help.openalex.org/how-to/> |
+| Springer | a rate-limits page, tiered Basic / Premium | global cap | <https://dev.springernature.com/docs/rate-limit-details/rate-limits/> — **figures not recorded**, see below |
+| APS | none found | global cap | <https://harvest.aps.org/docs/harvest-api> |
+| Unpaywall, Crossref, DataCite, DOAJ, HAL, OpenAIRE, Europe PMC, Semantic Scholar, IEEE | none found, or not yet checked | global cap | — |
+
+The Springer figures are **absent rather than guessed**: that page renders its body
+through JavaScript and the audit could not extract the numbers. A plausible-looking
+number here would be worse than the gap, because the point of the table is that it can
+be checked against the vendor. Someone should open it in a browser and fill the cell in.
+
+CORE's row is why the §1 matrix no longer calls its key "optional". Requests do resolve
+without one, at roughly a hundred simple queries a day — so a run that worked yesterday
+can stop working today, and "optional" gives the reader nothing to diagnose that with.

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -34,6 +34,22 @@ weight = 200
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+When the content leg is blocked, the enabled optional sources are asked whether anyone
+else holds a copy, and the URL they report is tried (#445). Four can name one:
+
+| source | field | notes |
+|---|---|---|
+| CORE | `downloadUrl` | |
+| HAL | `fileMain_s` | gated on `openAccess_bool` |
+| Europe PMC | `fullTextUrlList` | `documentStyle: pdf` and `availabilityCode` of `F` or `OA` |
+| OpenAlex | `locations[]` | the first entry with `is_oa` and a `pdf_url` (#461) |
+
+OpenAlex is the one that reports **every** location it knows of rather than a single best
+one, which is what makes it the likeliest to name an institutional-repository copy of a
+hybrid-OA article whose publisher refused. That host will not be on any curated list —
+`[network] trust_academic_repos` (ADR-0028) is the existing answer, and the denial help
+names it when it applies.
+
 The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
 it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
 not try before amends that section in the same PR (#497, ADR-0048).

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -126,8 +126,14 @@ There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).
 
 ### arXiv
 
-- Public, no-auth API, but the API has a 3-second-per-request rate guideline. doiget's
-  global 5/sec cap respects this.
+- Public, no-auth API. Its [Terms of Use](https://info.arxiv.org/help/api/tou.html)
+  cap requests at **one every three seconds, over a single connection**, collectively
+  across every machine under the caller's control.
+- doiget applies that per-source, via `SOURCE_RATE_OVERRIDES` (ADR-0045). One arXiv
+  *attempt* issues two *requests* — the Atom feed, then the PDF — and both are paced,
+  because the guideline counts requests.
+- This page previously claimed the global 5/sec cap "respects this". It did not: the
+  effective rate was 15x the guideline and the concurrency 5x (#493).
 - doiget uses arXiv for: arXiv id → PDF + metadata. The parsed metadata
   also carries the **published DOI** and **journal reference** when the
   submitter supplied them (`<arxiv:doi>` / `<arxiv:journal_ref>`) — the
@@ -278,5 +284,15 @@ doiget's defaults are designed to be on the polite side of every source we know 
 - `User-Agent: doiget/<version> (+https://github.com/QAtlasHub/doiget)`.
 - Honors `Retry-After` headers (treats 429 as `RATE_LIMITED` with the indicated wait).
 
-If a source publishes a stricter rate guideline, doiget will adopt the stricter value at
-the per-source level rather than relax the global cap.
+If a source publishes a stricter rate guideline, doiget adopts the stricter value at
+the per-source level rather than relaxing the global cap. This is now mechanical rather
+than a promise: `RateLimits::backoff_ms_for` and `max_concurrent_for` take the stricter
+of the global setting and the source's entry in `SOURCE_RATE_OVERRIDES`, so an entry can
+only ever tighten (ADR-0045).
+
+| source | interval | connections | published terms |
+|---|---|---|---|
+| `arxiv` | 3 s | 1 | <https://info.arxiv.org/help/api/tou.html> |
+
+Every other source uses the global 200 ms floor and the global concurrency cap. Sources
+whose vendor limits are not yet recorded are tracked in #496.

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -70,6 +70,81 @@ This is enforced structurally rather than only by documentation:
   sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
+## 2a. Access ceiling (binding constraint)
+
+§1 and §2 say what doiget does **not** do. This says what it **may** do, because an
+unstated ceiling cannot be checked — and the next feature that widens the content leg
+would widen it against nothing. Two widenings already shipped without anyone deciding
+the ceiling had moved (see "How this changed", below), which is what #497 is about.
+
+Written to be **falsifiable by reading the code**, not aspirational. Every clause below
+names where it is enforced.
+
+### The ceiling
+
+Given a ref, doiget attempts retrieval from exactly two kinds of location:
+
+**(a) A location an enabled source reported.** The URL appears verbatim in a response
+doiget received from a source that both the build and the runtime capability profile
+have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
+and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+`fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
+behind its own `DOIGET_ENABLE_*` flag.
+*Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
+per-source extractor and returns `None` for any other source name.
+
+**(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
+the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's
+`/html/<id>`; a Tier-3 publisher's documented TDM endpoint for a DOI whose registrant
+prefix says that publisher issued it.
+*Enforced by:* the `*_url` constructors in each source module, each of which is a
+`base.join(<documented path>)` and nothing else.
+
+**There is no third kind.** doiget does not derive a candidate URL from the *content*
+of a document it fetched — no link-following, no scraping, no `href` extraction — and
+does not guess a publisher URL pattern the publisher has not documented.
+
+### What bounds both, on every request and every redirect hop
+
+1. **Host allowlist.** The host must match the per-source allowlist. A redirect to a
+   host off the list fails as `RedirectDenied`; a non-`https` redirect fails as
+   `InsecureRedirect`; hop count is capped. This applies to every hop, not only the
+   first. *Enforced by:* the `reqwest::redirect::Policy::custom` closure in
+   `crates/doiget-core/src/http.rs`; ADR-0027.
+2. **Credential and consent, Tier 3 only.** The Cargo feature must be compiled in, the
+   user must supply their own API key, and the user must separately set
+   `DOIGET_AGREE_TDM_<PUBLISHER>=1`. All three, or the source is unavailable.
+   *Enforced by:* §6a.2, §6a.3, §6a.4.
+3. **Prefix scoping, Tier 3 only.** A publisher's endpoint is asked only about DOIs its
+   own registrant prefix covers, so enabling one TDM source does not disclose an
+   unrelated reading list to that publisher. *Enforced by:* `PUBLISHER_PREFIXES` per
+   source, checked before credentials; ADR-0041, ADR-0044.
+4. **Every attempt is recorded.** Consulted or not, and why. *Enforced by:*
+   `SourceAttempt` / `attempts_to_value`; ADR-0029, ADR-0043.
+
+### How this changed, and why it is still defensible
+
+The rule this project operated under informally was **"never go beyond what Unpaywall
+reports"**. That was clean and checkable, and it is no longer what the code does. The
+ceiling rose twice, both times deliberately, both times with an ADR, and neither time
+was this document updated to say so:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is asked
+  for the bytes. For `tdm-aps` that returns a PDF. Unpaywall never listed that location.
+- **#445 / ADR-0029** — when the OA chain and the arXiv preprint fallback are both
+  exhausted, the enabled optional sources are asked whether anyone else holds a copy,
+  and the URL they report is tried.
+
+Neither is improper. But the argument for them is **not** "we never exceed Unpaywall" —
+that argument is simply false now. The real argument is the one written above: every
+leg is a publisher-sanctioned API or an index the user switched on, reached at a host
+on the allowlist, under the user's own credential where one is required, with the
+attempt recorded.
+
+**A change that widens (a) or (b) amends this section in the same PR.** That is the
+point of writing it down: ADR-0044 could not have been reviewed against a ceiling that
+existed only as a shared belief.
+
 ## 3. Tool-neutrality framing
 
 doiget is positioned as a **general-purpose automation tool** in the sense familiar from

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -45,7 +45,8 @@ This is enforced structurally rather than only by documentation:
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
   runtime. See [`CAPABILITY.md`](CAPABILITY.md).
-- A hard-coded rate limit (5 concurrent fetches, 5/second) prevents bulk-scraping
+- A hard-coded rate limit (5 concurrent fetches, 5/second — stricter still for
+  sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
 ## 3. Tool-neutrality framing
@@ -147,8 +148,22 @@ them requires changing source files that are gated by branch protection.
    `MAX_FETCHES_PER_SECOND = 5.0` are library constants. The struct
    `RateLimits` exposes only `HARD_CODED`; field visibility is `pub(crate)`,
    so external callers cannot synthesize a `RateLimits` with different
-   values. *Enforced by:* `pub(crate)` field visibility,
-   `#[non_exhaustive]` on `RateLimits`, smoke tests in `lib.rs::tests`.
+   values.
+
+   Those two are the **ceiling**, not the whole limit. A source whose vendor
+   publishes something stricter is held to the stricter value, from the
+   `SOURCE_RATE_OVERRIDES` table (ADR-0045) — arXiv, for instance, at one
+   request every three seconds over a single connection. Table entries are
+   library constants for the same reason `RateLimits` is: an override a
+   caller could supply would hand back exactly what this safeguard
+   withholds. `RateLimits::backoff_ms_for` and `max_concurrent_for` return
+   the stricter of the global value and the entry, so an entry can only ever
+   tighten. *Enforced by:* `pub(crate)` field visibility,
+   `#[non_exhaustive]` on `RateLimits`, the `max`/`min` in those two
+   accessors, and smoke tests in `lib.rs::tests` and
+   `rate_limiter.rs::tests` — including one that fails the build if a table
+   entry is looser than the global cap and would therefore be silently
+   ignored.
 
 ### 6b. Policy commitments (3)
 

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -36,11 +36,32 @@ boundaries.
 
 This is enforced structurally rather than only by documentation:
 
-- Default released binaries include only Open Access sources (Crossref, Unpaywall, arXiv).
+- Default released binaries (`oa-only`) include only Open Access sources. In full,
+  the hosts a default build is able to contact — read off the allowlists the
+  production client is assembled from in
+  `crates/doiget-cli/src/commands/fetch.rs`, not from memory:
+
+  | allowlist | hosts | what it is for |
+  |---|---|---|
+  | `tier_1_allowlist` | `api.crossref.org`, `*.crossref.org`, `api.unpaywall.org`, `arxiv.org`, `export.arxiv.org` | DOI and arXiv resolution |
+  | `oa_publisher_allowlist` | ~20 publisher and repository patterns (`*.springer.com`, `*.nature.com`, `*.wiley.com`, `*.elsevier.com`, `*.sciencedirect.com`, `*.plos.org`, `*.mdpi.com`, `*.frontiersin.org`, `*.biorxiv.org`, `*.medrxiv.org`, `europepmc.org`, `*.nih.gov`, `*.aps.org`, `scipost.org`, …) | following the OA PDF URL an index reported; the host is wherever the OA copy lives (ADR-0027) |
+  | `discovery_allowlist` | `api.openalex.org` | `doiget search` discovery (ADR-0031 D4), **always-on, no env gate** |
+  | `fulltext_allowlist` | `ar5iv.labs.arxiv.org` | `doiget text` structured full text (ADR-0032), **always-on** |
+
+  This list read "Crossref, Unpaywall, arXiv" until #494. **OpenAlex was absent
+  entirely** — a third-party service, not an arXiv subdomain, reached by the shipped
+  binary with no opt-in. `SOURCES.md` had documented both discovery and ar5iv as
+  always-on Tier 1 the whole time; the one document written for publisher legal teams
+  was the one that did not say so.
+
+  A user-supplied `[[network.additional_hosts]]` entry (ADR-0028) can extend the
+  allowlist at runtime. That is the user's own decision about their own network, and
+  it is the only way the set above grows without a rebuild.
 - Institutional / TDM source code paths are gated by Cargo features (`tdm-elsevier`,
-  `tdm-aps`, `tdm-springer`) and are **not present** in the default published binary; a
-  user wishing to enable them must rebuild from source. See [`SCOPE.md`](SCOPE.md) and
-  ADR-0002.
+  `tdm-aps`, `tdm-springer`, `tdm-ieee`) and are **not present** in the default
+  published binary; a user wishing to enable them must rebuild from source. See
+  [`SCOPE.md`](SCOPE.md) and ADR-0002. (`tdm-ieee` landed with ADR-0042 and was
+  missing from this list until #494 — `SOURCES.md` had all four.)
 - Even when compiled in, TDM sources require both an explicit per-publisher
   agreement environment variable (`DOIGET_AGREE_TDM_<PUBLISHER>=1`) **and** a
   user-provided API key. Both must be present, otherwise the source is unavailable at
@@ -121,10 +142,24 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from environment variables or
-   `~/.config/doiget/credentials.toml`, wrapped in `secrecy::Secret`, and never
-   logged in raw form. *Enforced by:* `secrecy::Secret` types in
-   `doiget-core`; `tracing` redactor; CI grep for embedded key patterns.
+   binary. Credentials are read at runtime from **environment variables**
+   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
+   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
+   `tracing` redactor.
+
+   Two corrections here (#494):
+
+   - This said credentials are also read from `~/.config/doiget/credentials.toml`.
+     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
+     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
+     specifies it in full anyway, which is tracked as #509. A user following that
+     section today writes a key into a file doiget ignores.
+   - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
+     check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
+     imports, telemetry imports and non-rustls TLS backends; there is no secret
+     scanner in the tree. §6a is defined as controls a machine enforces, so an
+     enforcement clause that names nothing does not belong in it. The safeguard
+     itself stands on the type-level ones that are real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
    the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
@@ -133,8 +168,8 @@ them requires changing source files that are gated by branch protection.
    resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
-   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`). Default builds and crates.io
-   artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
+   (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and
+   crates.io artifacts contain no TDM source code. *Enforced by:* `Cargo.toml`
    `[features]` declarations; `posture-lint.yml` import-pattern grep;
    ADR-0002.
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -71,7 +71,7 @@ version = "0.4.42"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-trait]]
-version = "0.1.91"
+version = "0.1.92"
 criteria = "safe-to-deploy"
 
 [[exemptions.aws-lc-rs]]
@@ -119,11 +119,11 @@ version = "0.4.45"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
-version = "4.6.5"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.5"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
@@ -675,11 +675,11 @@ version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.serial_test_derive]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.sha2]]
@@ -743,11 +743,11 @@ version = "3.27.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinystr]]
@@ -875,7 +875,7 @@ version = "2.5.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.24.0"
+version = "1.25.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -175,15 +175,15 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling]]
-version = "0.23.0"
+version = "0.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_core]]
-version = "0.23.0"
+version = "0.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_macro]]
-version = "0.23.0"
+version = "0.24.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.deadpool]]
@@ -567,7 +567,7 @@ version = "1.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rmcp]]
-version = "2.2.0"
+version = "3.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rmcp-macros]]
@@ -575,7 +575,7 @@ version = "1.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rmcp-macros]]
-version = "2.2.0"
+version = "3.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.roman-numerals-rs]]


### PR DESCRIPTION
> [!NOTE]
> **Reviewed 2026-08-26 — four findings, all being fixed before this merges.** See the review comment below. The lists here describe what is on `next` **today**; #497, #471 and #461 are still in open PRs and are listed under *Pending*, not above it.

Promotion of `next` → `main` for **0.8.10**. Opened before the version strip on purpose — see *Pending* at the bottom.

## What this release is about

0.8.9 asked one question of the code: **is this actually reached?** The answer was no, four times.

0.8.10 asks it of the *documentation*: **is what we say about it true, and can a reader check?** The answer was no in eleven places, including a legal document, a vendor's terms of use, and 0.8.9's own release notes.

| | the claim | reality |
|---|---|---|
| #472 | 0.8.9's notes said the Tier-3 chain runs when Crossref answers | it did not; **retracted** |
| #493 | three places said the global cap "comfortably respects" arXiv's guideline | **15× the permitted rate, 5× the concurrency** |
| #494 | `LEGAL.md` said the default binary talks to Crossref, Unpaywall, arXiv | it also talks to **OpenAlex** and ar5iv, with no opt-in |
| #494 | `LEGAL.md` §6a.1 cited "CI grep for embedded key patterns" as enforcement | **no such check exists** |
| #494 | `LEGAL.md` said credentials come from `credentials.toml` | nothing reads it (→ #509) |
| #495 | 16 ToS links, "official Terms of Service" | **5 dead or pointing at the wrong document** |
| #496 | CORE's key is "optional" | ~100 simple queries/day unregistered |
| #496 | Springer named alongside Elsevier as metadata-only | that is **doiget's** choice, not Springer's restriction |
| #496 | the rate cap cites `LEGAL.md` §6 safeguard 8 | safeguard 8 is a *policy commitment*; the cap is §6a.5, an *enforced control* |
| #484 | `tdm-aps`'s wiremock tests were green | the URL it built is **not an endpoint APS serves** |
| #477 | `error[CODE]:` is the CLI contract | held on `fetch` only; **eight of nine** commands dumped raw anyhow |

### Fixed

- **[legal]** arXiv is fetched at one request / 3 s over a single connection, the rate its Terms of Use publish. `RateLimits` had no per-source dimension at all, and `SOURCES.md` §6 *promised* doiget would adopt a stricter vendor value per source — the promise was real and the mechanism did not exist (#493, ADR-0045).
- **[orchestrator]** Tier 3 is consulted when the **content leg** is blocked, not only when Crossref missed. For `tdm-aps` that now returns a PDF (#458, ADR-0044).
- **[tdm-aps]** The source requests the URL APS documents. It built `/v2/article/<%2F-encoded DOI>`; APS serves `/v2/journals/articles/<raw DOI>` (#484).
- **[diagnostics]** Per-source attempt rows keep their `DenialContext`, so `remediation` is reachable from one — the blocked PDF leg had carried it since #459 and the rows had not (#470).
- **[cli]** `config path` / `config show` print when stdout is not a terminal. From a pipe they produced **zero bytes and exit 0** (#476).
- **[cli]** The denial help names the one trust flag that covers the host. `remediation::for_denial` already computed it, so **the agent got a better diagnostic than the human** (#478).
- **[cli]** `list-recent` and `search --local` show whether a PDF was actually stored. Fifty refs with ten blocked listed as fifty identical rows (#481).
- **[cli]** Every ref-taking command emits `error[INVALID_REF]:` (#477).
- **[core]** An unrecognised ref reports "neither a DOI nor an arXiv id" instead of the arXiv parser's verdict — a mistyped DOI was answered with arXiv id shapes (#477).
- **[legal]** `LEGAL.md` declares the default binary's whole network surface, lists all four TDM features, and drops two claims that were not true (#494, ADR-0047).
- **[docs]** All 16 ToS links resolve, measured; `SOURCES.md` records what each vendor publishes as a rate limit, or says the figure could not be read (#495, #496, ADR-0046).

### Added

- **[core]** `SOURCE_RATE_OVERRIDES`, `RateLimiter::pace`, `Source::fetch_content`, `HttpClient::fetch_pdf_with_headers`, `PdfLegStatus::TdmFetched`, `EntryInfo::size_bytes` / `has_pdf`.
- **[cli]** `list-recent --missing-pdf`.
- **[ci]** `tos-links.yml` — monthly, opens an issue on a dead ToS link. Schedule-only by design.

### Changed

- **[deps]** rmcp 2.2 → 3.1.4, plus the routine dependabot roll-up (#452, #450, #451, #453).
- **[errors]** `AttemptOutcome::Disabled` carries a list; `consulted_denied` joins the closed `outcome` enum in `ERRORS.md` §3.3 (NORMATIVE).
- **[docs]** `batch --json` record order is stated: completion order, key on `ref` (#479).

## Review posture

Everything in this release was **verified by mutation** — the fix reverted, and exactly the intended test failing. That found three defects the tests would otherwise have missed, two of them in code written *in this release*:

- #461's dispatch arm could be deleted with no test and no clippy warning — and so could the three pre-existing arms.
- #471's own test insertion silently disabled two existing tests. `cargo clippy -D warnings` caught it; **`cargo test` did not**, because a test that is no longer a test simply does not appear in the list.
- #493's first draft had `pace()` recorded in the global rate window without being admitted by it. All ten tests passed before and after the fix.

## Filed, not fixed

- **#509** — `CONFIG.md` §6 specifies `credentials.toml` in full, including a `0600` warning. Nothing reads the file and no permission check exists. Implement or delete is a decision.
- **#516** — the optional chain is `metadata`-gated; its transport allowlist is `citation`-gated. A `metadata`-only build fails every optional source at `UnknownSource`. #454 one tier down.
- **#492** — `fetch` exits 1 for an invalid ref, `graph` exits 2, `ERRORS.md` §4 says 2. A test named `..._and_exit_1` pins the first.
- **#426** — backmerge PAT, excluded by the maintainer.

## Pending — do not merge yet

- [ ] **#514** (#497 access ceiling), **#515** (#471 wiring tests), **#518** (#461 OpenAlex) are still open against `next` and belong in this release.
- [ ] **Version strip**: `0.8.10-beta.12` → `0.8.10`. `version-bump` is red until then, by design (ADR-0033: a promotion must carry a clean `X.Y.Z`).
- [ ] **`CHANGELOG.md` needs a curated `## [0.8.10]` section** before tagging — release gate G5 refuses the tag without one.
