### PR TITLE
docs(changelog): fix what the 0.8.10 promotion review found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+
+- **[legal]** `docs/LEGAL.md` §2a states the **access ceiling** — what doiget may
+  attempt for a given ref, and what bounds it. §1 and §2 said only what doiget does
+  *not* do, so the positive limit existed as a shared belief: *"never go beyond what
+  Unpaywall reports"*. That belief is false. The ceiling rose twice, deliberately and
+  with ADRs — ADR-0044's Tier-3 content leg and #445's optional-source fall-through —
+  and neither could be reviewed against a limit that was never written down. Every
+  clause names the code that enforces it (#497, ADR-0048).
+
 ### Fixed
 
 - **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
+- **[source]** The #445 content-leg fall-through asks OpenAlex too. OpenAlex reports
+  every location it knows of, where Unpaywall reports one — so for a hybrid-OA article
+  whose publisher leg is refused, it is the source likeliest to name the institutional
+  repository copy that actually satisfies the fetch. `OpenalexSource` was compiled in and
+  reachable from `doiget graph`, but absent from the optional chain, so the accessor was
+  not "the only missing piece": the wiring was missing too (#461).
 - **[legal]** `docs/LEGAL.md` §2a states the **access ceiling** — what doiget may
   attempt for a given ref, and what bounds it. §1 and §2 said only what doiget does
   *not* do, so the positive limit existed as a shared belief: *"never go beyond what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   citation sent a reader looking for the enforcement basis to the section that has
   none (#496).
 
+- **[tdm-aps]** The source requests the URL APS documents. It built
+  `/v2/article/<percent-encoded DOI>`; APS Harvest serves
+  `/v2/journals/articles/<raw DOI>`, so a reached source would have 404'd. Both wiremock
+  stubs asserted the path the implementation produced, so they could never have caught
+  it — they are now pinned to a constant transcribed from the vendor's own curl example
+  (#484).
 - **[legal]** arXiv is fetched at the rate its Terms of Use publish — one request
   every three seconds over a single connection — instead of 15x that rate and 5x
   the concurrency. `RateLimits` had no per-source dimension at all, and three
@@ -155,6 +161,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[deps]** `rmcp` 2.2 → **3.1.4**, a semver-major of the MCP SDK. One breaking change
+  reaches this repo: `InitializeResult::server_info` is now `Option<Implementation>`.
+  `schemars` stays at 1.2.1, so every tool's generated input schema is byte-identical,
+  and `ProtocolVersion::V_2024_11_05` is pinned explicitly, so the advertised protocol
+  version does not move with the SDK. ADR-0001's stdio-only invariant holds — no `axum`,
+  `oauth2`, `jsonwebtoken` or streamable-http crate enters the tree (#452).
+- **[deps]** `serial_test` 3.5 → **4.0.1** (its MSRV rises to 1.93.1, which does not reach
+  the MSRV jobs — they build without `--all-targets`, so dev-dependencies are never
+  compiled at 1.86), plus `async-trait`, `clap`, `thiserror`, `uuid`, and the CI action
+  bumps (#450, #451, #453).
+- **[test]** `tools_list_carries_the_safety_annotations`. The 22 safety annotations
+  shipped in 0.8.6 are consumed entirely by the rmcp macro and read back by nothing, so a
+  macro or model change in a major could have dropped every one of them with the build
+  green and every other test passing (#452, #406).
 - **[docs]** `docs/SOURCES.md` §6.1 records what each vendor publishes as a rate limit
   and what doiget does about it. §6 promised doiget adopts a stricter vendor guideline
   per source while recording no vendor's limit anywhere, so the promise could not be
@@ -204,15 +224,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Retracted
 
-- **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers. It
-  does not. `resolve_tdm_chain` still short-circuits every entry to `NotNeeded` the moment
-  `crossref_answered` is true, so a configured TDM key still yields byte-identical output
-  for the DOIs the chain exists to serve, and #458 is open. The bullet is struck from
+- **[docs]** The 0.8.9 entry claimed the Tier-3 chain runs even when Crossref answers.
+  **In 0.8.9 it did not.** `resolve_tdm_chain` short-circuited every entry to `NotNeeded`
+  the moment `crossref_answered` was true, so a configured TDM key yielded byte-identical
+  output for exactly the DOIs the chain exists to serve. The bullet is struck from
   `## [0.8.9]` below and the GitHub Release body carries a correction; the `v0.8.9` tag
-  annotation is immutable and still states it. The notes were assembled by grepping
-  `main..next` for `Closes` and `Refs` and reading both as "fixed" — PR #466 wrote
-  `Refs #458` about an adjacent `cfg`-gate fix, deliberately and correctly. The two
-  keywords are not interchangeable when assembling release notes (#472).
+  annotation is immutable and still states it.
+
+  **#458 is fixed in this release** — see the Tier-3 content-leg entry above (ADR-0044).
+  The retraction stands anyway, because it is about what 0.8.9 *shipped*: a reader on
+  0.8.9 was told a feature worked when it did not, and a later fix does not unsay that.
+
+  Cause: the notes were assembled by grepping `main..next` for `Closes` and `Refs` and
+  reading both as "fixed". PR #466 wrote `Refs #458` about an adjacent `cfg`-gate fix,
+  deliberately and correctly. The two keywords are not interchangeable when assembling
+  release notes (#472).
+
+  This entry itself said "#458 is open" in the present tense until the 0.8.10 promotion
+  review caught it contradicting the Fixed section three screens above. A retraction that
+  goes stale is still a false statement.
 
 ## [0.8.9] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[test]** The three diagnostic wiring points would have survived being
+  disconnected. `batch --json`'s one line threading a real outcome's trace into the
+  record, and the MCP envelope's `attempts` and `remediation` insertions, each had
+  every nearby assertion calling the leaf helper directly with hand-built arguments —
+  so reverting any of them left the whole suite green while the trace or the
+  remediation vanished from the wire, which is the regression #459 exists to prevent.
+  `FetchPaperOutcome::for_test_synthetic_with_attempts` makes the first testable at
+  all: the plain constructor hard-codes `attempts: Vec::new()`, so the one test that
+  did drive `classify_joined` could not have observed a trace even if it had looked
+  (#471, #459).
+
 - **[legal]** `docs/LEGAL.md` §2 declares the default binary's whole network surface.
   It said "Crossref, Unpaywall, arXiv"; a default `oa-only` build also registers
   `oa_publisher_allowlist` (~20 publisher/repository patterns), `api.openalex.org`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.14"
+version = "0.8.10-beta.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.14"
+version = "0.8.10-beta.15"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.14"
+version = "0.8.10-beta.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.15"
+version = "0.8.10-beta.16"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.15"
+version = "0.8.10-beta.16"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.15"
+version = "0.8.10-beta.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.12"
+version = "0.8.10-beta.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.13"
+version = "0.8.10-beta.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.15"
+version       = "0.8.10-beta.16"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.15" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.15" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.15" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.16" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.16" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.16" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.12"
+version       = "0.8.10-beta.13"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.12" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.12" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.12" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.13" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.13" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.13" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.14"
+version       = "0.8.10-beta.15"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.14" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.14" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.14" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.15" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.15" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.15" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.13"
+version       = "0.8.10-beta.14"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.13" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.13" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.13" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.14" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.14" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.14" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/batch.rs
+++ b/crates/doiget-cli/src/commands/batch.rs
@@ -972,6 +972,71 @@ mod tests {
         );
     }
 
+    /// #471. The ONE line that threads a real outcome's trace into the
+    /// `--json` record had no test behind it: every assertion about
+    /// `attempts` called `build_jsonl_failure` directly with hand-built
+    /// arguments, and the only test that went through `classify_joined`
+    /// built its outcome with `for_test_synthetic`, which hard-codes
+    /// `attempts: Vec::new()` -- so it could not have observed a trace even
+    /// if it had looked.
+    ///
+    /// Reverting `batch.rs`'s `&outcome.attempts` to `&[]` left the whole
+    /// suite green while silently dropping the trace from `--json`, which is
+    /// the regression #459 exists to prevent.
+    #[test]
+    fn classify_joined_threads_the_real_outcomes_trace_into_the_json_record() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        use doiget_core::ErrorCode as Ec;
+
+        let blocked = PdfLegStatus::Blocked {
+            code: Ec::NetworkError,
+            message: "publisher refused".to_string(),
+            denial: None,
+            suggested_arxiv_id: None,
+        };
+        // A trace with something in it, and something a `&[]` cannot fake.
+        let attempts = vec![
+            SourceAttempt::new("crossref", AttemptOutcome::Resolved),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_HAL"],
+                },
+            ),
+        ];
+
+        let outcome = classify_joined(
+            Ok(TaskOutcome {
+                input: "10.1234/foo".to_string(),
+                result: Ok(FetchPaperOutcome::for_test_synthetic_with_attempts(
+                    "doi__10_1234_foo",
+                    "oa-publisher",
+                    blocked,
+                    attempts,
+                )),
+            }),
+            true,
+        );
+
+        let rec = outcome
+            .json_record
+            .unwrap_or_else(|| panic!("json mode must produce a record"));
+
+        let rows = rec["error"]["attempts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the trace must reach the wire; record: {rec}"));
+        assert_eq!(rows.len(), 2, "record: {rec}");
+        assert_eq!(rows[0]["source"], serde_json::json!("crossref"));
+        assert_eq!(rows[1]["source"], serde_json::json!("hal"));
+        // #470's structured form travels with it -- which is what proves this
+        // is the real outcome's trace rather than a placeholder.
+        assert_eq!(
+            rows[1]["required_env"],
+            serde_json::json!(["DOIGET_ENABLE_HAL"]),
+            "record: {rec}"
+        );
+    }
+
     #[test]
     fn classify_joined_blocked_pdf_emits_failure_with_denial_context() {
         // #210: a `PdfLegStatus::Blocked` outcome is reported as a

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1596,6 +1596,10 @@ async fn fetch_paper_doi(
 #[cfg(feature = "metadata")]
 fn optional_source_oa_url<'a>(source: &str, meta: &'a Value) -> Option<&'a str> {
     match source {
+        // #461: OpenAlex reports every location it knows of, not just a
+        // best one, so it is the source most likely to name a repository
+        // copy for a hybrid-OA article whose publisher refused.
+        "openalex" => crate::sources::openalex::open_access_pdf_url(meta),
         "core" => crate::sources::core_oa::open_access_pdf_url(meta),
         "hal" => crate::sources::hal::open_access_pdf_url(meta),
         "europe-pmc" => crate::sources::europepmc::open_access_pdf_url(meta),
@@ -4266,6 +4270,16 @@ async fn resolve_optional_chain(
         crate::sources::core_oa::CoreSource::new,
         crate::sources::core_oa::CoreSource::with_base,
     );
+    // #461: `OpenalexSource` was compiled in and reachable from `doiget
+    // graph`, but absent from THIS chain -- so the #445 content-leg
+    // fall-through could never ask the one source that reports more than one
+    // location per work. The issue said the accessor was "the only missing
+    // piece"; the wiring was missing too.
+    let openalex_contact = contact_email_from_env();
+    let openalex = match optional_base("DOIGET_OPENALEX_BASE") {
+        Some(base) => crate::sources::openalex::OpenalexSource::with_base(base, openalex_contact),
+        None => crate::sources::openalex::OpenalexSource::new(openalex_contact),
+    };
 
     // The name is carried explicitly rather than read from `src.name()`:
     // that borrows the source, while a `SourceAttempt` holds a `'static`
@@ -4285,6 +4299,7 @@ async fn resolve_optional_chain(
         ("openaire", &["DOIGET_ENABLE_OPENAIRE"], &openaire),
         ("hal", &["DOIGET_ENABLE_HAL"], &hal),
         ("core", &["DOIGET_ENABLE_CORE"], &core),
+        ("openalex", &["DOIGET_ENABLE_OPENALEX"], &openalex),
     ];
 
     let mut resolved: Option<(&'static str, Value)> = None;
@@ -4573,6 +4588,7 @@ mod chain_tests {
                 "DOIGET_OPENAIRE_BASE",
                 "DOIGET_HAL_BASE",
                 "DOIGET_CORE_BASE",
+                "DOIGET_OPENALEX_BASE",
             ];
             Self(
                 VARS.iter()
@@ -4605,6 +4621,12 @@ mod chain_tests {
             ("openaire", host),
             ("hal", host),
             ("core", host),
+            // #461. Production registers this unconditionally via
+            // `discovery_allowlist` (ADR-0031, and there is a test in
+            // `commands/fetch.rs` guarding exactly that), so omitting it
+            // here would fail the source at `UnknownSource` for a reason
+            // production does not have.
+            ("openalex", host),
         ]));
         let session_id = "01J0000000000000000000TEST".to_string();
         let log = Arc::new(
@@ -4644,6 +4666,7 @@ mod chain_tests {
         p.metadata.openaire = true;
         p.metadata.core = true;
         p.metadata.europe_pmc = true;
+        p.metadata.openalex = true;
         p
     }
 
@@ -4653,6 +4676,83 @@ mod chain_tests {
             .find(|a| a.source == name)
             .unwrap_or_else(|| panic!("no attempt recorded for {name}; got {attempts:?}"))
             .outcome
+    }
+
+    /// Every source in the optional chain that can name an OA document URL
+    /// has an `optional_source_oa_url` arm, and each arm reads the field its
+    /// vendor actually uses.
+    ///
+    /// #461 caught this the hard way: adding `"openalex"` to the chain and
+    /// then DELETING its dispatch arm broke nothing -- no test, no clippy
+    /// warning. The chain entry and the arm are two halves of one wiring and
+    /// only the first half was pinned. Same shape as #471.
+    ///
+    /// Table-driven, so a new source is added here or is not covered, and a
+    /// failure names which one.
+    #[test]
+    fn every_oa_url_bearing_source_has_a_dispatch_arm() {
+        // Each case carries the field its vendor actually uses.
+        // Deliberately different per source: a shared shape would let one
+        // arm accidentally serve another and still look green.
+        let cases: &[(&str, serde_json::Value, &str)] = &[
+            (
+                "core",
+                serde_json::json!({ "downloadUrl": "https://core.example/1.pdf" }),
+                "https://core.example/1.pdf",
+            ),
+            (
+                "hal",
+                serde_json::json!({
+                    "openAccess_bool": true,
+                    "fileMain_s": "https://hal.example/2.pdf"
+                }),
+                "https://hal.example/2.pdf",
+            ),
+            (
+                "europe-pmc",
+                serde_json::json!({
+                    "fullTextUrlList": {
+                        "fullTextUrl": [{
+                            "documentStyle": "pdf",
+                            "availabilityCode": "OA",
+                            "url": "https://epmc.example/3.pdf"
+                        }]
+                    }
+                }),
+                "https://epmc.example/3.pdf",
+            ),
+            (
+                "openalex",
+                serde_json::json!({
+                    "locations": [
+                        { "is_oa": true, "pdf_url": "https://repo.example.ac.uk/4.pdf" }
+                    ]
+                }),
+                "https://repo.example.ac.uk/4.pdf",
+            ),
+        ];
+
+        let mut broken: Vec<String> = Vec::new();
+        for (source, meta, expected) in cases {
+            let got = optional_source_oa_url(source, meta);
+            if got != Some(*expected) {
+                broken.push(format!("{source}: expected {expected:?}, got {got:?}"));
+            }
+        }
+        assert!(
+            broken.is_empty(),
+            "these sources are in the optional chain but their document URL never reaches the \
+             content leg -- a missing or wrong `optional_source_oa_url` arm:\n  {}",
+            broken.join("\n  ")
+        );
+
+        // A source with no arm returns None rather than something else's
+        // URL, which is what keeps the dispatch honest as it grows.
+        assert_eq!(
+            optional_source_oa_url("datacite", &serde_json::json!({ "downloadUrl": "x" })),
+            None,
+            "datacite reports no document URL; it must not fall through to another arm"
+        );
     }
 
     /// THE regression for the bug this whole change exists to fix.
@@ -4684,7 +4784,14 @@ mod chain_tests {
         let names: Vec<&str> = attempts.iter().map(|a| a.source).collect();
         assert_eq!(
             names,
-            vec!["datacite", "europe-pmc", "openaire", "hal", "core"],
+            vec![
+                "datacite",
+                "europe-pmc",
+                "openaire",
+                "hal",
+                "core",
+                "openalex"
+            ],
             "the trace must list every source, in chain order"
         );
         for a in &attempts {
@@ -4697,7 +4804,7 @@ mod chain_tests {
         }
         assert_eq!(
             server.received_requests().await.expect("recorded").len(),
-            5,
+            6,
             "each enabled source must issue exactly one request"
         );
     }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -913,6 +913,30 @@ impl FetchPaperOutcome {
             attempts: Vec::new(),
         }
     }
+
+    /// [`Self::for_test_synthetic`] carrying a resolution trace.
+    ///
+    /// #471: the plain constructor hard-codes `attempts: Vec::new()`, so a
+    /// test driving `classify_joined` with a `Blocked` outcome could not
+    /// observe a trace even if it looked -- and none did. Reverting the one
+    /// line that threads `outcome.attempts` into `build_jsonl_failure` left
+    /// the whole suite green, silently dropping the trace from `--json`,
+    /// which is the regression #459 exists to prevent.
+    ///
+    /// `#[doc(hidden)]` for the same reason as its sibling: not a stable
+    /// public API.
+    #[doc(hidden)]
+    pub fn for_test_synthetic_with_attempts(
+        safekey: impl Into<String>,
+        source: impl Into<String>,
+        pdf_leg: PdfLegStatus,
+        attempts: Vec<SourceAttempt>,
+    ) -> Self {
+        Self {
+            attempts,
+            ..Self::for_test_synthetic(safekey, source, pdf_leg)
+        }
+    }
 }
 
 /// Resolve a [`Ref`] to a PDF (or metadata-only fallback) and write it

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -214,6 +214,47 @@ impl Source for OpenalexSource {
 /// hints. Avoids dumping a multi-KB payload into a single log line
 /// when the response is malformed; 200 chars is enough to identify the
 /// shape (HTML 404 page vs. JSON error envelope vs. truncated work).
+/// Extract an open-access PDF URL from an OpenAlex Work record.
+///
+/// #461. OpenAlex carries a `locations[]` array -- every place it knows the
+/// work exists -- where Unpaywall's `best_oa_location` is one. For a
+/// hybrid-OA article whose publisher leg is refused, the copy that satisfies
+/// the fetch is often an institutional repository sitting in that array and
+/// in no curated list.
+///
+/// Returns the first entry with `is_oa == true` and a non-empty `pdf_url`.
+/// `landing_page_url` is deliberately NOT used: it is a page about the paper,
+/// not the paper, and `try_fetch_oa_pdf` would reject the HTML as `NotAPdf`
+/// after having made the request.
+///
+/// Like the CORE / HAL / Europe PMC accessors, this only SURFACES a
+/// candidate. The fetch is still performed by the `oa-publisher` leg, under
+/// that leg's allowlist and its ADR-0023 denial context -- so a repository
+/// host the user has not trusted is refused exactly as it is today, and the
+/// access ceiling in `LEGAL.md` §2a is unchanged: this is still case (a), a
+/// location an enabled source reported.
+///
+/// Known cost: `locations[0]` is usually the same location Unpaywall already
+/// offered and the chain already failed on, so the first candidate is often a
+/// retry of a request that was just refused. The three existing accessors
+/// share the property. Fixing it means telling the accessor which URL already
+/// failed, which none of them can see.
+#[must_use]
+pub fn open_access_pdf_url(record: &serde_json::Value) -> Option<&str> {
+    record
+        .get("locations")
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .find_map(|loc| {
+            if loc.get("is_oa").and_then(serde_json::Value::as_bool) != Some(true) {
+                return None;
+            }
+            loc.get("pdf_url")
+                .and_then(serde_json::Value::as_str)
+                .filter(|u| !u.is_empty())
+        })
+}
+
 fn truncate_for_hint(body: &[u8]) -> String {
     const MAX: usize = 200;
     let s = String::from_utf8_lossy(body);
@@ -392,5 +433,65 @@ mod tests {
             .await
             .expect_err("missing `id` must surface as SourceSchema");
         assert!(matches!(err, FetchError::SourceSchema { .. }));
+    }
+
+    // ---- #461: locations[] as a candidate source of OA copies ----------
+
+    /// The point of the accessor: OpenAlex reports EVERY location, so the
+    /// repository copy that satisfies a refused hybrid-OA article is in the
+    /// array even when it is not the primary one.
+    #[test]
+    fn open_access_pdf_url_finds_a_repository_copy_past_the_primary() {
+        let work = serde_json::json!({
+            "locations": [
+                // The publisher's own landing page: not OA, and no pdf_url.
+                // This is the one that just refused us.
+                { "is_oa": false, "landing_page_url": "https://ieeexplore.example/doc/1" },
+                // An institutional repository, which is the interesting case.
+                { "is_oa": true, "pdf_url": "https://repo.example.ac.uk/1/paper.pdf" }
+            ]
+        });
+        assert_eq!(
+            open_access_pdf_url(&work),
+            Some("https://repo.example.ac.uk/1/paper.pdf")
+        );
+    }
+
+    /// A location that is open but records only a landing page is skipped.
+    /// Returning it would spend a request to be told the HTML is `NotAPdf`.
+    #[test]
+    fn open_access_pdf_url_skips_a_landing_page_only_location() {
+        let work = serde_json::json!({
+            "locations": [
+                { "is_oa": true, "landing_page_url": "https://repo.example.ac.uk/1" },
+                { "is_oa": true, "pdf_url": "https://other.example.ac.uk/2/paper.pdf" }
+            ]
+        });
+        assert_eq!(
+            open_access_pdf_url(&work),
+            Some("https://other.example.ac.uk/2/paper.pdf")
+        );
+    }
+
+    /// `is_oa: false` is not a candidate even with a `pdf_url`. Offering it
+    /// would send doiget at a copy the index itself says is not open.
+    #[test]
+    fn open_access_pdf_url_ignores_a_non_oa_location() {
+        let work = serde_json::json!({
+            "locations": [
+                { "is_oa": false, "pdf_url": "https://paywall.example/1.pdf" }
+            ]
+        });
+        assert_eq!(open_access_pdf_url(&work), None);
+    }
+
+    /// An empty string is not a URL. Absent `locations` is not an error.
+    #[test]
+    fn open_access_pdf_url_rejects_empty_and_absent() {
+        let empty = serde_json::json!({
+            "locations": [{ "is_oa": true, "pdf_url": "" }]
+        });
+        assert_eq!(open_access_pdf_url(&empty), None);
+        assert_eq!(open_access_pdf_url(&serde_json::json!({})), None);
     }
 }

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4582,6 +4582,72 @@ mod tests {
     /// #459: the trace, and the distinction it exists to make. Absent
     /// rather than `[]` when unavailable — #413 was filed because those
     /// two were the same observable.
+    /// #471. `fetch_paper_success_envelope` is the only caller that inserts
+    /// `"attempts"`, and `pdf_leg_json` the only one that inserts
+    /// `"remediation"` -- and neither was called from any test. Every test
+    /// naming those fields called the leaf helpers directly with
+    /// hand-constructed values, so disconnecting either wiring point left
+    /// the suite green while the trace and the remediation vanished from the
+    /// envelope an agent reads.
+    ///
+    /// This drives the ENVELOPE BUILDER, so both insertions are exercised at
+    /// the point where a real outcome meets the wire.
+    #[test]
+    fn the_success_envelope_carries_the_trace_and_the_remediation() {
+        use doiget_core::orchestrator::{AttemptOutcome, FetchPaperOutcome, SourceAttempt};
+        use doiget_core::{DenialContext, DenialReason, ErrorCode};
+
+        let blocked = PdfLegStatus::Blocked {
+            code: ErrorCode::NetworkError,
+            message: "redirect target not in allowlist".to_string(),
+            denial: Some(DenialContext {
+                reason: DenialReason::RedirectNotInAllowlist,
+                source: Some("oa-publisher".to_string()),
+                attempted: Some("cdn.example.org".to_string()),
+                expected: Some(vec!["good.example.org".to_string()]),
+                hop_index: Some(1),
+                cap: None,
+                actual: None,
+            }),
+            suggested_arxiv_id: None,
+        };
+        let outcome = FetchPaperOutcome::for_test_synthetic_with_attempts(
+            "doi__10_1234_foo",
+            "oa-publisher",
+            blocked,
+            vec![
+                SourceAttempt::new("crossref", AttemptOutcome::Resolved),
+                SourceAttempt::new(
+                    "hal",
+                    AttemptOutcome::Disabled {
+                        env: &["DOIGET_ENABLE_HAL"],
+                    },
+                ),
+            ],
+        );
+
+        let env = fetch_paper_success_envelope(&outcome, "doi:10.1234/foo");
+
+        // The trace reached the envelope.
+        let rows = env["attempts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("attempts must be on the envelope; got {env}"));
+        assert_eq!(rows.len(), 2, "{env}");
+        assert_eq!(rows[0]["source"], json!("crossref"));
+        assert_eq!(
+            rows[1]["required_env"],
+            json!(["DOIGET_ENABLE_HAL"]),
+            "the #470 structured form travels with it; got {env}"
+        );
+
+        // And so did the remediation, through `pdf_leg_json`.
+        let rem = env["pdf"]["remediation"]
+            .as_array()
+            .unwrap_or_else(|| panic!("a redirect denial has a config channel; got {env}"));
+        assert!(!rem.is_empty(), "{env}");
+        assert_eq!(env["pdf"]["status"], json!("blocked"), "{env}");
+    }
+
     #[test]
     fn attempts_json_distinguishes_no_trace_from_an_empty_one() {
         use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};

--- a/docs/DECISIONS/0048-access-ceiling.md
+++ b/docs/DECISIONS/0048-access-ceiling.md
@@ -1,0 +1,104 @@
+# 0048 - The access ceiling is written down, and widening it amends the written form
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #497 (the operative invariant is not the believed one), #498 (the 2026-08-25 vendor-terms audit)
+
+## Context
+
+`docs/LEGAL.md` §1 and §2 state what doiget does **not** do: no access-control
+circumvention, no proxying across user boundaries, no redistribution. All still
+true, all still verifiable.
+
+What was missing was the positive statement. Given a ref, *what is doiget
+permitted to try, and where does it stop?*
+
+The rule the project operated under informally was **"never go beyond what
+Unpaywall reports"**. Clean, checkable, and no longer what the code does. It rose
+twice:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is
+  asked for the bytes. For `tdm-aps` that returns a PDF from a location Unpaywall
+  never listed.
+- **#445** — when the OA chain and the arXiv preprint fallback are exhausted, the
+  enabled optional sources are asked whether anyone else holds a copy, and the URL
+  they report is tried. Also not from Unpaywall.
+
+Both are opt-in, both have ADRs, both stay inside publisher-sanctioned APIs and
+inside the redirect allowlist, and both record their outcome in the attempt trace.
+**Neither is improper.** The defect is that the rule everyone believed was being
+enforced was not the rule being enforced, and the gap had never been written down —
+so ADR-0044 was reviewed against a ceiling that existed only as a shared belief.
+
+An unstated invariant cannot be checked. That is how both widenings happened
+without anyone deciding the ceiling had moved.
+
+## Decision
+
+**D1 — `LEGAL.md` gains §2a, stating the ceiling positively.** Two kinds of
+location, and no third:
+
+- **(a) a location an enabled source reported** — the URL appears verbatim in a
+  response from a source the build *and* the runtime profile enabled;
+- **(b) an endpoint built from a vendor's own documented URL scheme** for the
+  identifier the user supplied.
+
+Bounded on every request and every redirect hop by the host allowlist, by
+credential-plus-consent for Tier 3, by prefix scoping for Tier 3, and by the
+attempt trace.
+
+**D2 — Every clause names where it is enforced, and is falsifiable by reading
+that code.** §2a cites `optional_source_oa_url`'s dispatch, the `*_url`
+constructors, the `redirect::Policy::custom` closure, `PUBLISHER_PREFIXES`, and
+`SourceAttempt`. A reader who thinks a clause is false can go and check it in one
+place.
+
+**#497 proposed a candidate wording that this ADR rejects**, and the reason is
+instructive. It suggested doiget "never constructs a content URL that no enabled
+source reported". **That is false.** arXiv's `/pdf/<id>.pdf`, ar5iv's `/html/<id>`
+and every Tier-3 TDM endpoint are constructed from an identifier, not reported by
+anyone. Writing that sentence would have replaced an unstated invariant with a
+stated false one — worse, because it reads as verified.
+
+The issue anticipated this: *"That is a guess at the shape, not a proposal — the
+exact wording should be derived by reading `orchestrator.rs` and the allowlist."*
+It was, and the shape came out different.
+
+The distinction that matters is not *reported vs constructed*. It is **documented
+by the vendor vs guessed by us**. Constructing `/pdf/<id>.pdf` against arXiv's
+published scheme is exactly as sanctioned as following a URL Unpaywall handed
+over; inferring a publisher's URL pattern from observation would not be, and
+§2a's "no third kind" is what forbids it.
+
+**D3 — Widening (a) or (b) amends §2a in the same PR.** Not "should" — the ceiling
+is only useful as something a reviewer can hold a diff against.
+
+## Consequences
+
+**Positive.** The argument for the current posture is written and true. It is no
+longer "we never exceed Unpaywall" — which is false — but "every leg is a
+publisher-sanctioned API or an index the user switched on, at an allowlisted host,
+under the user's own credential where one is required, with the attempt recorded".
+That is defensible, and each conjunct is checkable.
+
+**Negative.** §2a is prose asserting properties of code, and nothing mechanically
+ties the two. A change could widen (b) and leave §2a stale exactly as ADR-0044 did.
+D3 is a review discipline, not a control — the honest classification, and the same
+distinction `LEGAL.md` §6a/§6b draws between enforced and committed. Making it
+enforceable would need something like a lint over the `*_url` constructors; that
+does not exist and this ADR does not pretend it does.
+
+**Negative.** Naming code locations in a NORMATIVE document means a refactor that
+renames `optional_source_oa_url` makes §2a wrong. Accepted deliberately: a clause
+citing nothing is unfalsifiable, which is the failure this ADR exists to fix, and
+ADR-0047 D2 made the same trade for §6a.
+
+## Alternatives rejected
+
+- **Restore the Unpaywall-only ceiling** by reverting ADR-0044 and #445. Both are
+  opt-in, sanctioned and useful; the problem was never the widening, only that it
+  was undeclared.
+- **Adopt #497's proposed wording.** False, as above.
+- **Leave the invariant implicit** and rely on ADR review. That was the default for
+  two releases, and it produced this issue.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -64,6 +64,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0045 | Per-source rate limits, taken as the stricter of the vendor's terms and the global cap | Accepted | `fix/493-per-source-rate-limits` | #493 |
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
+| 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
 
 ## Conventions
 

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -64,6 +64,81 @@ This is enforced structurally rather than only by documentation:
   sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
+## 2a. Access ceiling (binding constraint)
+
+§1 and §2 say what doiget does **not** do. This says what it **may** do, because an
+unstated ceiling cannot be checked — and the next feature that widens the content leg
+would widen it against nothing. Two widenings already shipped without anyone deciding
+the ceiling had moved (see "How this changed", below), which is what #497 is about.
+
+Written to be **falsifiable by reading the code**, not aspirational. Every clause below
+names where it is enforced.
+
+### The ceiling
+
+Given a ref, doiget attempts retrieval from exactly two kinds of location:
+
+**(a) A location an enabled source reported.** The URL appears verbatim in a response
+doiget received from a source that both the build and the runtime capability profile
+have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
+and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+`fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
+behind its own `DOIGET_ENABLE_*` flag.
+*Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
+per-source extractor and returns `None` for any other source name.
+
+**(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
+the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's
+`/html/<id>`; a Tier-3 publisher's documented TDM endpoint for a DOI whose registrant
+prefix says that publisher issued it.
+*Enforced by:* the `*_url` constructors in each source module, each of which is a
+`base.join(<documented path>)` and nothing else.
+
+**There is no third kind.** doiget does not derive a candidate URL from the *content*
+of a document it fetched — no link-following, no scraping, no `href` extraction — and
+does not guess a publisher URL pattern the publisher has not documented.
+
+### What bounds both, on every request and every redirect hop
+
+1. **Host allowlist.** The host must match the per-source allowlist. A redirect to a
+   host off the list fails as `RedirectDenied`; a non-`https` redirect fails as
+   `InsecureRedirect`; hop count is capped. This applies to every hop, not only the
+   first. *Enforced by:* the `reqwest::redirect::Policy::custom` closure in
+   `crates/doiget-core/src/http.rs`; ADR-0027.
+2. **Credential and consent, Tier 3 only.** The Cargo feature must be compiled in, the
+   user must supply their own API key, and the user must separately set
+   `DOIGET_AGREE_TDM_<PUBLISHER>=1`. All three, or the source is unavailable.
+   *Enforced by:* §6a.2, §6a.3, §6a.4.
+3. **Prefix scoping, Tier 3 only.** A publisher's endpoint is asked only about DOIs its
+   own registrant prefix covers, so enabling one TDM source does not disclose an
+   unrelated reading list to that publisher. *Enforced by:* `PUBLISHER_PREFIXES` per
+   source, checked before credentials; ADR-0041, ADR-0044.
+4. **Every attempt is recorded.** Consulted or not, and why. *Enforced by:*
+   `SourceAttempt` / `attempts_to_value`; ADR-0029, ADR-0043.
+
+### How this changed, and why it is still defensible
+
+The rule this project operated under informally was **"never go beyond what Unpaywall
+reports"**. That was clean and checkable, and it is no longer what the code does. The
+ceiling rose twice, both times deliberately, both times with an ADR, and neither time
+was this document updated to say so:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is asked
+  for the bytes. For `tdm-aps` that returns a PDF. Unpaywall never listed that location.
+- **#445 / ADR-0029** — when the OA chain and the arXiv preprint fallback are both
+  exhausted, the enabled optional sources are asked whether anyone else holds a copy,
+  and the URL they report is tried.
+
+Neither is improper. But the argument for them is **not** "we never exceed Unpaywall" —
+that argument is simply false now. The real argument is the one written above: every
+leg is a publisher-sanctioned API or an index the user switched on, reached at a host
+on the allowlist, under the user's own credential where one is required, with the
+attempt recorded.
+
+**A change that widens (a) or (b) amends this section in the same PR.** That is the
+point of writing it down: ADR-0044 could not have been reviewed against a ceiling that
+existed only as a shared belief.
+
 ## 3. Tool-neutrality framing
 
 doiget is positioned as a **general-purpose automation tool** in the sense familiar from

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -28,6 +28,10 @@
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
+it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
+not try before amends that section in the same PR (#497, ADR-0048).
+
 ### 1.1 When Tier 3 is consulted (ADR-0044)
 
 Tier-3 sources are asked two different questions at two different points, and the

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -28,6 +28,22 @@
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+When the content leg is blocked, the enabled optional sources are asked whether anyone
+else holds a copy, and the URL they report is tried (#445). Four can name one:
+
+| source | field | notes |
+|---|---|---|
+| CORE | `downloadUrl` | |
+| HAL | `fileMain_s` | gated on `openAccess_bool` |
+| Europe PMC | `fullTextUrlList` | `documentStyle: pdf` and `availabilityCode` of `F` or `OA` |
+| OpenAlex | `locations[]` | the first entry with `is_oa` and a `pdf_url` (#461) |
+
+OpenAlex is the one that reports **every** location it knows of rather than a single best
+one, which is what makes it the likeliest to name an institutional-repository copy of a
+hybrid-OA article whose publisher refused. That host will not be on any curated list —
+`[network] trust_academic_repos` (ADR-0028) is the existing answer, and the denial help
+names it when it applies.
+
 The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
 it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
 not try before amends that section in the same PR (#497, ADR-0048).

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -34,6 +34,10 @@ weight = 200
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
+it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
+not try before amends that section in the same PR (#497, ADR-0048).
+
 ### 1.1 When Tier 3 is consulted (ADR-0044)
 
 Tier-3 sources are asked two different questions at two different points, and the

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -34,6 +34,22 @@ weight = 200
 | Elsevier ScienceDirect TDM | 3 (institutional) | 5c | API key | <https://www.elsevier.com/about/policies-and-standards/text-and-data-mining> | `--features tdm-elsevier` + key + agree |
 | IEEE Xplore TDM (**unverified**) | 3 (institutional) | 5d | API key | <https://developer.ieee.org/> | `--features tdm-ieee` + key + agree |
 
+When the content leg is blocked, the enabled optional sources are asked whether anyone
+else holds a copy, and the URL they report is tried (#445). Four can name one:
+
+| source | field | notes |
+|---|---|---|
+| CORE | `downloadUrl` | |
+| HAL | `fileMain_s` | gated on `openAccess_bool` |
+| Europe PMC | `fullTextUrlList` | `documentStyle: pdf` and `availabilityCode` of `F` or `OA` |
+| OpenAlex | `locations[]` | the first entry with `is_oa` and a `pdf_url` (#461) |
+
+OpenAlex is the one that reports **every** location it knows of rather than a single best
+one, which is what makes it the likeliest to name an institutional-repository copy of a
+hybrid-OA article whose publisher refused. That host will not be on any curated list —
+`[network] trust_academic_repos` (ADR-0028) is the existing answer, and the denial help
+names it when it applies.
+
 The ceiling on all of this — what doiget may attempt for a given ref, and what bounds
 it — is [`LEGAL.md`](LEGAL.md) §2a. A change that lets doiget try a location it could
 not try before amends that section in the same PR (#497, ADR-0048).

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -70,6 +70,81 @@ This is enforced structurally rather than only by documentation:
   sources whose terms say so, e.g. arXiv at 1 request / 3 s) prevents bulk-scraping
   patterns and cannot be overridden by configuration.
 
+## 2a. Access ceiling (binding constraint)
+
+§1 and §2 say what doiget does **not** do. This says what it **may** do, because an
+unstated ceiling cannot be checked — and the next feature that widens the content leg
+would widen it against nothing. Two widenings already shipped without anyone deciding
+the ceiling had moved (see "How this changed", below), which is what #497 is about.
+
+Written to be **falsifiable by reading the code**, not aspirational. Every clause below
+names where it is enforced.
+
+### The ceiling
+
+Given a ref, doiget attempts retrieval from exactly two kinds of location:
+
+**(a) A location an enabled source reported.** The URL appears verbatim in a response
+doiget received from a source that both the build and the runtime capability profile
+have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
+and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+`fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
+behind its own `DOIGET_ENABLE_*` flag.
+*Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
+per-source extractor and returns `None` for any other source name.
+
+**(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
+the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's
+`/html/<id>`; a Tier-3 publisher's documented TDM endpoint for a DOI whose registrant
+prefix says that publisher issued it.
+*Enforced by:* the `*_url` constructors in each source module, each of which is a
+`base.join(<documented path>)` and nothing else.
+
+**There is no third kind.** doiget does not derive a candidate URL from the *content*
+of a document it fetched — no link-following, no scraping, no `href` extraction — and
+does not guess a publisher URL pattern the publisher has not documented.
+
+### What bounds both, on every request and every redirect hop
+
+1. **Host allowlist.** The host must match the per-source allowlist. A redirect to a
+   host off the list fails as `RedirectDenied`; a non-`https` redirect fails as
+   `InsecureRedirect`; hop count is capped. This applies to every hop, not only the
+   first. *Enforced by:* the `reqwest::redirect::Policy::custom` closure in
+   `crates/doiget-core/src/http.rs`; ADR-0027.
+2. **Credential and consent, Tier 3 only.** The Cargo feature must be compiled in, the
+   user must supply their own API key, and the user must separately set
+   `DOIGET_AGREE_TDM_<PUBLISHER>=1`. All three, or the source is unavailable.
+   *Enforced by:* §6a.2, §6a.3, §6a.4.
+3. **Prefix scoping, Tier 3 only.** A publisher's endpoint is asked only about DOIs its
+   own registrant prefix covers, so enabling one TDM source does not disclose an
+   unrelated reading list to that publisher. *Enforced by:* `PUBLISHER_PREFIXES` per
+   source, checked before credentials; ADR-0041, ADR-0044.
+4. **Every attempt is recorded.** Consulted or not, and why. *Enforced by:*
+   `SourceAttempt` / `attempts_to_value`; ADR-0029, ADR-0043.
+
+### How this changed, and why it is still defensible
+
+The rule this project operated under informally was **"never go beyond what Unpaywall
+reports"**. That was clean and checkable, and it is no longer what the code does. The
+ceiling rose twice, both times deliberately, both times with an ADR, and neither time
+was this document updated to say so:
+
+- **ADR-0044** — when the OA content leg is blocked, an enabled Tier-3 source is asked
+  for the bytes. For `tdm-aps` that returns a PDF. Unpaywall never listed that location.
+- **#445 / ADR-0029** — when the OA chain and the arXiv preprint fallback are both
+  exhausted, the enabled optional sources are asked whether anyone else holds a copy,
+  and the URL they report is tried.
+
+Neither is improper. But the argument for them is **not** "we never exceed Unpaywall" —
+that argument is simply false now. The real argument is the one written above: every
+leg is a publisher-sanctioned API or an index the user switched on, reached at a host
+on the allowlist, under the user's own credential where one is required, with the
+attempt recorded.
+
+**A change that widens (a) or (b) amends this section in the same PR.** That is the
+point of writing it down: ADR-0044 could not have been reviewed against a ceiling that
+existed only as a shared belief.
+
 ## 3. Tool-neutrality framing
 
 doiget is positioned as a **general-purpose automation tool** in the sense familiar from


### PR DESCRIPTION
Review fixes for #519 (`next` → `main` for 0.8.10). Stacked on #518 — merge that first.

## F1 — the retraction had gone stale, which made it false

`### Retracted` was written while #458 was open. It says, in the present tense:

> `resolve_tdm_chain` **still** short-circuits every entry to `NotNeeded` … and **#458 is open**

**#458 is fixed in this same release**, three screens above it. So 0.8.10 would have shipped release notes contradicting themselves — with the *retraction* being the wrong half this time, which is the exact failure mode this release exists to correct.

Rewritten to past tense. The retraction **stands**, because it is about what 0.8.9 *shipped*: a reader on 0.8.9 was told a feature worked when it did not, and a later fix does not unsay that. It now also says #458 was fixed here, and records the lesson: **a retraction that goes stale is still a false statement.**

## F2–F4 — three merged changes had no CHANGELOG line at all

| | |
|---|---|
| **#484** | `tdm-aps` requested a URL APS does not serve, and both wiremock stubs asserted the path the implementation produced |
| **#452** | rmcp 2.2 → **3.1.4**, a semver-**major** of the MCP SDK |
| **#450 / #451 / #453** | the dependency roll-up, including `serial_test` 3 → 4 |

The rmcp one is the worst: a user upgrading got no notice whatsoever that the MCP SDK crossed a major version, which is close to the single thing a changelog exists for. The entry records what was checked — `schemars` unchanged at 1.2.1 so tool input schemas are byte-identical, `ProtocolVersion::V_2024_11_05` pinned explicitly, ADR-0001's stdio-only invariant intact.

Also adds the `tools_list_carries_the_safety_annotations` entry, since that test is the reason the rmcp major is known *not* to have silently dropped the 22 safety annotations from 0.8.6.

## The fourth finding was in the promotion PR itself

#519's body listed #497, #471 and #461 under **Fixed** / **Added** while they sit in open PRs (#514, #515, #518) and are not on `next`. That is the 0.8.9 mistake reproduced inside the PR reviewing it. Corrected in place, with a note at the top of the body saying the lists describe `next` as it is today.

## How these were found

By reading `## [Unreleased]` end to end against `git log origin/main..origin/next` and checking which issue numbers appear in each. `#484`, `#452` and `#450` appear **zero** times in the section; 35 commits landed and three of them left no trace a user would see.

That is worth keeping as a promotion-time step — it is cheap, and it is the check 0.8.9 did not have.

Refs #519, #472, #484, #452, #450, #451, #453, #406
