### PR TITLE
docs(integration): fill the six host guides, and say which are exercised

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.1"
+version       = "0.8.11-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/INTEGRATION/README.md
+++ b/docs/INTEGRATION/README.md
@@ -1,42 +1,58 @@
 # Integration guides
 
-> **Status: INFORMATIVE (placeholder).** Concrete host-integration snippets land
-> in **Phase 3** alongside the MCP server (`doiget serve`). Until then, this
-> directory is a pointer rather than a recipe collection.
+> **Status: INFORMATIVE.** `doiget serve` ships; these are the host-side
+> snippets. Each page states whether it has been exercised against that
+> host, and the ones that have not say so.
 
-## Why this is empty today
+`doiget serve` is a stdio MCP server. It is the same entry point everywhere —
+`mcpb/manifest.json` runs `doiget serve`, and so does the MCP Registry entry.
+The differences between hosts are only where the config file lives and what it
+is called.
 
-Phase 0 ships specifications (see [`../MCP_TOOLS.md`](../MCP_TOOLS.md) and
-[`../PUBLIC_API.md`](../PUBLIC_API.md)) but no functional MCP server. Without a
-runnable `doiget serve`, integration snippets would either be untested aspirational
-config or would lead a reader to a Phase 0 stub error. Phase 3 ships the actual
-server and the corresponding host snippets in this directory.
-
-## Planned files (Phase 3)
-
-| File | Host | Status |
+| File | Host | Exercised? |
 |---|---|---|
-| `claude-desktop.md` | Claude Desktop (stdio MCP) | Phase 3 (stub) |
-| `cursor.md` | Cursor | Phase 3 (stub) |
-| `codex.md` | OpenAI Codex CLI | Phase 3 (stub) |
-| `claude-code.md` | Claude Code (this tool) | Phase 3 (stub) |
-| `obsidian.md` | Obsidian backend export | Phase 7 (optional, stub) |
-| `chain-with-paperqa.md` | Composition with paper-qa for content processing | Phase 3+ (stub) |
+| [`claude-code.md`](./claude-code.md) | Claude Code | **Yes** — this is what the project is developed under |
+| [`claude-desktop.md`](./claude-desktop.md) | Claude Desktop (`.mcpb`, or manual stdio) | **Yes**, for the `.mcpb` route (shipping since 0.8.4) |
+| [`cursor.md`](./cursor.md) | Cursor | No |
+| [`codex.md`](./codex.md) | OpenAI Codex CLI | No |
+| [`obsidian.md`](./obsidian.md) | Obsidian | Not applicable — Obsidian hosts no MCP server; the page says what does work |
+| [`chain-with-paperqa.md`](./chain-with-paperqa.md) | Composition with paper-qa | No, as a chain |
 
-## What to read in the meantime
+## The one setting to get right
 
