### PR TITLE
chore: retarget next to 0.8.11-beta.1 after the 0.8.10 promotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10"
+version       = "0.8.11-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
Lane hygiene after the 0.8.10 release. **Version only.**

`next` currently sits on a clean `0.8.10`, equal to `main`. That is neither a beta nor a promotable base, so ADR-0033's `version-bump` gate refuses **every** subsequent PR to `next` until the base moves — the first PR after a promotion must retarget.

`0.8.10` → **`0.8.11-beta.1`**: a valid +1 single-component step over stable, counter reset to `.1`. Patch per the maintainer's call. The other two legal choices were `0.9.0-beta.1` and `1.0.0-beta.1`; nothing queued needs either, and the base can be raised later by a retarget of the same shape if a cycle grows into a feature or breaking release.

Both halves are bumped — `[workspace.package].version` and the three `[workspace.dependencies]` pins. The gate reads only the first, which is how they drifted to `beta.11` vs `beta.6` once before.

```
version-bump gate PASSED (0.8.11-beta.1 → base 'next')
```

## State after the 0.8.10 release

- `v0.8.10` tagged and signed; release pipeline 10/10; crates.io ×3, GitHub Release (16 assets), MCP registry all on `0.8.10`.
- Back-merge landed in #523 — by hand, for the **fourth consecutive release**, because `backmerge.yml` still fails on the PAT-lifetime policy (#426).
- `next..main` is 0.

`version-check` stays red on this branch and that is correct: it asks "would tagging the current version release?", and `0.8.11-beta.1` has no `## [0.8.11-beta.1]` CHANGELOG section. G5 only needs one at tag time.

Refs #519, #426, ADR-0033
