### PR TITLE
fix(transport): gate the Tier-2 allowlist on `metadata`, not `citation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.1"
+version       = "0.8.11-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -23,7 +23,11 @@ workspace = true
 default  = ["oa-only"]
 oa-only  = ["doiget-core/oa-only"]
 metadata = ["doiget-core/metadata"]
-citation = ["doiget-core/citation"]
+# Mirrors `doiget-core`'s own `citation = ["metadata"]`. Without the
+# CLI-level implication `cfg(feature = "metadata")` is FALSE in a
+# `--features citation` build, so anything gated on `metadata` here
+# silently drops out of the richer build (#516).
+citation = ["metadata", "doiget-core/citation"]
 # The `doiget-mcp/*` half matters: `doiget serve` builds its client
 # through the MCP twin of `build_http_client`, so a CLI-only feature
 # would leave the MCP surface without the Tier-3 transport gate (#454).

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -46,7 +46,7 @@ use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 
 use super::output::print_err;
-#[cfg(feature = "citation")]
+#[cfg(feature = "metadata")]
 use doiget_core::http::tier_2_allowlist;
 use doiget_core::http::{
     discovery_allowlist, fulltext_allowlist, oa_publisher_allowlist, tier_1_allowlist,
@@ -258,13 +258,18 @@ pub(crate) fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> 
         // `"ar5iv"` source key unconditionally so `paper_text::paper_text`
         // can reach ar5iv in `oa-only` builds.
         allowlists.extend(fulltext_allowlist());
-        // Slice 16: when the `citation` feature is compiled in, the
-        // graph subcommand walks OpenAlex Work IDs via
-        // `ctx.http.fetch_bytes("openalex", ...)`. The Tier 2
-        // allowlist registers the `api.openalex.org` host under
-        // that source key. CapabilityProfile.metadata.openalex is
-        // the runtime gate; the allowlist is the transport gate.
-        #[cfg(feature = "citation")]
+        // The Tier-2 transport gate. The sources it serves — OpenAlex,
+        // Semantic Scholar, DOAJ, DataCite, HAL, OpenAIRE, CORE and
+        // Europe PMC — are compiled under `metadata`, and
+        // `resolve_optional_chain` is `#[cfg(feature = "metadata")]`,
+        // so this extend MUST be gated on `metadata` too. It was gated
+        // on `citation` for six releases: in a `--features metadata`
+        // build (which CI's clippy matrix builds explicitly) the chain
+        // ran, `can_serve` passed, and the request died at
+        // `UnknownSource` because no allowlist entry existed for the
+        // key (#516). CapabilityProfile.metadata.* is the runtime gate;
+        // this is the transport gate, and the two must agree.
+        #[cfg(feature = "metadata")]
         allowlists.extend(tier_2_allowlist());
         // #454: the Tier-3 transport gate. #444 made the orchestrator
         // reach these sources; without this line the fetch it then issues
@@ -1383,6 +1388,62 @@ mod tests {
         }
     }
 
+    /// #516: the Tier-2 half of the same guard, and the reason it is
+    /// needed is that the Tier-3 lesson was not applied one tier up.
+    ///
+    /// `every_tier_2_source_has_a_transport_allowlist_entry` (in
+    /// `http.rs`) asserts that `tier_2_allowlist()` *contains* every
+    /// source key. That stayed true while the extend into the production
+    /// client was gated on `citation` rather than `metadata`, so in a
+    /// `--features metadata` build — which CI's clippy matrix builds
+    /// explicitly — `resolve_optional_chain` ran, `can_serve` passed,
+    /// and the request died at `UnknownSource`.
+    ///
+    /// This asserts the object the fetch goes through, and it enumerates
+    /// from `tier_2_allowlist()` rather than a literal so a new source
+    /// cannot be added to the list and missed here.
+    #[test]
+    #[serial]
+    #[cfg(feature = "metadata")]
+    fn the_production_client_registers_every_tier_2_source_key() {
+        // Every base override must be clear or `build_http_client` takes
+        // the test-mode branch, which registers whatever it is given and
+        // would prove nothing.
+        let _g: Vec<EnvGuard> = [
+            "DOIGET_ARXIV_BASE",
+            "DOIGET_CROSSREF_BASE",
+            "DOIGET_UNPAYWALL_BASE",
+            "DOIGET_OA_PUBLISHER_BASE",
+            "DOIGET_OPENALEX_BASE",
+            "DOIGET_AR5IV_BASE",
+        ]
+        .iter()
+        .map(|k| {
+            let g = EnvGuard::save(k);
+            std::env::remove_var(k);
+            g
+        })
+        .collect();
+
+        let client = build_http_client(None).expect("production client builds");
+
+        // Fully qualified on purpose: the `use` at the top of this file is
+        // itself `#[cfg(feature = "metadata")]`, so importing it here would
+        // turn a regression into a compile error in this file rather than the
+        // assertion failure that names the actual defect.
+        let keys: Vec<String> = doiget_core::http::tier_2_allowlist()
+            .iter()
+            .map(|a| a.source.clone())
+            .collect();
+        assert!(!keys.is_empty(), "the guard must have checked something");
+        for key in keys {
+            assert!(
+                client.source_allowlist(&key).is_some(),
+                "the production client has no allowlist for `{key}`; \n                 `resolve_optional_chain` reaches this source in a \n                 `metadata` build and the fetch would die at \n                 UnknownSource (#516)"
+            );
+        }
+    }
+
     #[test]
     fn new_session_id_is_26_chars() {
         // ULID textual form is fixed-width 26 chars (Crockford base32).
@@ -1582,9 +1643,10 @@ host = "*.uj.edu.pl"
     /// ADR-0031 D2: discovery search (`doiget search`) ships in the default
     /// `oa-only` binary, so `api.openalex.org` MUST be on the production
     /// allowlist under the `"openalex"` source key WITHOUT `--features
-    /// citation`. The Tier-2 `tier_2_allowlist()` extend is
-    /// `#[cfg(feature = "citation")]`; this test proves
-    /// `discovery_allowlist()` covers that gap in the shipped build.
+    /// metadata`. The Tier-2 `tier_2_allowlist()` extend is
+    /// `#[cfg(feature = "metadata")]` (#516 moved it off `citation`);
+    /// this test proves `discovery_allowlist()` covers that gap in the
+    /// shipped `oa-only` build, where neither feature is compiled.
     #[test]
     #[serial]
     fn build_http_client_registers_openalex_for_discovery() {

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -61,7 +61,7 @@ use crate::source::{FetchContext, FetchError};
 /// Shares the `"openalex"` key with `crate::sources::openalex` so that
 /// `crate::http::discovery_allowlist` (always compiled) and
 /// `tier_2_allowlist` (always compiled, but only *called* by the CLI
-/// under `#[cfg(feature = "citation")]`) register the same
+/// under `#[cfg(feature = "metadata")]` — #516) register the same
 /// `api.openalex.org` host under one key (an idempotent overwrite — see
 /// ADR-0031 D2).
 const SOURCE_KEY: &str = "openalex";

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -275,13 +275,15 @@ pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
 /// Tier-1 `discovery::paper_search` (`GET /works?search=`) can reach the
 /// endpoint in the **default `oa-only` binary** — unlike
 /// [`tier_2_allowlist`], which the CLI only wires in under
-/// `#[cfg(feature = "citation")]`.
+/// `#[cfg(feature = "metadata")]` (#516; it was `citation` until then,
+/// which left every other Tier-2 source `UnknownSource` in a
+/// `metadata`-only build).
 ///
 /// Discovery search is classified as Tier 1 OA metadata (read-only, never
 /// paywalled, never a PDF — same risk class as Crossref/Unpaywall), so its
 /// transport allowlist must exist regardless of the `metadata`/`citation`
 /// features (ADR-0031 D1/D2). The CLI's `build_http_client` extends the
-/// production allowlist with this **unconditionally**; in `citation`
+/// production allowlist with this **unconditionally**; in `metadata`
 /// builds [`tier_2_allowlist`] re-registers the identical
 /// `"openalex" → api.openalex.org` entry, which is a harmless idempotent
 /// `HashMap` overwrite in [`HttpClient::new`].

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4735,6 +4735,45 @@ mod tests {
         }
     }
 
+    /// #516: the MCP half of the Tier-2 transport gate.
+    ///
+    /// The CLI builder had this extend behind `#[cfg(feature =
+    /// "citation")]` while the sources it serves are gated on
+    /// `metadata`, so a `metadata`-only build reached them and died at
+    /// `UnknownSource`. `build_http_client_for_fetch` registers
+    /// `tier_2_allowlist()` unconditionally and is therefore correct
+    /// today — this pins that, because "correct today in one of two
+    /// hand-maintained twins" is exactly the state #454 was filed from.
+    #[test]
+    #[serial_test::serial]
+    fn the_production_client_registers_every_tier_2_source_key() {
+        // Any base override takes the test-mode branch, which registers
+        // whatever it is handed and would prove nothing.
+        let _guards = [
+            EnvGuard::unset("DOIGET_ARXIV_BASE"),
+            EnvGuard::unset("DOIGET_ARXIV_SRC_BASE"),
+            EnvGuard::unset("DOIGET_CROSSREF_BASE"),
+            EnvGuard::unset("DOIGET_UNPAYWALL_BASE"),
+            EnvGuard::unset("DOIGET_OA_PUBLISHER_BASE"),
+            EnvGuard::unset("DOIGET_OPENALEX_BASE"),
+            EnvGuard::unset("DOIGET_AR5IV_BASE"),
+        ];
+
+        let client = build_http_client_for_fetch().expect("production client builds");
+
+        let keys: Vec<String> = tier_2_allowlist()
+            .iter()
+            .map(|a| a.source.clone())
+            .collect();
+        assert!(!keys.is_empty(), "the guard must have checked something");
+        for key in keys {
+            assert!(
+                client.source_allowlist(&key).is_some(),
+                "the production MCP client has no allowlist for `{key}`; the \n                 optional chain reaches this source and the fetch would \n                 die at UnknownSource (#516)"
+            );
+        }
+    }
+
     /// Set XDG_CONFIG_HOME / APPDATA / HOME / USERPROFILE so
     /// `config_dir_utf8()` resolves to the supplied directory on
     /// every supported test host. Returns guards that restore prior


### PR DESCRIPTION
Closes #516.

## The defect

`build_http_client` (`crates/doiget-cli/src/commands/fetch.rs`) extended the production allowlist with `tier_2_allowlist()` under `#[cfg(feature = "citation")]`. Every source it serves — OpenAlex, Semantic Scholar, DOAJ, DataCite, HAL, OpenAIRE, CORE, Europe PMC — is compiled under `metadata`, and so is `resolve_optional_chain`.

So in a `--features metadata` build the chain ran, `can_serve` passed, a request went out under the source key, and `HttpClient` rejected it as `UnknownSource` because no allowlist entry for that key had ever been registered. That is a supported configuration: `doiget-cli` exposes `metadata` as its own feature and CI's clippy matrix builds `oa-only,metadata,tdm-*` explicitly.

OpenAlex escaped because `discovery_allowlist()` registers it unconditionally for `doiget search` (ADR-0031 D2) — a route around the wrong gate, not a correction of it. The other five had no route.

## Why moving the cfg alone is not the fix

`doiget-cli`'s features were:

```toml
metadata = ["doiget-core/metadata"]
citation = ["doiget-core/citation"]
```

`doiget-core`'s `citation` implies `doiget-core/metadata`, but nothing implied **`doiget-cli`'s own** `metadata`. So `cfg(feature = "metadata")` is FALSE inside `doiget-cli` in a `--features citation` build, and moving the gate on its own would have dropped Tier 2 out of the *richer* build.

This PR makes `citation = ["metadata", "doiget-core/citation"]`, mirroring core. That also fixes `capabilities`, whose `compile_time_features()` omitted `metadata` from a citation build for the same reason.

## MCP

`doiget-mcp`'s `build_http_client_for_fetch` already registered Tier 2 unconditionally, so it needed no change. #454's lesson says not to leave that as "correct today in one of two hand-maintained twins", so the guard lands there too.

## Guards

`the_production_client_registers_every_tier_2_source_key`, in both `doiget-cli` and `doiget-mcp`. It asserts the **client** a fetch goes through, not the list — the list-level guard `every_tier_2_source_has_a_transport_allowlist_entry` stayed green through all of this, which is the #454 failure one tier up.

- Keys are enumerated from `tier_2_allowlist()`, so a source added to the list cannot be missed here.
- The call is fully qualified, so a regression fails the assertion with a message naming the defect rather than failing to compile the test file.

## Verified locally

`stable-x86_64-pc-windows-gnu`:

- `cargo check -p doiget-cli --features oa-only,metadata --all-targets` — ok
- `cargo check -p doiget-cli --features oa-only,citation --all-targets` — ok
- `cargo check -p doiget-mcp --all-targets` — ok
- both new guards pass; `build_http_client_registers_openalex_for_discovery` still passes
- `doiget-cli --features oa-only --lib`: 122 passed, 0 failed
- `cargo fmt --all --check` clean

## Note on the version-bump gate

Set to `0.8.11-beta.2`. The gate requires exactly `origin/next`'s `beta.N + 1`, so only one open PR can be green at a time; whichever of the current batch lands second onward needs a one-line re-bump.

Refs #454, #442, #413, ADR-0031

🤖 Generated with [Claude Code](https://claude.com/claude-code)