-- **MCP tool spec:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tool surface
-  Phase 3 will expose. Sufficient to plan a host integration in advance.
-- **Public Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders that
-  link `doiget-core` directly rather than going through the MCP server.
-- **Architecture overview:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — for
-  how tools, transport, and the capability gate fit together.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and the
-  `~/.config/doiget/` layout that any host-side wiring will need to respect.
+`DOIGET_STORE_ROOT`, as an absolute path.
+
+The store root defaults to `./papers` **relative to the process's working
+directory** (ADR-0036). For a CLI run that is exactly right — artifacts land
+where you are working. For an MCP server it is not: the working directory
+belongs to the host, so the store lands somewhere you did not choose and a
+later CLI run does not see it. That is
+[#369](https://github.com/QAtlasHub/doiget/issues/369).
+
+`DOIGET_CONTACT_EMAIL` is the second one. Without it every request goes out as
+`doiget@localhost` on the non-polite pool, where a throttled answer is
+indistinguishable from "this paper has no OA copy"
+([#504](https://github.com/QAtlasHub/doiget/issues/504)).
+
+Everything else is off by default and documented in
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Also worth reading
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — every tool with its
+  JSON Schema. `doiget_capability_profile` reports the same thing at runtime
+  for the build you actually have.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — precedence and the
+  `config.toml` schema.
+- **Errors:** [`../ERRORS.md`](../ERRORS.md) — the closed set of error codes
+  and what an agent should do with each.
+- **Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders linking
+  `doiget-core` directly instead of going through MCP.
 
 ## Contributing a snippet
 
-If you have a working integration with an MCP host that is not in the planned list,
-open a GitHub Discussion describing the host, the JSON-RPC trace, and any
-host-specific config quirks. PRs adding a new file under `docs/INTEGRATION/` will
-be accepted in Phase 3+ once `doiget serve` is real and the snippet is verifiable.
+A working configuration for a host not listed here is welcome. Open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+host, the config file and its path, and anything host-specific that bit you —
+or a PR adding a page in the shape of the others, including an honest
+"exercised?" line.

--- a/docs/INTEGRATION/chain-with-paperqa.md
+++ b/docs/INTEGRATION/chain-with-paperqa.md
@@ -1,43 +1,55 @@
 # Chaining with paper-qa
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table this composition guide is scoped to
-> **Phase 3+** — `doiget serve` ships first, then a verified chain recipe.
+> **Status: UNTESTED as a chain.** Both halves are real — doiget writes PDFs to
+> a directory, paper-qa reads a directory of PDFs — but nobody has run the
+> composition end to end and reported back. Treat the shape below as the
+> intended design, not a verified recipe. Last checked 2026-08-26.
 
-[paper-qa](https://github.com/Future-House/paper-qa) is a retrieval-augmented
-question-answering system over scientific papers. The chain pattern this
-guide will document keeps `doiget`'s role narrow — DOI resolution, metadata,
-and content fetch via the tools in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — and
-hands the resulting documents to paper-qa for embedding, retrieval, and
-answer synthesis. Composition keeps each tool single-purpose and avoids
-duplicating retrieval logic inside `doiget`.
+[paper-qa](https://github.com/Future-House/paper-qa) does retrieval-augmented
+question answering over scientific papers. It handles embedding, retrieval and
+answer synthesis; doiget handles getting the papers, legally and with a
+provenance trail. Neither needs to know about the other, because the interface
+is a directory.
 
-## Configuration (Phase 3)
+## The shape
 
-The example below is intentionally empty. The chain shape depends on the
-final Phase 3 tool surface and on paper-qa's MCP/CLI ingestion entry point.
+```sh
+export DOIGET_STORE_ROOT="$HOME/papers"
+export DOIGET_CONTACT_EMAIL="you@institution.edu"
 
-```toml
-<!-- TODO Phase 3: paste verified doiget + paper-qa chain config here. -->
+# 1. Resolve and fetch a bibliography's references (OA only).
+doiget batch refs.bib
+
+# 2. Point paper-qa at the store.
+pqa -i "$HOME/papers" ask "what do these papers say about X?"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+`doiget batch` reports per-reference outcomes; the ones it could not fetch are
+named rather than dropped, so the corpus paper-qa sees is one you can account
+for.
 
-## What to read in the meantime
+## Why compose rather than integrate
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+doiget's job stops at "the bytes are on disk, and here is where they came
+from". Embedding and retrieval are a different problem with different
+dependencies, and duplicating either inside doiget would widen its network
+surface and its supply chain for no gain — see [`../SCOPE.md`](../SCOPE.md).
+
+The same argument means doiget will not ship a paper-qa plugin. The directory
+is the integration.
+
+## What doiget gives you that a scraper does not
+
+- **Provenance.** Every fetch is a hash-chained row in the append-only log
+  ([`../PROVENANCE_LOG.md`](../PROVENANCE_LOG.md)), so the corpus behind an
+  answer is auditable.
+- **Licence, per entry.** The sidecar records it, which matters as soon as an
+  answer is quoted.
+- **A refusal you can read.** A blocked paper produces a named reason and a
+  remediation, not a silent gap in the corpus.
 
 ## Contributing
 
-If you have a working `doiget` + paper-qa chain ahead of Phase 3, open a
-GitHub Discussion with the orchestration script and any host-specific quirks
-rather than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you run this, the useful thing to report is the orchestration script and
+any paper-qa-side quirks — open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions).

--- a/docs/INTEGRATION/claude-code.md
+++ b/docs/INTEGRATION/claude-code.md
@@ -1,40 +1,99 @@
 # Claude Code integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED.** The `claude mcp add` form below is the configuration
+> this project is developed under. Last checked 2026-08-26 against
+> `doiget 0.8.10`.
 
-[Claude Code](https://www.anthropic.com/claude-code) is Anthropic's official
-CLI and supports MCP servers. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as an MCP server in Claude Code (via
-`claude mcp add` or a project-scoped `.mcp.json`) so that the tool surface
-listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) is callable from Claude Code
-sessions.
+[Claude Code](https://www.anthropic.com/claude-code) hosts MCP servers over
+stdio. `doiget serve` is the entry point — the same one
+[`mcpb/manifest.json`](../../mcpb/manifest.json) and the
+[MCP Registry](https://registry.modelcontextprotocol.io/) use.
 
-## Configuration (Phase 3)
+Install `doiget` first (see [`../../README.md`](../../README.md) §Installation);
+it must be on `PATH`, or give an absolute path below.
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+## One line
+
+```sh
+claude mcp add doiget -- doiget serve
+```
+
+With the environment set at the same time, and available in every project
+rather than only this one:
+
+```sh
+claude mcp add doiget --scope user \
+  -e DOIGET_STORE_ROOT="$HOME/papers" \
+  -e DOIGET_CONTACT_EMAIL="you@institution.edu" \
+  -- doiget serve
+```
+
+`--scope` is `local` (this project, private) by default; `user` is every
+project, `project` writes the committed `.mcp.json` below. `claude mcp add
+--help` lists the rest.
+
+## Project-scoped `.mcp.json`
+
+Committed at the repository root, this shares the server with everyone who
+opens the project:
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Code .mcp.json entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "type": "stdio",
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "${HOME}/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+On Windows, `command` is the full path if `doiget` is not on `PATH`, e.g.
+`"C:/Users/<you>/AppData/Local/Programs/doiget/doiget"`.
+
+## Environment
+
+`DOIGET_STORE_ROOT` is the one to set. Without it the store root defaults to
+`./papers` **relative to the process's working directory** (ADR-0036), which
+for an MCP server is the host's, not yours — #369 is that mistake. Set it to
+an absolute path and the store is the same one `doiget` on the command line
+uses.
+
+| Variable | Why |
+|---|---|
+| `DOIGET_STORE_ROOT` | Absolute path to the paper store. Set this. |
+| `DOIGET_CONTACT_EMAIL` | Polite-pool contact for Crossref / Unpaywall. Without it requests go out as `doiget@localhost` from the non-polite pool, where a throttled answer is indistinguishable from "no OA copy" (#504). |
+| `DOIGET_UNPAYWALL_EMAIL` | Only if it differs from the contact address. |
+| `DOIGET_ENABLE_OPENALEX`, `DOIGET_ENABLE_EUROPE_PMC`, `DOIGET_ENABLE_CORE`, `DOIGET_ENABLE_OPENAIRE`, `DOIGET_ENABLE_HAL`, `DOIGET_ENABLE_DATACITE`, `DOIGET_ENABLE_S2`, `DOIGET_ENABLE_DOAJ` | Widen the search past the three always-on sources. **All off by default** (ADR-0040) — with none of them set, `no OA PDF available` means only that Crossref, Unpaywall and arXiv had nothing. |
+| `DOIGET_CORE_API_KEY` | Optional free CORE key; raises that source's rate limit. |
+
+Full precedence and the complete list: [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+**A build caveat, once.** Those `DOIGET_ENABLE_*` flags need the `metadata`
+feature compiled in. The official release binaries and the `.mcpb` are built
+`--features oa-only,citation` (which implies `metadata`), so they work there.
+A binary you built yourself with the default `oa-only` will log a warning and
+leave the source unavailable — `doiget_capability_profile` reports the truth
+for the binary you actually have.
+
+## Checking it worked
+
+```
+/mcp
 ```
 
-## What to read in the meantime
+should list `doiget`. Then ask the model to call `doiget_health` — it reports
+the version, whether the store is writable, and where the store actually is,
+which is the fastest way to catch a wrong `DOIGET_STORE_ROOT`.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Tool surface
 
-## Contributing
-
-If you have a working Claude Code integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+22 tools, enumerated with their JSON Schemas in
+[`../MCP_TOOLS.md`](../MCP_TOOLS.md). `doiget_capability_profile` reports which
+sources this particular build and environment may use.

--- a/docs/INTEGRATION/claude-desktop.md
+++ b/docs/INTEGRATION/claude-desktop.md
@@ -1,39 +1,75 @@
 # Claude Desktop integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED for the `.mcpb` route** (shipping since 0.8.4; attached to
+> every GitHub Release). The manual JSON route below is the same stdio
+> invocation and is included for people who would rather not install an
+> extension. Last checked 2026-08-26.
 
-[Claude Desktop](https://claude.ai/download) is Anthropic's desktop client and
-hosts MCP servers over stdio. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as a tool provider in Claude Desktop's
-MCP configuration so that `resolve_doi`, `fetch_metadata`, and the rest of the
-tool surface in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are callable from a chat.
+[Claude Desktop](https://claude.ai/download) hosts MCP servers over stdio.
 
-## Configuration (Phase 3)
+## Recommended: install the `.mcpb` extension
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+Each [GitHub Release](https://github.com/QAtlasHub/doiget/releases) attaches
+`doiget-<version>.mcpb`. Download it and open it — Claude Desktop installs it
+as an extension. The bundle carries the binaries for macOS, Windows and Linux
+and picks the right one, so there is no PATH to configure.
+
+It asks for one setting, **Paper store location**, which becomes
+`DOIGET_STORE_ROOT`. Point it at a real directory you own; the default is
+`~/Documents/doiget-papers`.
+
+Requires Claude Desktop **0.10.0 or newer**
+(`mcpb/manifest.json` → `compatibility.claude_desktop`).
+
+## Manual: `claude_desktop_config.json`
+
+Settings → Developer → Edit Config. The file lives at:
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Desktop MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "/usr/local/bin/doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an **absolute** `command` path. A desktop app does not inherit the `PATH`
+your shell has, so a bare `doiget` frequently fails to launch with no visible
+error.
 
-## What to read in the meantime
+Restart Claude Desktop after editing.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Environment
 
-## Contributing
+`DOIGET_STORE_ROOT` matters more here than anywhere else: the working
+directory of a GUI-launched process is not a directory you chose, so the
+`./papers` default (ADR-0036) lands somewhere arbitrary. That was #369.
 
-If you have a working Claude Desktop integration ahead of Phase 3, open a
-GitHub Discussion with the JSON-RPC trace and host-side config rather than a
-PR — see [`README.md`](./README.md) §Contributing a snippet.
+The remaining variables are the same as for Claude Code — see
+[`claude-code.md`](./claude-code.md) §Environment,
+[`../CONFIG.md`](../CONFIG.md) and [`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Checking it worked
+
+Ask for `doiget_health`. It reports the version, store writability and the
+resolved store path.
+
+## Verifying the download
+
+Every release asset except the `.mcpb` currently ships `.sha256` and
+`.cosign.bundle` sidecars; [#483](https://github.com/QAtlasHub/doiget/issues/483)
+adds them for the `.mcpb` too. Until it lands, verify the raw binary if you
+need a signature check, and install that manually per above.

--- a/docs/INTEGRATION/codex.md
+++ b/docs/INTEGRATION/codex.md
@@ -1,39 +1,33 @@
 # OpenAI Codex CLI integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Codex CLI as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server, and the snippet below is the standard stdio shape,
+> but this specific host has not been exercised. Report success or failure on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512).
 
-[OpenAI Codex CLI](https://github.com/openai/codex) is OpenAI's terminal-native
-coding agent and supports MCP servers. Once `doiget serve` ships in Phase 3,
-this guide will document how to register `doiget` as an MCP server in Codex
-CLI so that the tools enumerated in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Codex sessions.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative TOML from
-elsewhere — wait for the verified Phase 3 snippet.
+[Codex CLI](https://github.com/openai/codex) reads `~/.codex/config.toml`.
+MCP servers go under `[mcp_servers.<name>]`:
 
 ```toml
-<!-- TODO Phase 3: paste verified Codex CLI MCP server entry here. -->
+[mcp_servers.doiget]
+command = "doiget"
+args = ["serve"]
+
+[mcp_servers.doiget.env]
+DOIGET_STORE_ROOT = "/home/you/papers"
+DOIGET_CONTACT_EMAIL = "you@institution.edu"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on `PATH`.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment, [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
 
-## Contributing
+## Checking it worked
 
-If you have a working Codex CLI integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Ask for `doiget_health`, then `doiget_capability_profile`.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/cursor.md
+++ b/docs/INTEGRATION/cursor.md
@@ -1,39 +1,44 @@
 # Cursor integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Cursor as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server with no host-specific behaviour, and the snippet
+> below is the standard stdio shape — but nobody has run it in Cursor and
+> reported back. If you do, please say so on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512) and this banner
+> comes off.
 
-[Cursor](https://www.cursor.com/) is an AI-first code editor that supports MCP
-servers. Once `doiget serve` ships in Phase 3, this guide will show how to
-register `doiget` as an MCP server in Cursor so that DOI resolution, metadata
-fetch, and the other tools listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Cursor's agent.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+[Cursor](https://www.cursor.com/) supports MCP servers. Configuration is a
+`mcp.json` file: `.cursor/mcp.json` inside a project, or `~/.cursor/mcp.json`
+for every project.
 
 ```json
-<!-- TODO Phase 3: paste verified Cursor MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on the `PATH` the editor
+inherits.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment. `DOIGET_STORE_ROOT` is the one that silently misbehaves if
+omitted (ADR-0036, #369).
 
-## Contributing
+## Checking it worked
 
-If you have a working Cursor integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Have the agent call `doiget_health`. If Cursor's own MCP panel reports the
+server as connected but no tool is callable, `doiget_capability_profile` will
+say what this build is allowed to do.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/obsidian.md
+++ b/docs/INTEGRATION/obsidian.md
@@ -1,42 +1,42 @@
-# Obsidian backend export
+# Obsidian
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table, an Obsidian backend export is scoped to
-> **Phase 7 (optional)** — this stub exists so future contributors have an
-> obvious landing place rather than a 404.
+> **Status: NOT IMPLEMENTED, and this page says what does work instead.**
+> There is no Obsidian backend export and none is in progress. The
+> "Phase 7 (optional)" marker in the planned-files table is the only
+> commitment, and it is not a schedule. Last checked 2026-08-26.
 
-[Obsidian](https://obsidian.md/) is a markdown-based knowledge base. The
-Phase 7 Obsidian backend export will, when shipped, let `doiget` write
-metadata and citation records into an Obsidian vault as plain Markdown notes
-with frontmatter, so that the same data exposed by the MCP tools in
-[`../MCP_TOOLS.md`](../MCP_TOOLS.md) can be browsed inside Obsidian.
+Obsidian does not host MCP servers, so there is nothing to register. What
+exists today is that doiget's store is **plain files**, so a vault can sit on
+top of it with no integration at all.
 
-## Configuration (Phase 3)
+## What doiget writes
 
-The example below is intentionally empty. The Obsidian backend export is a
-Phase 7 deliverable; even the Phase 3 wiring is not yet implemented.
+One TOML sidecar and one PDF per entry, under `DOIGET_STORE_ROOT`. The layout
+and the field contract are in [`../STORE.md`](../STORE.md).
 
-```toml
-<!-- TODO Phase 3: paste verified Obsidian export config block here. -->
+Point the store at a folder inside your vault:
+
+```sh
+export DOIGET_STORE_ROOT="$HOME/Vault/papers"
+doiget fetch 10.1103/PhysRevLett.130.200601
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+The PDFs are then openable from Obsidian, and the sidecars are readable text.
+They are **TOML, not Markdown with YAML frontmatter**, so Obsidian will not
+index them as notes and Dataview will not see them.
 
-## What to read in the meantime
+## What is missing, precisely
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+A Markdown-with-frontmatter projection of the sidecar. That is the whole of
+the "Obsidian backend export" idea, and it is not implemented — not the wiring,
+not the frontmatter schema, not a `doiget` subcommand.
+
+`doiget csl <ref>` and `doiget bib <ref>` emit CSL-JSON and BibTeX from the
+same records, which is enough to script a projection yourself.
 
 ## Contributing
 
-If you have a working Obsidian export workflow ahead of Phase 7, open a
-GitHub Discussion describing the vault layout and frontmatter shape rather
-than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you build one, open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+vault layout and the frontmatter shape before a PR — the schema is the part
+worth agreeing on first.


### PR DESCRIPTION
Closes #512.

## What was there

Every file in `docs/INTEGRATION/` carried `Status: PLACEHOLDER (Phase 3)` and two unfilled TODOs. `claude-code.md` said:

> The example below is intentionally empty. **Do not copy speculative JSON from elsewhere — wait for the verified Phase 3 snippet.**

`doiget serve` shipped long ago. `mcpb/manifest.json` launches it, the `.mcpb` is attached to every release, and doiget is listed in the MCP Registry. The caution was correct when written and had become the only thing standing between a reader and a working configuration — worse than having no guide, because a missing page invites a guess and this one forbade one.

`README.md:51` sends the "Agent / MCP host integrator" persona straight there.

## What each page says now

The issue asked for honesty where a host has not been exercised, so that is a first-class field rather than a blanket disclaimer:

| page | exercised? |
|---|---|
| `claude-code.md` | **Yes** — this is what the project is developed under |
| `claude-desktop.md` | **Yes**, for the `.mcpb` route (shipping since 0.8.4); the manual JSON route is the same stdio invocation |
| `cursor.md` | **No** — "untested against Cursor as of 2026-08-26", with the standard stdio shape and a request to report back on #512 |
| `codex.md` | **No** — same, for `~/.codex/config.toml` |
| `obsidian.md` | **Not applicable.** Obsidian hosts no MCP server. The page says what *does* work — the store is plain files, so point `DOIGET_STORE_ROOT` inside a vault — and states precisely what is missing (a Markdown-with-frontmatter projection; the sidecars are TOML, so Dataview will not see them) |
| `chain-with-paperqa.md` | **No**, as a chain. Both halves are real — doiget writes PDFs to a directory, paper-qa reads one — but nobody has run the composition |

## The env block each TODO promised

Led by `DOIGET_STORE_ROOT`, because that is the one that misbehaves silently: the default is `./papers` **relative to the process's working directory** (ADR-0036), which for an MCP server belongs to the host, not the user. That is #369.

`DOIGET_CONTACT_EMAIL` is second, for the reason #504 documents — without it a throttled answer is indistinguishable from "this paper has no OA copy".

The `DOIGET_ENABLE_*` row states the thing a reader most needs: **all off by default**, so `no OA PDF available` from a stock install means only that Crossref, Unpaywall and arXiv had nothing.

## Verified while writing

- `claude mcp add`'s actual flag surface — `-e KEY=value` (not `--env KEY value`) and `--scope local|user|project`
- 22 tools in `mcpb/manifest.json`, and `compatibility.claude_desktop >= 0.10.0`
- release binaries are built `--features oa-only,citation`, which implies `metadata`, so the `DOIGET_ENABLE_*` flags work in the published artifacts — a self-built `oa-only` binary logs a warning instead, and that caveat is stated once
- `doiget bib` / `doiget csl` exist, as the Obsidian page claims
- every relative link in the six pages resolves (checked mechanically)
- `docs/INTEGRATION/` is not projected by `scripts/sync_docs_to_site.sh`, so there is no `site/content/` counterpart to regenerate

## Not done here

`README.md:114` still points at closed issue #247 for the missing install channels. That is #501's subject, not this one.

Refs #247, #369, #472, #493, #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)