### PR TITLE
chore: remove the .cargo/config.local.toml channel, document the ones that work

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,12 @@
 # Reproducible-build settings. See docs/SECURITY.md §1.9.
-# Per-developer overrides may go in .cargo/config.local.toml (gitignored).
-
-[build]
-# Default to the host triple. CI overrides per matrix entry.
+#
+# Per-developer overrides do NOT go in a sibling file here. Cargo reads only
+# `config.toml` from a `.cargo` directory, and the `include = [...]` that
+# would make a sibling real is a HARD ERROR before any cargo command runs
+# when the included file is absent — which it is in every fresh clone and on
+# every CI runner, because such a file would be gitignored. See
+# CONTRIBUTING.md "Per-developer settings" for the two mechanisms that work
+# ($CARGO_HOME/config.toml and CARGO_TARGET_DIR).
 
 [net]
 git-fetch-with-cli = false

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ lcov.info
 *.crt
 
 # Local config (per-developer)
-.cargo/config.local.toml
+# NOT .cargo/config.local.toml — cargo never reads it, and reserving the name
+# is what made three people believe it worked. See CONTRIBUTING.md.
 .envrc
 .env
 .env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,42 @@ subcommand list, and any `doiget <subcommand>` returns a `Phase 0 stub` error.
 `cargo test` runs the four smoke tests in
 `crates/doiget-core/src/lib.rs::tests`.
 
+### Per-developer settings
+
+**Do not put them in the repository.** `.cargo/config.toml` is tracked and pins
+the reproducibility settings ([`docs/SECURITY.md`](docs/SECURITY.md) §1.9); it is
+not a place for your machine's preferences. There is no
+`.cargo/config.local.toml` — cargo reads only `config.toml` from a `.cargo`
+directory, and the `include = [...]` that would make a sibling file real is a
+hard error before any cargo command runs when the file is missing, which it
+would be in every fresh clone and on every CI runner (#521).
+
+Two mechanisms work and need no change to this repository:
+
+**`$CARGO_HOME/config.toml`** (`~/.cargo/config.toml`) — cargo merges it into
+the config hierarchy automatically for every project. Per cargo's documented
+precedence it sits *below* the repository's `.cargo/config.toml`, so the pinned
+`[net]` / `[term]` / reproducibility values still win where the two overlap.
+That is the right way round: your defaults apply to everything the repo does
+not deliberately fix.
+
+**`CARGO_TARGET_DIR`** (or `--target-dir`) for build output. Worth being
+deliberate about:
+
+```sh
+# per-checkout, and it goes away with the checkout
+cargo build                       # -> ./target
+
+# shared across checkouts — pick a path you will actually look at
+export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/doiget"
+```
+
+A shared target directory grows without bound and nothing prunes it. On
+2026-08-26 two of them — set ad hoc to fixed paths under `%TEMP%` — held
+**115 GB and 81 GB** on one machine and took it to 95% full; deleting them
+recovered 195 GB. If you share one, put it somewhere you will notice, and
+`cargo clean --target-dir <path>` occasionally.
+
 ## Before you open a PR
 
 1. Read [docs/SCOPE.md](docs/SCOPE.md) for the **Permanent non-goals** list. PRs that move

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.1"
+version       = "0.8.11-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
Closes #521.

## What was there

`.cargo/config.toml:2` — "Per-developer overrides may go in `.cargo/config.local.toml` (gitignored)." — plus `.gitignore:41` reserving the name. The comment names the file, the gitignore reserves it, a developer creates it, sees no error, and reasonably believes it applied. Cargo reads only `config.toml` from a `.cargo` directory.

## Why the one-line fix is not available

Adding `include = ["config.local.toml"]` makes a **missing** include a hard error (`exit 101`, before any cargo command runs). The file is gitignored, so it is absent in every fresh clone and on every CI runner. As specified, the mechanism is not unimplemented — it is unimplementable in that shape.

## What replaces it

`CONTRIBUTING.md` gains **Per-developer settings**, naming the two mechanisms that work today and need no repository change:

- **`$CARGO_HOME/config.toml`** — cargo merges it for every project. Per cargo's documented precedence it sits *below* the repository's `.cargo/config.toml`, so the pinned `[net]` / `[term]` / reproducibility values still win where they overlap. That is the right way round, and it is also why "override" was the wrong word for the included-file design.
- **`CARGO_TARGET_DIR`** for the build-output case.

The gitignore entry goes too, replaced by a comment saying why the name is absent — a reserved filename with no reader is what re-creates this for the next person who notices it.

## The disk number is in the doc on purpose

`target-dir` is exactly the setting the original comment was trying to route somewhere. With the sanctioned channel inert, it went into an ad-hoc environment variable instead, where nothing discovered it and nothing bounded it: on 2026-08-26 two such directories under `%TEMP%` held **115 GB and 81 GB** on one machine and took it to 95% full; removing them recovered 195 GB.

"Put it somewhere you will notice" is not advice anyone acts on without the number.

## Also

Drops the `[build]` table — a header with a comment and no keys.

## Verified locally

- `cargo metadata` — exit 0 with the rewritten `.cargo/config.toml`
- `cargo check -p doiget-core --features oa-only` — Finished
- no remaining reference to `config.local.toml` anywhere except the two comments that explain its absence

Refs #493, #247, #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)