### PR TITLE
release: cut 0.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.10] - 2026-08-26
+
 ### Added
 
 - **[source]** The #445 content-leg fall-through asks OpenAlex too. OpenAlex reports
@@ -2934,4 +2936,4 @@ harden the wire contracts the previous commits introduced:
   `doiget-mcp/tests/initialize_handshake.rs` (renamed test),
   ERRORS.md §1 + §2 (new variant + semantics row).
 
-[Unreleased]: https://github.com/sotashimozono/doiget/compare/main...HEAD
+[Unreleased]: https://github.com/QAtlasHub/doiget/compare/main...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.16"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.16"
+version = "0.8.10"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.16"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.16"
+version       = "0.8.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.16" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.16" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.16" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
The version strip for #519. `0.8.10-beta.16` → **`0.8.10`**, and `## [Unreleased]` closed as `## [0.8.10] - 2026-08-26`.

## `version-bump` is red on purpose

ADR-0033's cadence for a PR to `next` is `beta.N+1`; a cut carries a clean `X.Y.Z`. Documented exception, same as the 0.8.8 cut (#436) and the 0.8.9 cut (#469). The **required** checks — `test (ubuntu-latest)` and `test (windows-latest)` — are unaffected.

## All eight release gates pass locally

`scripts/release-version-gate.sh v0.8.10`:

```
PASS G0: tag 'v0.8.10' -> version '0.8.10' (lane: stable)
PASS G1: tag version == manifest version (0.8.10)
PASS G2: Cargo.lock in sync (cargo metadata --locked OK)
PASS G5: CHANGELOG.md has a non-empty [0.8.10] section
PASS G6: prerelease consistent (tag/manifest/lane all 'stable')
PASS G3/G4: doiget-core / doiget-cli / doiget-mcp — unpublished and strictly greater
SKIP G7: tag object not present locally (pre-tag dry-run)
```

G5 is the one that matters here — it is the `#164`-class gate, and it refuses the tag unless a curated `## [0.8.10]` section already exists. That is what the `[Unreleased]` rename provides.

## Also in here

The `[Unreleased]` compare link still named `sotashimozono/doiget`, the pre-#398 org. Repointed at `QAtlasHub/doiget` — a pointer fix, which ADR-0046 D3 says does not need an ADR of its own. Noted because it is the only change in this PR that is not the cut.

## After this lands

`#519` (`next` → `main`) becomes mergeable, and the tag follows.

Refs #519, #436, ADR-0025, ADR-0033, ADR-0046
