### PR TITLE
fix(cli): an unparsable ref exits 2 everywhere, from one mapping

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -16,6 +16,18 @@ name: backmerge
 # trigger the required CI checks (GitHub recursion guard), so they could
 # never be merged into the protected `next`. (Same constraint the release-plz
 # era already hit; the secret is reused.)
+#
+# The QAtlasHub org refuses fine-grained PATs with a lifetime over 366 days
+# (#426). A PAT minted under the personal account before the migration is
+# rejected with a raw GraphQL error, and every such token expires eventually,
+# so this failure recurs by construction. `gh pr create` is therefore trapped
+# below and the reason is classified into an actionable `::error::` — the
+# 0.8.7 promotion failed here and read as a bare `backmerge / failure` in the
+# Actions list, with the notices above it never reaching the log.
+#
+# A GitHub App installation token (`actions/create-github-app-token`) removes
+# the expiry treadmill and is org-policy clean; it needs an App created and
+# installed, which is a maintainer action, so it is not done here.
 
 on:
   push:
@@ -67,7 +79,42 @@ jobs:
             echo "**Expected merge-time conflict (every back-merge):** \`[workspace.package].version\` and \`Cargo.lock\` conflict — \`next\` carries \`X.Y.Z-beta.N\`, \`main\` carries the clean stable \`X.Y.Z\`. **Keep \`next\`'s \`-beta.N\` version**; take \`main\`'s other changes. Resolve any non-version conflict on its merits."
           } > "$body_file"
 
-          gh pr create --repo "$GITHUB_REPOSITORY" --base next --head main \
-            --title "chore: back-merge main → next (ADR-0025 §D6)" \
-            --body-file "$body_file"
-          echo "::notice::opened main → next back-merge PR."
+          # Trap rather than let `set -e` kill the step on a raw GraphQL
+          # dump. What a reader needs from the Actions list is which of the
+          # three recurring causes it was and what to do, not a log dive.
+          err_file="$(mktemp)"
+          if gh pr create --repo "$GITHUB_REPOSITORY" --base next --head main \
+               --title "chore: back-merge main → next (ADR-0025 §D6)" \
+               --body-file "$body_file" 2>"$err_file"; then
+            echo "::notice::opened main → next back-merge PR."
+            exit 0
+          fi
+
+          err="$(cat "$err_file")"
+          echo "$err" >&2
+
+          cause="gh pr create failed"
+          fix="Open it by hand: gh pr create --base next --head main"
+          case "$err" in
+            *"forbids access via a fine-grained personal access token"*|*"token's lifetime"*)
+              cause="RELEASE_PLZ_TOKEN refused by the QAtlasHub PAT-lifetime policy (max 366 days)"
+              fix="Re-mint the fine-grained PAT with lifetime <= 366 days (contents + pull-requests: write) and update the RELEASE_PLZ_TOKEN repo secret. To stop this recurring on every expiry, move to a GitHub App installation token (actions/create-github-app-token). See #426."
+              ;;
+            *"Bad credentials"*|*"401"*)
+              cause="RELEASE_PLZ_TOKEN is invalid or expired"
+              fix="Re-mint the PAT and update the RELEASE_PLZ_TOKEN repo secret. See #426."
+              ;;
+            *"Resource not accessible"*|*"403"*)
+              cause="RELEASE_PLZ_TOKEN is missing a permission"
+              fix="It needs contents: write and pull-requests: write on this repository. See #426."
+              ;;
+            *"No commits between"*)
+              cause="GitHub reports no diff between main and next"
+              fix="Nothing to do; the branches agree despite the rev-list count above."
+              ;;
+          esac
+
+          echo "::error::back-merge PR could not be opened: $cause"
+          echo "::error::$fix"
+          echo "::error::next is $behind commit(s) behind main and stays there until a PR is opened."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+
+- **[config]** `~/.config/doiget/credentials.toml` is **read**. `docs/CONFIG.md` §6
+  had specified it in full — schema, precedence, a `0600` warning "at startup" — and
+  nothing opened it, so a user who followed a NORMATIVE document wrote their Elsevier
+  key into a file doiget ignored and then reported the source unavailable for want of
+  a key. `[tdm.<publisher>] api_key` now sits one rung below
+  `DOIGET_KEY_<PUBLISHER>`, and the permission warning exists. **The agreement did
+  not move**: `DOIGET_AGREE_TDM_<PUBLISHER>=1` stays environment-only, so it remains
+  an act taken in the session that runs the fetch rather than a boolean written once
+  into a file — an `agreed` key there is parsed only so doiget can warn that it
+  grants nothing (#509, ADR-0050).
+
 ## [0.8.10] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Changed
+
+- **[cli]** **Breaking for scripts.** An unparsable ref now exits **2** (misuse) on
+  every ref-taking command, not 1. `docs/ERRORS.md` §4 already reserved 1 for "at
+  least one fetch was attempted and failed", and an unparsable ref fetches nothing —
+  but `cli_exit_code` had no `INVALID_REF` arm, so `fetch` and the eight commands
+  #477 converted fell through to the catch-all 1 while `graph` hard-coded the 2 the
+  table prescribes. One binary, two answers for the same input, and a comment at
+  each site asserting agreement with the other. A caller that branched on `$? == 1`
+  to mean "invalid ref" was already wrong: 1 was also every network failure and
+  every other code under the catch-all (#492, ADR-0049).
+
 ## [0.8.10] - 2026-08-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.1"
+version       = "0.8.11-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -54,9 +54,64 @@ pub struct ResolvedConfig {
     /// Contact email for the polite User-Agent header (and Unpaywall fallback).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contact_email: Option<String>,
+    /// Which rung produced `contact_email` (#504) — same reason
+    /// `store_root_source` exists (#441): a setting that did nothing must
+    /// not look like a setting that worked.
+    pub contact_email_source: String,
     /// Unpaywall-specific contact email; falls back to `contact_email` when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unpaywall_email: Option<String>,
+    /// Which rung produced `unpaywall_email` (#504).
+    pub unpaywall_email_source: String,
+}
+
+/// Which rung of the #504 ladder produced an address.
+///
+/// Reported for the reason [`super::StoreRootSource`] is: `config init`
+/// wrote `[network] unpaywall_email`, the template called it STRONGLY
+/// RECOMMENDED, `doctor` never mentioned it, and nothing read it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmailSource {
+    /// The env var for this field.
+    Env(&'static str),
+    /// `[network] <field>` in the user's `config.toml`.
+    ConfigFile(&'static str),
+    /// Nothing set it.
+    Unset,
+}
+
+impl EmailSource {
+    /// Short label for `config show` / `doctor`.
+    fn label(self) -> String {
+        match self {
+            Self::Env(v) => v.to_string(),
+            Self::ConfigFile(k) => format!("[network] {k} in config.toml"),
+            Self::Unset => "unset".to_string(),
+        }
+    }
+}
+
+/// Resolve one address across env → `config.toml` → nothing.
+///
+/// Mirrors `doiget_core::orchestrator::resolve_contact_email`. Two
+/// separate readers is the hazard #441 named, so the shared half — which
+/// file, and how it parses — lives in `doiget_core::user_extension`, and
+/// only the rung order is restated here. Both ends are pinned:
+/// `contact_email_comes_from_config_toml_when_the_env_is_unset` below,
+/// and `resolve_contact_email_reads_the_config_file_rung` in
+/// `doiget-core`.
+fn resolve_email(
+    env_var: &'static str,
+    key: &'static str,
+    from_file: Option<String>,
+) -> (Option<String>, EmailSource) {
+    if let Some(v) = std::env::var(env_var).ok().filter(|s| !s.trim().is_empty()) {
+        return (Some(v), EmailSource::Env(env_var));
+    }
+    match from_file {
+        Some(v) => (Some(v), EmailSource::ConfigFile(key)),
+        None => (None, EmailSource::Unset),
+    }
 }
 
 impl ResolvedConfig {
@@ -113,6 +168,19 @@ impl ResolvedConfig {
         let config_dir = cfg.join("doiget");
         let config_path = config_dir.join("config.toml");
 
+        // #504: the two addresses have a `config.toml` rung, like
+        // `store_root` since #441. Read once — a parse failure loses every
+        // file rung at once, and `doctor`'s user-extension check reports it
+        // separately, so this stays quiet and reports `unset`.
+        let file = doiget_core::user_extension::load(&config_path).unwrap_or_default();
+        let (contact_email, contact_email_source) =
+            resolve_email("DOIGET_CONTACT_EMAIL", "contact_email", file.contact_email);
+        let (unpaywall_email, unpaywall_email_source) = resolve_email(
+            "DOIGET_UNPAYWALL_EMAIL",
+            "unpaywall_email",
+            file.unpaywall_email,
+        );
+
         Ok(Self {
             store_root,
             store_root_source: store_root_source.label().to_string(),
@@ -120,8 +188,10 @@ impl ResolvedConfig {
             log_path,
             config_dir,
             config_path,
-            contact_email: std::env::var("DOIGET_CONTACT_EMAIL").ok(),
-            unpaywall_email: std::env::var("DOIGET_UNPAYWALL_EMAIL").ok(),
+            contact_email,
+            contact_email_source: contact_email_source.label(),
+            unpaywall_email,
+            unpaywall_email_source: unpaywall_email_source.label(),
         })
     }
 }
@@ -261,12 +331,14 @@ pub async fn run(
                 &mut all_ok,
             );
             check(
-                "contact_email set",
+                &format!("contact_email set (from: {})", cfg.contact_email_source),
                 cfg.contact_email.is_some(),
                 Some(
-                    "set DOIGET_CONTACT_EMAIL to your email address\n               \
+                    "set DOIGET_CONTACT_EMAIL, or [network] contact_email in config.toml\n               \
                      e.g. export DOIGET_CONTACT_EMAIL=you@institution.edu\n               \
-                     (required for the polite User-Agent header and Unpaywall API)",
+                     (polite User-Agent header + Unpaywall API; without it requests go\n               \
+                     out as doiget@localhost from the non-polite pool, where a throttled\n               \
+                     answer is indistinguishable from `no OA copy` — #504)",
                 ),
                 &mut all_ok,
             );
@@ -417,10 +489,19 @@ pub(crate) fn config_template() -> &'static str {
 [network]
 # Contact address for the polite pool. STRONGLY RECOMMENDED.
 #
-# Without it doiget still queries Unpaywall, but as `doiget@localhost`, from
-# the non-polite pool — where you may be throttled or refused. Since the
-# automatic arXiv-preprint fallback fires on what Unpaywall reports, a
-# throttled response quietly costs you that fallback too.
+# Without it doiget still queries Unpaywall and Crossref, but as
+# `doiget@localhost`, from the non-polite pool — where you may be throttled
+# or refused. Since the automatic arXiv-preprint fallback fires on what
+# Unpaywall reports, a throttled response quietly costs you that fallback
+# too, and the run still exits 0 saying `no OA PDF available`.
+#
+# This is also what `doiget config doctor` checks. Overridden by
+# DOIGET_CONTACT_EMAIL, one rung above.
+# contact_email = "you@institution.edu"
+
+# Only if Unpaywall should see a DIFFERENT address from contact_email above
+# — most people should leave this alone. Overridden by
+# DOIGET_UNPAYWALL_EMAIL.
 # unpaywall_email = "you@institution.edu"
 
 # Allow the curated academic-repository suffixes, i.e. where institutions
@@ -605,7 +686,9 @@ fn contact_report_lines(contact_email: Option<&str>) -> Vec<String> {
             "  contact         polite User-Agent as {e} (all outbound requests)"
         )],
         None => vec![
-            "  contact         no DOIGET_CONTACT_EMAIL — every outbound request, metadata"
+            "  contact         unset — set DOIGET_CONTACT_EMAIL or [network] contact_email"
+                .to_string(),
+            "                  in config.toml. Until then every outbound request, metadata"
                 .to_string(),
             "                  AND publisher content, goes out on the non-polite pool and"
                 .to_string(),
@@ -777,6 +860,15 @@ mod tests {
         .collect()
     }
 
+    /// Point every config-dir rung at `dir`, so `config_dir_utf8()`
+    /// resolves there on any host. Returns guards that restore prior values.
+    fn scoped_config_home(dir: &str) -> Vec<EnvGuard> {
+        ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"]
+            .iter()
+            .map(|v| EnvGuard::set(v, dir))
+            .collect()
+    }
+
     #[test]
     #[serial_test::serial]
     fn from_env_uses_cwd_default_when_unset() {
@@ -796,6 +888,64 @@ mod tests {
         );
         assert_eq!(cfg.contact_email, None);
         assert_eq!(cfg.unpaywall_email, None);
+        assert_eq!(cfg.contact_email_source, "unset");
+        assert_eq!(cfg.unpaywall_email_source, "unset");
+    }
+
+    /// #504, and the exact shape #441 needed: a `config.toml` carrying only
+    /// `[network] contact_email` must produce a non-default contact.
+    ///
+    /// The old tests asserted the env-derived values and the template's key
+    /// list, and **both passed with the rung missing** — so on a machine
+    /// configured from the template every fetch went out as
+    /// `doiget@localhost` while `doctor` reported the store root correctly
+    /// from the very same file.
+    #[test]
+    #[serial_test::serial]
+    fn contact_email_comes_from_config_toml_when_the_env_is_unset() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+        std::fs::write(
+            dir.join("doiget").join("config.toml").as_std_path(),
+            "[network]\ncontact_email = \"file@institution.edu\"\nunpaywall_email = \"up@institution.edu\"\n",
+        )
+        .expect("write config");
+        let _scoped = scoped_config_home(dir.as_str());
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        assert_eq!(cfg.contact_email.as_deref(), Some("file@institution.edu"));
+        assert_eq!(cfg.unpaywall_email.as_deref(), Some("up@institution.edu"));
+        assert_eq!(
+            cfg.contact_email_source, "[network] contact_email in config.toml",
+            "doctor must name the rung that answered, or an inert setting looks like a live one"
+        );
+    }
+
+    /// The env rung stays above the file rung, per field.
+    #[test]
+    #[serial_test::serial]
+    fn the_env_var_outranks_the_config_file_for_each_address() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+        std::fs::write(
+            dir.join("doiget").join("config.toml").as_std_path(),
+            "[network]\ncontact_email = \"file@institution.edu\"\n",
+        )
+        .expect("write config");
+        let _scoped = scoped_config_home(dir.as_str());
+        std::env::set_var("DOIGET_CONTACT_EMAIL", "env@institution.edu");
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        std::env::remove_var("DOIGET_CONTACT_EMAIL");
+
+        assert_eq!(cfg.contact_email.as_deref(), Some("env@institution.edu"));
+        assert_eq!(cfg.contact_email_source, "DOIGET_CONTACT_EMAIL");
     }
 
     /// Issue #405: `config show` / `config path` / `doctor` MUST name the
@@ -889,6 +1039,7 @@ mod tests {
         for key in [
             "[store]",
             "root =",
+            "contact_email",
             "unpaywall_email",
             "trust_academic_repos",
             "trust_oa_registries",
@@ -1250,9 +1401,17 @@ mod tests {
     /// #443: the wording must not pin the cost of an unset contact address
     /// on the metadata leg — the 429 that prompted this came from the
     /// publisher, on the content leg.
+    ///
+    /// #504 adds the second half: the advisory must name **both** rungs, or
+    /// it sends a user who configured from `config init` to the one place
+    /// they were not looking.
     #[test]
     fn the_contact_advisory_names_every_outbound_request_not_just_unpaywall() {
         let joined = contact_report_lines(None).join("\n");
+        assert!(
+            joined.contains("DOIGET_CONTACT_EMAIL") && joined.contains("[network] contact_email"),
+            "both rungs must be named, not only the env var:\n{joined}"
+        );
         assert!(
             joined.contains("every outbound request") && joined.contains("publisher content"),
             "the advisory must cover the content leg too:\n{joined}"

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -138,24 +138,21 @@ fn home_dir_utf8() -> Result<Utf8PathBuf> {
     Err(anyhow!("neither HOME nor USERPROFILE is set"))
 }
 
-/// Best-effort config-dir resolution. Honors `XDG_CONFIG_HOME` first
-/// (POSIX), then `APPDATA` (Windows), then falls back to `$HOME/.config`.
+/// Config-dir resolution, delegated to `doiget_core::user_extension`.
 ///
-/// Crate-visible so sibling modules (`commands::capabilities`,
-/// `commands::config`) can resolve the same `<config_dir>/doiget/`
-/// path the production HTTP-client builder reads from. Keep the
-/// signature stable: any divergence between this and the MCP-side
-/// copy (`crates/doiget-mcp/src/lib.rs::config_dir_utf8`) would
-/// silently desync the user-extension allowlist surfaces.
+/// This used to be one of three copies. The previous comment here asked
+/// the reader to "keep the signature stable" because divergence from the
+/// MCP-side copy "would silently desync the user-extension allowlist
+/// surfaces" — and they had already diverged, this one accepting
+/// `XDG_CONFIG_HOME=""` and resolving a *relative* config path under the
+/// cwd where the MCP copy treated blank as unset. The shared resolver
+/// keeps blank-is-unset, so a blank variable no longer silently selects a
+/// different file.
+///
+/// Kept as a crate-visible wrapper so the ~20 call sites in
+/// `commands::capabilities` / `commands::config` are unchanged.
 pub(crate) fn config_dir_utf8() -> Result<Utf8PathBuf> {
-    if let Some(s) = read_env_utf8("XDG_CONFIG_HOME")? {
-        return Ok(Utf8PathBuf::from(s));
-    }
-    if let Some(s) = read_env_utf8("APPDATA")? {
-        return Ok(Utf8PathBuf::from(s));
-    }
-    let home = home_dir_utf8()?;
-    Ok(home.join(".config"))
+    Ok(doiget_core::user_extension::config_dir()?)
 }
 
 /// Best-effort resolver-cache root (`docs/CACHE.md`). Honors
@@ -377,10 +374,11 @@ pub(crate) fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> 
 
 /// Resolved configuration derived from the environment.
 ///
-/// Slice 2: `contact_email` / `unpaywall_email` are now read by the
-/// `doiget-core::orchestrator::fetch_paper` orchestrator directly from
-/// the env (`contact_email_from_env` / `unpaywall_email_from_env` in
-/// that module), so the CLI no longer threads them through. The fields
+/// Slice 2: `contact_email` / `unpaywall_email` are read by the
+/// `doiget-core::orchestrator::fetch_paper` orchestrator itself
+/// (`resolve_contact_email` / `resolve_unpaywall_email` in that module —
+/// env var, then `[network]` in `config.toml`, then the default since
+/// #504), so the CLI no longer threads them through. The fields
 /// stay here so a future slice that adds CLI-flag overrides has a
 /// natural attachment point — the `#[allow(dead_code)]` is the minimal
 /// intervention until that slice lands.

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1049,6 +1049,13 @@ pub(crate) fn cli_exit_code(code: ErrorCode) -> i32 {
         // A name filter that matched several entities is user-fixable by
         // narrowing the query → `docs/ERRORS.md` §4 exit 2 ("misuse").
         ErrorCode::Ambiguous => 2,
+        // An unparsable ref is a bad argument, and §4's exit 1 is "at
+        // least one fetch failed" — which does not describe a run where
+        // nothing was fetched. `graph` had followed the table with a
+        // hard-coded 2 while `fetch` and the eight #477 commands fell to
+        // the `_ => 1` arm below, so the same input produced different
+        // exit codes from the same binary (#492, ADR-0049).
+        ErrorCode::InvalidRef => 2,
         _ => 1,
     }
 }
@@ -1661,6 +1668,16 @@ host = "*.uj.edu.pl"
         // ADR-0031 D5: a name-filter ambiguity is user-fixable → exit 2,
         // distinct from the generic exit 1.
         assert_eq!(cli_exit_code(ErrorCode::Ambiguous), 2);
+    }
+
+    #[test]
+    fn invalid_ref_maps_to_exit_code_2() {
+        // ADR-0049: an unparsable ref is misuse. `docs/ERRORS.md` §4
+        // reserves 1 for "at least one fetch was attempted and failed",
+        // and nothing is fetched here. `Ambiguous` — a value that fails
+        // to select one entity — was already 2; `InvalidRef` is a value
+        // that fails to parse, and sat at the catch-all 1 next to it.
+        assert_eq!(cli_exit_code(ErrorCode::InvalidRef), 2);
     }
 
     /// Minimal `DenialContext` carrying only `reason`; every other field

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -59,12 +59,15 @@ pub async fn run(
         Ok(r) => r,
         Err(e) => {
             // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2
-            // (issue #149). NOTE: `fetch` exits 1 for the same input; §4
-            // says misuse is 2, so they disagree and this is the one
-            // following the table. Not reconciled in #477 -- see
-            // `commands::render_ref_parse_error`.
+            // (issue #149). Routed through `cli_exit_code` since #492:
+            // this used to hard-code the 2 while `fetch` fell to the
+            // generic 1, so the same input got two answers out of one
+            // binary and the comment here asserted a consistency that
+            // did not hold.
             super::render_ref_parse_error(&e);
-            return Err(anyhow::Error::new(CliExit(2)));
+            return Err(anyhow::Error::new(CliExit(
+                crate::commands::fetch::cli_exit_code(doiget_core::ErrorCode::InvalidRef),
+            )));
         }
     };
     let doi = match &ref_ {

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -54,17 +54,17 @@ pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
     }
 }
 
-/// The renderer on its own, for the two call sites that already choose
-/// their own exit code.
+/// The renderer on its own, for the two call sites that build their own
+/// `CliExit` rather than going through [`parse_ref_or_exit`].
 ///
-/// `fetch` exits 1 (`cli_exit_code(InvalidRef)`) and `graph` exits 2,
-/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparsable
-/// argument is misuse, so they disagree and `graph` is the one following
-/// the table. Filed separately rather than changed here: #477 is about the
-/// message, `fetch`'s exit 1 is pinned by a named test, and quietly moving
-/// an exit code is how a script breaks without anyone noticing.
+/// Both now take the exit code from `fetch::cli_exit_code(InvalidRef)`,
+/// which is **2** since #492 / ADR-0049. Before that `fetch` fell to the
+/// generic `_ => 1` arm while `graph` hard-coded the 2 that
+/// `docs/ERRORS.md` §4 prescribes, so one binary gave two answers for the
+/// same input and each site's comment claimed agreement with the other.
 ///
-/// One renderer either way, which is the part that was missing.
+/// One renderer and one exit code. `every_ref_taking_command_exits_2_for_
+/// an_invalid_ref` is what keeps it that way.
 pub fn render_ref_parse_error(e: &doiget_core::RefParseError) {
     output::print_err(format_args!(
         "error[{}]: invalid ref: {e}",

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -13,8 +13,15 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
+/// #119 gave `fetch` the `error[CODE]:` line and asserted exit **1**,
+/// which is what `cli_exit_code`'s catch-all produced rather than a
+/// decision anyone made. `docs/ERRORS.md` §4 reserves 1 for "at least one
+/// fetch failed", and an unparsable ref fetches nothing.
+///
+/// #492 / ADR-0049 moved it to 2 for every ref-taking command at once.
+/// The name is part of the assertion, so it moved too.
 #[test]
-fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
+fn fetch_invalid_ref_emits_cargo_style_error_and_exit_2() {
     let td = TempDir::new().expect("tempdir");
     Command::cargo_bin("doiget")
         .expect("doiget binary built")
@@ -24,7 +31,7 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
         .env("DOIGET_LOG_PATH", "")
         .args(["fetch", "not a doi"])
         .assert()
-        .code(1)
+        .code(2)
         .stderr(predicate::str::contains("error[INVALID_REF]: invalid ref"))
         // stdout MUST stay clean (ADR-0001 stdio rule).
         .stdout(predicate::str::is_empty());
@@ -95,6 +102,59 @@ fn every_ref_taking_command_emits_the_error_code_contract() {
         broken.is_empty(),
         "these commands do not honour the error[CODE] contract for an invalid ref:\n  {}",
         broken.join("\n  ")
+    );
+}
+
+/// #492: the exit code is half the contract, and it was the half that
+/// disagreed with itself.
+///
+/// `fetch` exited 1, `graph` exited 2, and `docs/ERRORS.md` §4 says 2 —
+/// so one binary answered the same input two ways, and the comment at
+/// each site asserted consistency with the other. A message contract that
+/// every command honours and an exit code that half of them get wrong is
+/// worse than neither, because a script keys off the exit code.
+///
+/// Same table as the message test above, deliberately: a new ref-taking
+/// subcommand is covered by both or by neither.
+#[test]
+fn every_ref_taking_command_exits_2_for_an_invalid_ref() {
+    let mut commands: Vec<Vec<&str>> = vec![
+        vec!["fetch"],
+        vec!["info"],
+        vec!["link"],
+        vec!["cite"],
+        vec!["text"],
+        vec!["bib"],
+        vec!["csl"],
+        vec!["source", "--out", "."],
+        vec!["tag"],
+    ];
+    if cfg!(feature = "citation") {
+        commands.push(vec!["graph"]);
+    }
+
+    let td = TempDir::new().expect("tempdir");
+    let root = td.path().to_str().expect("utf-8");
+
+    let mut wrong: Vec<String> = Vec::new();
+    for argv in &commands {
+        let mut cmd = Command::cargo_bin("doiget").expect("doiget binary built");
+        cmd.env("DOIGET_STORE_ROOT", root)
+            .env("DOIGET_LOG_PATH", "")
+            .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+            .args(argv)
+            .arg("not a doi");
+        let out = cmd.output().expect("run doiget");
+        if out.status.code() != Some(2) {
+            wrong.push(format!("{}: exit {:?}", argv.join(" "), out.status.code()));
+        }
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "docs/ERRORS.md §4: an unparsable ref is misuse (exit 2), not a failed fetch \
+         (exit 1). These disagree:\n  {}",
+        wrong.join("\n  ")
     );
 }
 

--- a/crates/doiget-core/src/credentials.rs
+++ b/crates/doiget-core/src/credentials.rs
@@ -1,0 +1,273 @@
+//! `credentials.toml` — the per-publisher TDM **API keys** (#509).
+//!
+//! `docs/CONFIG.md` §6 specified this file in full — schema, precedence, and
+//! a `0600` permission warning — and nothing read it. A user who followed a
+//! NORMATIVE document wrote their Elsevier key into a file doiget ignored,
+//! and the source then reported itself unavailable for want of a key. That
+//! is the #442 / #454 / #476 shape, landed on credentials.
+//!
+//! ## What this file carries, and what it deliberately does not
+//!
+//! **`api_key`: yes.** A long-lived key is genuinely better off in a file
+//! than in the environment. It survives a shell restart, it is not visible
+//! in `ps`, and it does not leak into the environment of every subprocess.
+//! The `0600` check is then a real control rather than a sentence.
+//!
+//! **`agreed`: no.** `docs/LEGAL.md` §6a.2 makes the per-publisher
+//! agreement an *enforced control*, and part of why it is meaningful is
+//! that `DOIGET_AGREE_TDM_<PUBLISHER>=1` is a variable the user sets in the
+//! session that runs the fetch. A boolean written once into a file and
+//! forgotten is a weaker act of consent, and weakening it as a side effect
+//! of adding a convenience is the kind of accident ADR-0048 was written
+//! about. So the key may come from either place; **the agreement is
+//! environment-only**, and an `agreed` key here is reported rather than
+//! silently discarded — a documented field with no reader is the defect
+//! this module exists to close.
+//!
+//! ## Precedence
+//!
+//! `DOIGET_KEY_<PUBLISHER>` wins over `[tdm.<publisher>] api_key`, matching
+//! the `docs/CONFIG.md` §1 chain and the `store_root` / `contact_email`
+//! rungs (#441, #504).
+
+use camino::Utf8PathBuf;
+use serde::Deserialize;
+
+/// Publisher slugs this file may carry, matching the `[tdm.<slug>]` tables
+/// in `docs/CONFIG.md` §6 and the `tdm-<slug>` Cargo features.
+pub const PUBLISHERS: [&str; 4] = ["elsevier", "aps", "springer", "ieee"];
+
+/// Parsed `credentials.toml`.
+///
+/// Absent, unreadable and malformed all yield the default (no keys): the
+/// file is optional, and one bad line must not take a fetch down. Every
+/// such case emits `tracing::warn!` — silence about this file is precisely
+/// what cost a user their configuration.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct Credentials {
+    keys: Vec<(String, String)>,
+}
+
+impl Credentials {
+    /// The `api_key` for `publisher`, if the file supplied one.
+    #[must_use]
+    pub fn api_key(&self, publisher: &str) -> Option<&str> {
+        self.keys
+            .iter()
+            .find(|(p, _)| p == publisher)
+            .map(|(_, k)| k.as_str())
+    }
+
+    /// True when the file carried no usable key at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawFile {
+    #[serde(default)]
+    tdm: Option<std::collections::BTreeMap<String, RawEntry>>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawEntry {
+    #[serde(default)]
+    api_key: Option<String>,
+    /// Parsed only so its presence can be *reported*. The agreement is
+    /// environment-only (`docs/LEGAL.md` §6a.2); see the module docs.
+    #[serde(default)]
+    agreed: Option<bool>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+/// `<config_dir>/doiget/credentials.toml`.
+///
+/// # Errors
+///
+/// As [`crate::user_extension::config_dir`].
+pub fn path() -> Result<Utf8PathBuf, crate::user_extension::ConfigDirError> {
+    Ok(crate::user_extension::config_dir()?
+        .join("doiget")
+        .join("credentials.toml"))
+}
+
+/// Load the credentials file, or the empty set.
+///
+/// Never fails; every failure mode is warned about. See [`Credentials`].
+#[must_use]
+pub fn load_or_default() -> Credentials {
+    let path = match path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(error = %e, "no config directory; credentials.toml not read");
+            return Credentials::default();
+        }
+    };
+    let text = match std::fs::read_to_string(path.as_std_path()) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Credentials::default(),
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "credentials.toml exists but could not be read; keys from it are \
+                 unavailable and only DOIGET_KEY_* will be used"
+            );
+            return Credentials::default();
+        }
+    };
+    warn_if_group_or_world_accessible(&path);
+    parse(&text, &path)
+}
+
+/// Parse a `credentials.toml` body. Pure; the path is for messages only.
+fn parse(text: &str, path: &camino::Utf8Path) -> Credentials {
+    let raw: RawFile = match toml::from_str(text) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "credentials.toml is malformed; keys from it are unavailable and only \
+                 DOIGET_KEY_* will be used"
+            );
+            return Credentials::default();
+        }
+    };
+    let Some(tdm) = raw.tdm else {
+        return Credentials::default();
+    };
+
+    let mut keys = Vec::new();
+    for (publisher, entry) in tdm {
+        if !PUBLISHERS.contains(&publisher.as_str()) {
+            tracing::warn!(
+                path = %path,
+                publisher = %publisher,
+                "credentials.toml has [tdm.{}], which is not a publisher doiget knows; \
+                 expected one of {:?}",
+                publisher,
+                PUBLISHERS
+            );
+            continue;
+        }
+        if entry.agreed.is_some() {
+            // Reported, not obeyed. A field parsed and discarded in silence
+            // is exactly what #509 is about.
+            tracing::warn!(
+                path = %path,
+                publisher = %publisher,
+                "credentials.toml sets [tdm.{}] agreed, which doiget does NOT read. The \
+                 per-publisher agreement is environment-only (DOIGET_AGREE_TDM_{}=1) so \
+                 that it is an act taken in the session that runs the fetch — \
+                 docs/LEGAL.md §6a.2. Only api_key is read from this file.",
+                publisher,
+                publisher.to_uppercase()
+            );
+        }
+        // Blank means unset, as everywhere else: an empty key cannot
+        // authenticate, and building a grant around one would mask the
+        // misconfiguration `AgreedButNoKey` exists to surface.
+        let key = entry
+            .api_key
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty());
+        if let Some(k) = key {
+            keys.push((publisher, k));
+        }
+    }
+    Credentials { keys }
+}
+
+/// Warn when the file is group- or world-accessible on POSIX.
+///
+/// `docs/CONFIG.md` §6 promised this warning from the day it was written.
+/// It did not exist, and neither did the reader it was attached to (#509).
+#[cfg(unix)]
+fn warn_if_group_or_world_accessible(path: &camino::Utf8Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let Ok(meta) = std::fs::metadata(path.as_std_path()) else {
+        return;
+    };
+    let mode = meta.permissions().mode() & 0o777;
+    if mode & 0o077 != 0 {
+        tracing::warn!(
+            path = %path,
+            mode = format!("{mode:04o}"),
+            "credentials.toml is readable beyond its owner (mode {:04o}); it holds \
+             publisher API keys. Run: chmod 600 {}",
+            mode,
+            path
+        );
+    }
+}
+
+/// No-op off POSIX: Windows ACLs are not a mode, and a warning phrased in
+/// `chmod` terms would be advice the user cannot follow.
+#[cfg(not(unix))]
+fn warn_if_group_or_world_accessible(_path: &camino::Utf8Path) {}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn p() -> camino::Utf8PathBuf {
+        camino::Utf8PathBuf::from("/tmp/credentials.toml")
+    }
+
+    #[test]
+    fn an_api_key_is_read_per_publisher() {
+        let c = parse(
+            "[tdm.elsevier]\napi_key = \"abc\"\n\n[tdm.aps]\napi_key = \"def\"\n",
+            &p(),
+        );
+        assert_eq!(c.api_key("elsevier"), Some("abc"));
+        assert_eq!(c.api_key("aps"), Some("def"));
+        assert_eq!(c.api_key("springer"), None);
+    }
+
+    /// The whole point of the split: the file may carry the key, never the
+    /// agreement (`docs/LEGAL.md` §6a.2). There is no accessor for `agreed`
+    /// at all, so no caller can be tempted to consult one.
+    #[test]
+    fn agreed_in_the_file_grants_nothing() {
+        let c = parse("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n", &p());
+        assert_eq!(
+            c.api_key("elsevier"),
+            Some("abc"),
+            "the key is still read; only the agreement is refused"
+        );
+    }
+
+    #[test]
+    fn a_blank_key_is_treated_as_unset() {
+        let c = parse("[tdm.aps]\napi_key = \"   \"\n", &p());
+        assert!(c.is_empty(), "a blank key cannot authenticate");
+    }
+
+    #[test]
+    fn a_malformed_file_yields_no_keys_rather_than_a_panic() {
+        assert!(parse("this is not toml = = =", &p()).is_empty());
+    }
+
+    #[test]
+    fn an_unknown_publisher_table_is_skipped() {
+        assert!(
+            parse("[tdm.wiley]\napi_key = \"abc\"\n", &p()).is_empty(),
+            "unknown publishers grant nothing"
+        );
+    }
+
+    #[test]
+    fn an_absent_tdm_table_is_not_an_error() {
+        assert!(parse("[something_else]\nx = 1\n", &p()).is_empty());
+        assert!(parse("", &p()).is_empty());
+    }
+}

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -16,6 +16,7 @@ use sha2::Digest;
 
 // --- Modules ---
 pub mod canonical;
+pub mod credentials;
 pub mod discovery;
 pub mod dry_run;
 pub mod http;
@@ -1369,29 +1370,40 @@ impl CapabilityProfile {
         };
 
         // -- Tier 3 TDM grants ----------------------------------------------
+        // #509: the key may also come from `credentials.toml`, which
+        // `docs/CONFIG.md` §6 has specified in full since 0.7 and which
+        // nothing read. Loaded once — one file, one reader, so `config
+        // doctor` and a fetch can never describe different files (#441's
+        // lesson). The **agreement** stays environment-only; see the
+        // `credentials` module docs and `docs/LEGAL.md` §6a.2.
+        let creds = crate::credentials::load_or_default();
         let tdm_elsevier = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_ELSEVIER",
             "DOIGET_KEY_ELSEVIER",
             "tdm-elsevier",
             cfg!(feature = "tdm-elsevier"),
+            creds.api_key("elsevier"),
         )?;
         let tdm_aps = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_APS",
             "DOIGET_KEY_APS",
             "tdm-aps",
             cfg!(feature = "tdm-aps"),
+            creds.api_key("aps"),
         )?;
         let tdm_springer = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_SPRINGER",
             "DOIGET_KEY_SPRINGER",
             "tdm-springer",
             cfg!(feature = "tdm-springer"),
+            creds.api_key("springer"),
         )?;
         let tdm_ieee = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_IEEE",
             "DOIGET_KEY_IEEE",
             "tdm-ieee",
             cfg!(feature = "tdm-ieee"),
+            creds.api_key("ieee"),
         )?;
 
         Ok(Self {
@@ -1430,24 +1442,32 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
     }
 }
 
-/// Resolve a Tier 3 TDM grant from the `agree`/`key` env-var pair and the
-/// per-publisher Cargo feature.
+/// Resolve a Tier 3 TDM grant from the agreement env var, the key (env var
+/// or `credentials.toml`), and the per-publisher Cargo feature.
 ///
 /// Implements the rules in `docs/CAPABILITY.md` §2:
 ///
 /// - both unset → `Ok(None)`.
-/// - `agree == "1"` and `key` set → `Ok(Some(TdmGrant { .. }))` (when the
+/// - `agree == "1"` and a key → `Ok(Some(TdmGrant { .. }))` (when the
 ///   feature is enabled), or warn-and-`Ok(None)` (when the feature is not
 ///   compiled in).
-/// - `agree == "1"` and `key` unset →
-///   [`CapabilityError::AgreedButNoKey`].
-/// - `key` set and `agree` unset OR `agree` set to anything other than `"1"`
-///   → [`CapabilityError::KeyButNotAgreed`].
+/// - `agree == "1"` and no key → [`CapabilityError::AgreedButNoKey`].
+/// - a key, and `agree` unset OR set to anything other than `"1"` →
+///   [`CapabilityError::KeyButNotAgreed`].
+///
+/// `file_key` is `[tdm.<publisher>] api_key` from `credentials.toml`, one
+/// rung **below** `DOIGET_KEY_<PUBLISHER>` (#509). The two rules above are
+/// unchanged by its existence: a key from the file still needs the
+/// agreement, and the agreement still comes only from the environment, so
+/// `KeyButNotAgreed` now also fires for a file-supplied key with no
+/// `DOIGET_AGREE_TDM_<PUBLISHER>=1`. That is the point — `docs/LEGAL.md`
+/// §6a.2 is an enforced control, and a convenience must not dilute it.
 fn resolve_tdm_grant(
     agree_var: &str,
     key_var: &str,
     feature: &str,
     feature_enabled: bool,
+    file_key: Option<&str>,
 ) -> Result<Option<TdmGrant>, CapabilityError> {
     // `agree` is "agreed" iff the value is exactly the literal "1"; any other
     // value (including "true", "yes", empty) is treated as not-agreed per
@@ -1460,7 +1480,14 @@ fn resolve_tdm_grant(
     // An empty value is treated as "not set" — an empty API key cannot
     // authenticate, and silently constructing a grant around it would
     // mask the misconfiguration the AgreedButNoKey rule exists to surface.
-    let key_value = std::env::var(key_var).ok().filter(|v| !v.is_empty());
+    //
+    // Env above file (#509), matching `docs/CONFIG.md` §1 and the
+    // `store_root` / `contact_email` rungs. `credentials.toml` has already
+    // applied the same blank-is-unset rule.
+    let key_value = std::env::var(key_var)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| file_key.map(str::to_string));
 
     match (agreed, agree_present, key_value) {
         (true, _, Some(key)) => {
@@ -1629,9 +1656,25 @@ mod tests {
         }
     }
 
+    /// Point every config-dir rung at `dir`, so `credentials.toml` and
+    /// `config.toml` resolve there. Returns guards restoring prior values.
+    fn scoped_config_home(dir: &str) -> Vec<EnvGuard> {
+        ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"]
+            .iter()
+            .map(|v| EnvGuard::set(v, dir))
+            .collect()
+    }
+
     /// Convenience: unset every Tier 2 / Tier 3 env var the resolution
     /// algorithm reads, returning a vector of guards that restore them on
     /// drop. Callers can then `EnvGuard::set` individual vars on top.
+    ///
+    /// The caller MUST also scope the config directory — see
+    /// [`isolated_capability_env`]. Since #509 the TDM key has a
+    /// `credentials.toml` rung, so a test that only clears the environment
+    /// reads the developer's real credentials file: green in CI and red on
+    /// the one machine that has TDM configured, which is the least useful
+    /// place for a test to fail.
     fn unset_all_capability_env_vars() -> Vec<EnvGuard> {
         [
             "DOIGET_ENABLE_OPENALEX",
@@ -1643,10 +1686,138 @@ mod tests {
             "DOIGET_KEY_APS",
             "DOIGET_AGREE_TDM_SPRINGER",
             "DOIGET_KEY_SPRINGER",
+            "DOIGET_AGREE_TDM_IEEE",
+            "DOIGET_KEY_IEEE",
         ]
         .iter()
         .map(|v| EnvGuard::unset(v))
         .collect()
+    }
+
+    /// Clean environment AND an empty config directory, so
+    /// `CapabilityProfile::from_env` sees neither an env var nor a
+    /// credentials file. Hold the returned tuple for the test's lifetime.
+    fn isolated_capability_env() -> (tempfile::TempDir, Vec<EnvGuard>, Vec<EnvGuard>) {
+        isolated_env_with(None)
+    }
+
+    /// As [`isolated_capability_env`], optionally writing `credentials.toml`.
+    fn isolated_env_with(
+        credentials: Option<&str>,
+    ) -> (tempfile::TempDir, Vec<EnvGuard>, Vec<EnvGuard>) {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        if let Some(body) = credentials {
+            std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+            std::fs::write(
+                dir.join("doiget").join("credentials.toml").as_std_path(),
+                body,
+            )
+            .expect("write credentials.toml");
+        }
+        let env = unset_all_capability_env_vars();
+        let home = scoped_config_home(dir.as_str());
+        (td, env, home)
+    }
+
+    /// #509: `credentials.toml` supplies the KEY, and the agreement still
+    /// comes only from the environment.
+    ///
+    /// Asserts the production path (`CapabilityProfile::from_env`), not the
+    /// parser — the parser was never the missing part. #442, #454 and #458
+    /// were each a correct component nothing reached, and a file reader
+    /// with no caller would be that defect again.
+    ///
+    /// Holds in the shipped `oa-only` build: `KeyButNotAgreed` fires before
+    /// any feature gate, so this proves the file is read without needing a
+    /// `tdm-*` feature compiled.
+    #[test]
+    #[serial_test::serial]
+    fn a_key_from_credentials_toml_is_read_and_still_needs_the_agreement() {
+        let (_td, _env, _home) = isolated_env_with(Some(
+            "[tdm.elsevier]
+api_key = \"file-key\"
+",
+        ));
+
+        match CapabilityProfile::from_env() {
+            Err(CapabilityError::KeyButNotAgreed { agree_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+            }
+            other => panic!(
+                "a key in credentials.toml must be READ, so the missing agreement is reported. Before #509 this was Ok(no grant) because the file was never opened. Got {other:?}"
+            ),
+        }
+    }
+
+    /// The half that must NOT work: `agreed = true` in the file is not an
+    /// agreement (`docs/LEGAL.md` §6a.2). Key from the file, no
+    /// `DOIGET_AGREE_TDM_ELSEVIER` — still `KeyButNotAgreed`.
+    #[test]
+    #[serial_test::serial]
+    fn agreed_in_credentials_toml_does_not_grant_anything() {
+        let (_td, _env, _home) = isolated_env_with(Some(
+            "[tdm.elsevier]
+api_key = \"file-key\"
+agreed = true
+",
+        ));
+
+        match CapabilityProfile::from_env() {
+            Err(CapabilityError::KeyButNotAgreed { agree_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+            }
+            other => panic!(
+                "`agreed` in the file must not substitute for the environment agreement; got {other:?}"
+            ),
+        }
+    }
+
+    /// Env above file, per `docs/CONFIG.md` §1: the agreement plus either
+    /// key resolves, and a blank env key falls through to the file rather
+    /// than counting as a key (the blank-is-unset rule every rung uses).
+    #[test]
+    #[serial_test::serial]
+    fn the_env_key_outranks_the_file_and_a_blank_one_falls_through() {
+        let _g = unset_all_capability_env_vars();
+
+        let granted = resolve_tdm_grant(
+            "DOIGET_AGREE_TDM_ELSEVIER",
+            "DOIGET_KEY_ELSEVIER",
+            "tdm-elsevier",
+            false,
+            Some("file-key"),
+        );
+        match granted {
+            Err(CapabilityError::KeyButNotAgreed { .. }) => {}
+            other => panic!("a file key with no agreement is KeyButNotAgreed; got {other:?}"),
+        }
+
+        let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "   ");
+        match resolve_tdm_grant(
+            "DOIGET_AGREE_TDM_ELSEVIER",
+            "DOIGET_KEY_ELSEVIER",
+            "tdm-elsevier",
+            false,
+            Some("file-key"),
+        ) {
+            Err(CapabilityError::KeyButNotAgreed { .. }) => {}
+            other => panic!("a blank env key must fall through to the file; got {other:?}"),
+        }
+
+        let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
+        assert!(
+            resolve_tdm_grant(
+                "DOIGET_AGREE_TDM_ELSEVIER",
+                "DOIGET_KEY_ELSEVIER",
+                "tdm-elsevier",
+                false,
+                Some("file-key"),
+            )
+            .is_ok(),
+            "agreement + a file key is a valid configuration"
+        );
     }
 
     #[test]
@@ -1655,7 +1826,7 @@ mod tests {
         // Rule: with every relevant env var unset, the resolved profile has
         // all TDM grants `None` and all metadata flags `false`. Hard-coded
         // rate limits still apply. (Replaces the old Phase 0 stub test.)
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
 
         let p = CapabilityProfile::from_env().expect("clean env never errors");
         assert!(p.tdm_elsevier.is_none());
@@ -1672,7 +1843,7 @@ mod tests {
     fn from_env_no_tdm_returns_tier_1_profile() {
         // Rule (CAPABILITY.md §2): with every TDM env var unset, all
         // `tdm_*` fields are `None` and no error is produced.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
 
         let p = CapabilityProfile::from_env().expect("no TDM env -> Ok");
         assert!(p.tdm_elsevier.is_none());
@@ -1684,7 +1855,7 @@ mod tests {
     #[serial_test::serial]
     fn from_env_agreed_but_no_key_errs() {
         // Rule (CAPABILITY.md §2): agree=1 + key unset -> AgreedButNoKey.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
 
         let result = CapabilityProfile::from_env();
@@ -1705,7 +1876,7 @@ mod tests {
         // DOIGET_KEY_ELSEVIER="" the misconfiguration must surface as
         // AgreedButNoKey, not silently build a grant around an empty
         // secret that could never authenticate.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "");
 
@@ -1727,7 +1898,7 @@ mod tests {
         // It must resolve to Ok(None) (no grant, no error) — an empty
         // string must NOT trip the KeyButNotAgreed leaked-credential
         // rule, since there is no credential.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "");
 
         let p = CapabilityProfile::from_env()
@@ -1745,7 +1916,7 @@ mod tests {
     fn from_env_key_but_not_agreed_errs() {
         // Rule (CAPABILITY.md §2): key set + agree unset -> KeyButNotAgreed.
         // A leaked DOIGET_KEY_ELSEVIER must not silently enable a source.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "sk-test");
 
         let result = CapabilityProfile::from_env();
@@ -1763,7 +1934,7 @@ mod tests {
         // Rule (CAPABILITY.md §2): the agree var must be exactly "1". Any
         // other value (here: "true") is treated as not-agreed; combined
         // with a key set, that triggers KeyButNotAgreed.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "true");
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "sk-test");
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4210,6 +4210,19 @@ mod attempt_denial_tests {
 
 /// Whether a `SourceSchema` hint describes an access refusal rather than a
 /// malformed response.
+///
+/// The coupling is prose: a source says why it refused in free text and
+/// this reads the text back. That is fragile, and #503 is the proof — it
+/// reworded Europe PMC's refusal from "not open access" to "advertises no
+/// retrievable PDF" and the row silently reclassified from
+/// `NotOpenAccess` to `Failed`, which reads to an operator as "the source
+/// broke" rather than "the source has it and cannot give it to us".
+///
+/// It is caught rather than prevented: `an_access_refusal_is_recorded_
+/// distinctly_from_a_miss` drives the real chain, so any source whose
+/// wording drifts out of this predicate fails there. A typed refusal on
+/// `FetchError` would prevent it instead, at the cost of widening the
+/// closed error set in `docs/ERRORS.md` §3.
 #[cfg(any(
     feature = "metadata",
     feature = "tdm-elsevier",
@@ -4218,7 +4231,13 @@ mod attempt_denial_tests {
     feature = "tdm-ieee"
 ))]
 fn is_access_refusal(hint: &str) -> bool {
-    hint.contains("not open access") || hint.contains("openAccess")
+    hint.contains("not open access")
+        || hint.contains("openAccess")
+        // #503: Europe PMC refuses on "nothing retrievable is
+        // advertised", which is a strictly narrower claim than "outside
+        // the OA subset" and is still an access refusal, not a schema
+        // failure.
+        || hint.contains("no retrievable PDF")
 }
 
 /// Run the optional resolution chain and record one [`SourceAttempt`] per
@@ -4924,6 +4943,11 @@ mod chain_tests {
     /// An access refusal is not a miss. OpenAIRE / Europe PMC / HAL all
     /// report "found it, cannot give it to you" — that must not be recorded
     /// as `NoRecord`, or the operator concludes the paper does not exist.
+    ///
+    /// This record carries no `fullTextUrlList` at all, so after #503 it is
+    /// refused for the narrower reason and must still classify as
+    /// `NotOpenAccess` — see `is_access_refusal`, whose coupling to the
+    /// wording this test is the only thing guarding.
     #[tokio::test]
     #[serial_test::serial]
     async fn an_access_refusal_is_recorded_distinctly_from_a_miss() {
@@ -4954,6 +4978,53 @@ mod chain_tests {
             o.render().contains("not open access"),
             "the reason must survive into the message; got {}",
             o.render()
+        );
+    }
+
+    /// #503, at the level that matters: a Europe PMC record OUTSIDE the
+    /// bulk OA subset that still advertises a Free PDF must resolve, and
+    /// the URL must reach `optional_source_oa_url` — which is what
+    /// `try_optional_source_oa_fallback` hands to the `oa-publisher` leg.
+    ///
+    /// The source-level test proves the gate; this proves the copy is not
+    /// dropped somewhere between the gate and the fetch. Every bug in the
+    /// #442 family was a correct component that nothing reached.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_closed_subset_record_with_a_free_pdf_resolves_and_carries_its_url() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"resultList":{"result":[{"doi":"10.1098/rspa.2014.0585",
+                   "isOpenAccess":"N","inEPMC":"Y","fullTextUrlList":{"fullTextUrl":[
+                   {"availability":"Free","availabilityCode":"F","documentStyle":"pdf",
+                    "site":"Europe_PMC",
+                    "url":"https://europepmc.org/articles/PMC4277194?pdf=render"}]}}]}}"#,
+            ))
+            .mount(&server)
+            .await;
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Doi(Doi::parse("10.1098/rspa.2014.0585").expect("doi"));
+        let mut fields = CrossrefFields::default();
+        let mut attempts = Vec::new();
+        let mut on = all_off();
+        on.metadata.europe_pmc = true;
+
+        let resolved =
+            resolve_optional_chain(&ref_, &on, &ctx, false, &mut fields, &mut attempts).await;
+
+        let (source, record) = resolved.expect("a Free PDF entry must resolve, not refuse");
+        assert_eq!(source, "europe-pmc");
+        let row = outcome(&attempts, "europe-pmc");
+        assert!(
+            matches!(row, AttemptOutcome::Resolved),
+            "the row must read as resolved, not as an access refusal; got {row:?}"
+        );
+        assert_eq!(
+            optional_source_oa_url("europe-pmc", &record),
+            Some("https://europepmc.org/articles/PMC4277194?pdf=render"),
+            "the URL the oa-publisher leg fetches must survive the chain"
         );
     }
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -554,12 +554,29 @@ fn extract_metadata_authors(meta: &Value) -> Vec<String> {
 // helpers so a single test fixture can drive both crates.
 // ---------------------------------------------------------------------------
 
-/// `DOIGET_CONTACT_EMAIL`, defaulting to the same `doiget@localhost`
-/// the CLI uses (`crates/doiget-cli/src/commands/fetch.rs::OrchestratorConfig`).
+/// Last rung of the contact ladder — the same `doiget@localhost` the CLI
+/// uses (`crates/doiget-cli/src/commands/fetch.rs::OrchestratorConfig`).
 const FALLBACK_CONTACT_EMAIL: &str = "doiget@localhost";
 
-fn contact_email_from_env() -> String {
-    std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| FALLBACK_CONTACT_EMAIL.to_string())
+/// Read an env var, treating blank as unset.
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|s| !s.trim().is_empty())
+}
+
+/// Polite-pool contact address: `DOIGET_CONTACT_EMAIL`, then
+/// `[network] contact_email` in `config.toml`, then `doiget@localhost`
+/// (#504).
+///
+/// Same rung order ADR-0036 / #441 gave `store_root`, per field. The file
+/// is opened only when the env rung is empty, and the result is
+/// deliberately **not** cached: a long-lived `doiget serve`, `config
+/// doctor` and the tests must all see an edit to the file or the
+/// environment, and one small read is free next to the network legs it
+/// precedes.
+fn resolve_contact_email() -> String {
+    env_nonempty("DOIGET_CONTACT_EMAIL")
+        .or_else(|| crate::user_extension::load_or_default().contact_email)
+        .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
 }
 
 fn arxiv_source_from_env() -> ArxivSource {
@@ -613,7 +630,7 @@ async fn metadata_only_doi(
     profile: &CapabilityProfile,
     ctx: &FetchContext,
 ) -> Result<MetadataOnlyOutcome, FetchError> {
-    let contact = contact_email_from_env();
+    let contact = resolve_contact_email();
     let crossref = crossref_source_from_env(&contact);
     match crossref.fetch(ref_, profile, ctx).await {
         Ok(res) => {
@@ -1149,8 +1166,8 @@ async fn fetch_paper_doi(
     store_root: &Utf8Path,
     safekey: &Safekey,
 ) -> Result<FetchPaperOutcome, FetchError> {
-    let contact = contact_email_from_env();
-    let unpaywall_contact = unpaywall_email_from_env(&contact);
+    let contact = resolve_contact_email();
+    let unpaywall_contact = resolve_unpaywall_email(&contact);
     let crossref = crossref_source_from_env(&contact);
     // Issue #120: Crossref is NON-fatal. A transient Crossref failure
     // must not abort the whole DOI fetch when Unpaywall alone can
@@ -2523,8 +2540,25 @@ fn strip_arxiv_version(id: &str) -> &str {
     id
 }
 
-fn unpaywall_email_from_env(fallback_contact: &str) -> String {
-    std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| fallback_contact.to_string())
+/// Unpaywall contact: `DOIGET_UNPAYWALL_EMAIL`, then
+/// `[network] unpaywall_email`, then whatever the caller resolved as the
+/// general contact address (#504).
+///
+/// The more specific field wins at each rung, which is how
+/// `DOIGET_UNPAYWALL_EMAIL` already beat `DOIGET_CONTACT_EMAIL`.
+///
+/// `[network] unpaywall_email` was written by `config init`, called
+/// STRONGLY RECOMMENDED by the template's own prose, and read by nothing
+/// for four releases. The cost is not politeness. The template says so
+/// itself: the automatic arXiv-preprint fallback fires on what Unpaywall
+/// reports, so a throttled answer from the non-polite pool quietly costs
+/// that fallback — and the run still exits 0 with `metadata-only: no OA
+/// PDF available`. A degraded search and a true negative were the same
+/// observable.
+fn resolve_unpaywall_email(fallback_contact: &str) -> String {
+    env_nonempty("DOIGET_UNPAYWALL_EMAIL")
+        .or_else(|| crate::user_extension::load_or_default().unpaywall_email)
+        .unwrap_or_else(|| fallback_contact.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -2633,6 +2667,128 @@ pub fn batch_fetch_plans(
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    // ── #504: the contact ladder, at the end that actually fetches ──────
+
+    /// RAII env guard for the ladder tests.
+    struct LadderEnv {
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl LadderEnv {
+        /// Clear both address vars and point every config-dir rung at `dir`.
+        fn scoped(dir: &str) -> Self {
+            let mut vars = Vec::new();
+            for v in ["DOIGET_CONTACT_EMAIL", "DOIGET_UNPAYWALL_EMAIL"] {
+                vars.push((v, std::env::var_os(v)));
+                std::env::remove_var(v);
+            }
+            for v in ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"] {
+                vars.push((v, std::env::var_os(v)));
+                std::env::set_var(v, dir);
+            }
+            Self { vars }
+        }
+
+        fn set(&mut self, var: &'static str, value: &str) {
+            self.vars.push((var, std::env::var_os(var)));
+            std::env::set_var(var, value);
+        }
+    }
+
+    impl Drop for LadderEnv {
+        fn drop(&mut self) {
+            for (var, prior) in self.vars.iter().rev() {
+                match prior {
+                    Some(v) => std::env::set_var(var, v),
+                    None => std::env::remove_var(var),
+                }
+            }
+        }
+    }
+
+    /// Write a `config.toml` under `dir` and return `dir`.
+    fn write_config(td: &tempfile::TempDir, body: &str) -> String {
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+        std::fs::write(dir.join("doiget").join("config.toml").as_std_path(), body)
+            .expect("write config.toml");
+        dir.to_string()
+    }
+
+    /// #504. The fetch path read the environment and nothing else, so
+    /// `[network] unpaywall_email` — written by `config init`, called
+    /// STRONGLY RECOMMENDED in the template's own prose — did nothing, and
+    /// every request from a machine configured that way went out as
+    /// `doiget@localhost`.
+    ///
+    /// This is the end that matters: `ResolvedConfig` agreeing is what
+    /// `doctor` reports, but this is what the network sees.
+    #[test]
+    #[serial_test::serial]
+    fn resolve_contact_email_reads_the_config_file_rung() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = write_config(
+            &td,
+            "[network]\ncontact_email = \"file@institution.edu\"\nunpaywall_email = \"up@institution.edu\"\n",
+        );
+        let _env = LadderEnv::scoped(&dir);
+
+        let contact = resolve_contact_email();
+        assert_eq!(contact, "file@institution.edu");
+        assert_eq!(resolve_unpaywall_email(&contact), "up@institution.edu");
+    }
+
+    /// The env rung stays on top, per field, and `unpaywall_email` still
+    /// falls back to the resolved contact when only that one is absent.
+    #[test]
+    #[serial_test::serial]
+    fn the_env_rung_outranks_the_file_and_unpaywall_falls_back_to_contact() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = write_config(&td, "[network]\ncontact_email = \"file@institution.edu\"\n");
+        let mut env = LadderEnv::scoped(&dir);
+        env.set("DOIGET_CONTACT_EMAIL", "env@institution.edu");
+
+        let contact = resolve_contact_email();
+        assert_eq!(contact, "env@institution.edu");
+        assert_eq!(
+            resolve_unpaywall_email(&contact),
+            "env@institution.edu",
+            "no unpaywall rung is set, so it must inherit the resolved contact"
+        );
+    }
+
+    /// No file and no env is still the documented fallback — the ladder
+    /// must not have turned a missing config into an error or a blank
+    /// address.
+    #[test]
+    #[serial_test::serial]
+    fn an_absent_config_still_yields_the_documented_fallback() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8")
+            .to_string();
+        let _env = LadderEnv::scoped(&dir);
+
+        let contact = resolve_contact_email();
+        assert_eq!(contact, FALLBACK_CONTACT_EMAIL);
+        assert_eq!(resolve_unpaywall_email(&contact), FALLBACK_CONTACT_EMAIL);
+    }
+
+    /// A blank value is not an address. Both rungs treat it as unset —
+    /// an empty `mailto:` reads to the upstream as no contact at all,
+    /// which is the state the field exists to avoid.
+    #[test]
+    #[serial_test::serial]
+    fn a_blank_value_on_either_rung_is_treated_as_unset() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = write_config(&td, "[network]\ncontact_email = \"   \"\n");
+        let mut env = LadderEnv::scoped(&dir);
+        env.set("DOIGET_CONTACT_EMAIL", "");
+
+        assert_eq!(resolve_contact_email(), FALLBACK_CONTACT_EMAIL);
+    }
 
     /// A Crossref `message` envelope (the shape `metadata_only_doi` stores
     /// in `MetadataOnlyOutcome.metadata`: `CrossrefSource` returns
@@ -4275,7 +4431,7 @@ async fn resolve_optional_chain(
     // fall-through could never ask the one source that reports more than one
     // location per work. The issue said the accessor was "the only missing
     // piece"; the wiring was missing too.
-    let openalex_contact = contact_email_from_env();
+    let openalex_contact = resolve_contact_email();
     let openalex = match optional_base("DOIGET_OPENALEX_BASE") {
         Some(base) => crate::sources::openalex::OpenalexSource::with_base(base, openalex_contact),
         None => crate::sources::openalex::OpenalexSource::new(openalex_contact),

--- a/crates/doiget-core/src/sources/europepmc.rs
+++ b/crates/doiget-core/src/sources/europepmc.rs
@@ -13,14 +13,30 @@
 //! `CapabilityProfile::from_env` from `DOIGET_ENABLE_EUROPE_PMC`, which
 //! is **off by default** (ADR-0040).
 //!
-//! ## OA subset only
+//! ## Retrievable, not "in the OA subset"
 //!
-//! Europe PMC indexes far more than it can give you: a record can be
-//! `inEPMC = "Y"` — present in the archive — while `isOpenAccess = "N"`,
-//! meaning the full text sits behind the publisher subscription. Only
-//! `isOpenAccess = "Y"` is accepted, and anything else is an explicit
-//! refusal rather than a hit, exactly as #415 requires. `inEPMC` is
-//! deliberately **not** the gate; it answers a different question.
+//! Europe PMC indexes far more than it can give you, and it reports the
+//! difference in three places that do not mean the same thing:
+//!
+//! * `inEPMC = "Y"` — the record is in the archive. It says nothing
+//!   about whether the full text is readable, so it is **not** the gate
+//!   (#415).
+//! * `isOpenAccess = "Y"` — the record is in the bulk OA subset. That is
+//!   a licensing / bulk-rights statement, and it is **reported, not a
+//!   veto** (#503).
+//! * `fullTextUrlList` — per-entry availability. An entry with
+//!   `documentStyle = "pdf"` and `availabilityCode` `F` (Free) or `OA`
+//!   is a specific claim that *this article's* PDF can be retrieved.
+//!
+//! The third is strictly weaker than the second, and it is the one
+//! doiget can act on, so it is the gate. `10.1098/rspa.2014.0585`
+//! (PMC4277194) is the record that motivated the change: `isOpenAccess
+//! = N`, and a 670 kB Free PDF sitting at `europepmc.org` — a host
+//! already on the `oa-publisher` allowlist. The old gate discarded it
+//! one line before `open_access_pdf_url` would have found it.
+//!
+//! A record that advertises no `F`/`OA` PDF entry is an explicit refusal
+//! rather than a hit, exactly as #415 requires.
 //!
 //! ## Retrieval goes through the existing OA chain, not this source
 //!
@@ -161,12 +177,20 @@ impl Source for EuropePmcSource {
             hint: format!("europepmc has no record for {}", doi.as_str()),
         })?;
 
-        // #415: OA subset only, as an explicit refusal rather than a retry.
-        if !is_open_access(record) {
+        // #503: refuse on "advertises nothing retrievable", not on
+        // "outside the OA subset". `isOpenAccess` is a bulk-rights
+        // statement; `fullTextUrlList` reports single-article
+        // retrievability per entry, and the second can be true while the
+        // first is false. Gating on the subset threw away Free PDFs at
+        // `europepmc.org` — already an `oa-publisher` allowlist host —
+        // one line before the code written to find them. The flags stay
+        // in the refusal because they are what a reader checks next.
+        if open_access_pdf_url(record).is_none() {
             return Err(FetchError::SourceSchema {
                 hint: format!(
-                    "europepmc record is indexed but not open access \
-                     (isOpenAccess = {}, inEPMC = {})",
+                    "europepmc record advertises no retrievable PDF: no \
+                     fullTextUrlList entry has documentStyle = pdf with \
+                     availabilityCode F or OA (isOpenAccess = {}, inEPMC = {})",
                     flag(record, "isOpenAccess").unwrap_or("absent"),
                     flag(record, "inEPMC").unwrap_or("absent"),
                 ),
@@ -212,9 +236,14 @@ fn flag<'a>(record: &'a serde_json::Value, name: &str) -> Option<&'a str> {
 /// True only for `isOpenAccess == "Y"`.
 ///
 /// Deliberately **not** `inEPMC`: a record can be in the archive while its
-/// full text is subscription-only, so gating on presence rather than
-/// openness would return records doiget cannot retrieve. Absent counts as
-/// not open.
+/// full text is subscription-only, so presence is not openness. Absent
+/// counts as not open.
+///
+/// Since #503 this is **reported, not a veto**: `isOpenAccess` describes
+/// membership of the bulk OA subset, and `fetch` gates on the strictly
+/// weaker per-entry claim that [`open_access_pdf_url`] reads. The value
+/// still travels to the caller inside `metadata_json`, and still appears
+/// in the refusal message when nothing retrievable is advertised.
 #[must_use]
 pub fn is_open_access(record: &serde_json::Value) -> bool {
     flag(record, "isOpenAccess") == Some("Y")
@@ -322,6 +351,33 @@ mod tests {
         ]}
     }"#;
 
+    /// #503, observed live on 10.1098/rspa.2014.0585 (PMC4277194): the
+    /// record is OUTSIDE the bulk OA subset (`isOpenAccess = N`) and
+    /// still advertises a Free PDF at `europepmc.org`. Fetching that URL
+    /// by hand returned 670 kB of `application/pdf`.
+    const SAMPLE_CLOSED_SUBSET_WITH_FREE_PDF: &str = r#"{
+        "hitCount": 1,
+        "resultList": {"result": [
+            {
+                "id": "PMC4277194",
+                "source": "PMC",
+                "doi": "10.1098/rspa.2014.0585",
+                "title": "Continuous analogues of matrix factorizations.",
+                "pubYear": "2015",
+                "isOpenAccess": "N",
+                "inEPMC": "Y",
+                "fullTextUrlList": {"fullTextUrl": [
+                    {"availability": "Free", "availabilityCode": "F",
+                     "documentStyle": "pdf", "site": "Europe_PMC",
+                     "url": "https://europepmc.org/articles/PMC4277194?pdf=render"},
+                    {"availability": "Subscription required", "availabilityCode": "S",
+                     "documentStyle": "doi", "site": "DOI",
+                     "url": "https://doi.org/10.1098/rspa.2014.0585"}
+                ]}
+            }
+        ]}
+    }"#;
+
     const SAMPLE_EMPTY: &str = r#"{"hitCount": 0, "resultList": {"result": []}}"#;
 
     fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
@@ -409,10 +465,15 @@ mod tests {
 
     /// The trap this gate exists for. `inEPMC = Y` means the record is in
     /// the archive; it says nothing about whether the full text is
-    /// readable. Gating on presence instead of openness would hand back
-    /// records doiget cannot retrieve.
+    /// readable. Gating on presence would hand back records doiget cannot
+    /// retrieve.
+    ///
+    /// Since #503 the refusal is for the narrower reason — this fixture
+    /// advertises no `fullTextUrlList` at all — and the message must say
+    /// so, or it cannot be told apart from
+    /// `closed_subset_record_with_a_free_pdf_is_accepted` below.
     #[tokio::test]
-    async fn in_epmc_but_not_open_access_is_refused() {
+    async fn in_epmc_with_no_retrievable_pdf_is_refused() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/europepmc/webservices/rest/search"))
@@ -435,6 +496,50 @@ mod tests {
         assert!(
             msg.contains("isOpenAccess = N") && msg.contains("inEPMC = Y"),
             "the refusal must say WHY, naming both flags; got: {msg}"
+        );
+        assert!(
+            msg.contains("no retrievable PDF"),
+            "the refusal must be about retrievability, not subset membership \
+             — the two are distinguishable and #503 was the case where they \
+             differ; got: {msg}"
+        );
+    }
+
+    /// #503. `isOpenAccess = N` is a statement about the bulk OA subset,
+    /// and the record still carries a Free PDF at an already-allowlisted
+    /// host. Refusing here discarded a copy doiget could retrieve, one
+    /// line before `open_access_pdf_url` — which already accepted `F` —
+    /// would have found it.
+    #[tokio::test]
+    async fn closed_subset_record_with_a_free_pdf_is_accepted() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/europepmc/webservices/rest/search"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(SAMPLE_CLOSED_SUBSET_WITH_FREE_PDF),
+            )
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = EuropePmcSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1098/rspa.2014.0585").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("a Free PDF entry is retrievable even outside the OA subset");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+        let rec = got.metadata_json.expect("record");
+        assert_eq!(
+            open_access_pdf_url(&rec),
+            Some("https://europepmc.org/articles/PMC4277194?pdf=render"),
+            "the URL the oa-publisher leg will fetch must survive to the caller"
+        );
+        assert!(
+            !is_open_access(&rec),
+            "the subset flag is reported, not corrected — a caller that \
+             cares can still read it"
         );
     }
 

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -317,6 +317,14 @@ struct RawNetwork {
     /// open-access registry allowlist (issue #405). See [`oa_registry_hosts`].
     #[serde(default)]
     trust_oa_registries: bool,
+    /// `[network] contact_email` — the polite-pool contact address (#504).
+    #[serde(default)]
+    contact_email: Option<String>,
+    /// `[network] unpaywall_email` — written by `config init` since 0.7 and
+    /// parsed by nobody until #504, so every fetch on a machine configured
+    /// from the template went out as `doiget@localhost`.
+    #[serde(default)]
+    unpaywall_email: Option<String>,
     #[serde(flatten)]
     _other: serde::de::IgnoredAny,
 }
@@ -357,6 +365,13 @@ pub struct UserExtensionConfig {
     /// The CLI and MCP resolvers own that step, and both place this rung
     /// below `DOIGET_STORE_ROOT` and above the cwd default (ADR-0036).
     pub store_root: Option<String>,
+    /// `[network] contact_email`, trimmed, when present and non-empty
+    /// (#504). Rung below `DOIGET_CONTACT_EMAIL`.
+    pub contact_email: Option<String>,
+    /// `[network] unpaywall_email`, trimmed, when present and non-empty
+    /// (#504). Rung below `DOIGET_UNPAYWALL_EMAIL`, itself above
+    /// [`Self::contact_email`].
+    pub unpaywall_email: Option<String>,
 }
 
 /// Returns the built-in curated set of academic institution host patterns.
@@ -465,6 +480,13 @@ fn parse_str(
     let raw_net = raw.network.unwrap_or_default();
     let trust_academic_repos = raw_net.trust_academic_repos;
     let trust_oa_registries = raw_net.trust_oa_registries;
+    // Same "blank means unset" rule as `[store] root` below: an empty
+    // address would be sent as an empty `mailto:` and read to the upstream
+    // as no contact at all, which is the state the field exists to avoid.
+    let trim_nonempty =
+        |v: Option<String>| v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    let contact_email = trim_nonempty(raw_net.contact_email);
+    let unpaywall_email = trim_nonempty(raw_net.unpaywall_email);
     let raw_hosts = raw_net.additional_hosts;
 
     // Two-phase: collect ALL invalid patterns rather than failing on
@@ -504,7 +526,121 @@ fn parse_str(
         trust_academic_repos,
         trust_oa_registries,
         store_root,
+        contact_email,
+        unpaywall_email,
     })
+}
+
+/// Why the config directory could not be resolved.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigDirError {
+    /// An environment variable is set to a non-UTF-8 value.
+    ///
+    /// An error rather than a fall-through: silently trying the next rung
+    /// would resolve a *different* file from the one the user configured,
+    /// and report success.
+    #[error("{key} is not valid UTF-8")]
+    NotUnicode {
+        /// The offending variable.
+        key: &'static str,
+    },
+    /// None of `XDG_CONFIG_HOME`, `APPDATA`, `HOME` or `USERPROFILE` is set.
+    #[error("neither HOME nor USERPROFILE is set")]
+    NoHome,
+}
+
+/// Read an env var, treating blank as unset and non-UTF-8 as an error.
+fn env_utf8(key: &'static str) -> Result<Option<String>, ConfigDirError> {
+    match std::env::var(key) {
+        Ok(s) if s.is_empty() => Ok(None),
+        Ok(s) => Ok(Some(s)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(ConfigDirError::NotUnicode { key }),
+    }
+}
+
+/// Config-directory resolution: `XDG_CONFIG_HOME`, then `APPDATA`
+/// (Windows), then `$HOME/.config`.
+///
+/// **The single source of truth.** This existed as two hand-maintained
+/// copies — `doiget-cli::commands::fetch::config_dir_utf8` and
+/// `doiget-mcp::config_dir_utf8` — whose own doc comment warned that
+/// divergence "would silently desync the user-extension allowlist
+/// surfaces". They had already diverged: the CLI copy accepted
+/// `XDG_CONFIG_HOME=""` and resolved a *relative* `doiget/config.toml`
+/// under the cwd, while the MCP copy treated blank as unset. Blank-is-
+/// unset is the answer kept here, because a relative config path is a
+/// silent wrong answer of exactly the #441 / #504 kind.
+///
+/// It lives in `doiget-core` because the fetch path needs it: with the
+/// resolver one crate up, `orchestrator` could not read `config.toml` at
+/// all, so every file-based setting had to be re-implemented in the CLI
+/// or go unread. `[network] unpaywall_email` went unread for four
+/// releases for that reason (#504).
+///
+/// No `dirs` dependency — every new dep adds cargo-vet exemption churn,
+/// and `expand_store_root` below already reads `HOME` directly.
+///
+/// # Errors
+///
+/// [`ConfigDirError::NotUnicode`] if a consulted variable is set to a
+/// non-UTF-8 value; [`ConfigDirError::NoHome`] if none is set.
+pub fn config_dir() -> Result<Utf8PathBuf, ConfigDirError> {
+    if let Some(s) = env_utf8("XDG_CONFIG_HOME")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    if let Some(s) = env_utf8("APPDATA")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    if let Some(s) = env_utf8("HOME")? {
+        return Ok(Utf8PathBuf::from(s).join(".config"));
+    }
+    if let Some(s) = env_utf8("USERPROFILE")? {
+        return Ok(Utf8PathBuf::from(s).join(".config"));
+    }
+    Err(ConfigDirError::NoHome)
+}
+
+/// `<config_dir>/doiget/config.toml` — the one file every reader means.
+///
+/// # Errors
+///
+/// As [`config_dir`].
+pub fn config_path() -> Result<Utf8PathBuf, ConfigDirError> {
+    Ok(config_dir()?.join("doiget").join("config.toml"))
+}
+
+/// The `config.toml` settings, or defaults when it is missing or
+/// unreadable.
+///
+/// Never fails: a caller on the fetch path wants the setting or the
+/// default, and one bad line in a config file must not take a fetch down.
+/// A read or parse failure is logged at `warn` — not swallowed — for the
+/// reason `store_root_from_config` records: TOML fails the whole document,
+/// so a typo anywhere makes every file rung disappear at once, and the
+/// resulting behaviour is indistinguishable from "nothing was configured".
+#[must_use]
+pub fn load_or_default() -> UserExtensionConfig {
+    let path = match config_path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(error = %e, "no config directory; config.toml not read");
+            return UserExtensionConfig::default();
+        }
+    };
+    match load(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "config.toml could not be read; its settings are ignored and defaults used \
+                 instead. Run `doiget config doctor` to see what is in effect."
+            );
+            UserExtensionConfig::default()
+        }
+    }
 }
 
 /// Turn a raw `[store] root` value into a path, expanding a leading `~`.

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3906,20 +3906,10 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
 /// case the caller downgrades to "user extension disabled" rather
 /// than failing the whole request.
 fn config_dir_utf8() -> anyhow::Result<Utf8PathBuf> {
-    if let Ok(s) = std::env::var("XDG_CONFIG_HOME") {
-        if !s.is_empty() {
-            return Ok(Utf8PathBuf::from(s));
-        }
-    }
-    if let Ok(s) = std::env::var("APPDATA") {
-        if !s.is_empty() {
-            return Ok(Utf8PathBuf::from(s));
-        }
-    }
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_err(|_| anyhow::anyhow!("neither HOME nor USERPROFILE is set"))?;
-    Ok(Utf8PathBuf::from(home).join(".config"))
+    // Delegated to `doiget_core::user_extension::config_dir` (#504): this
+    // was the second of three hand-maintained copies, and the CLI's
+    // already disagreed with it about a blank `XDG_CONFIG_HOME`.
+    Ok(doiget_core::user_extension::config_dir()?)
 }
 
 /// Resolve the provenance log path. Mirrors the CLI's precedence

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -180,7 +180,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
 | `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
-| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). OA subset only: gated on `isOpenAccess`, **not** `inEPMC` — a record can be in the archive while its full text is subscription-only (#415). |
+| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). Gated on the record advertising a retrievable PDF — a `fullTextUrlList` entry with `documentStyle = pdf` and `availabilityCode` `F` or `OA` (#503) — **not** on `inEPMC` (presence is not openness, #415) and **not** on `isOpenAccess` (bulk-subset membership, which is reported rather than a veto). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -127,9 +127,13 @@ impl CapabilityProfile {
     }
 }
 
-fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, CapabilityError> {
+// `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
+// BELOW the env var (#509, ADR-0050). The agreement has no file rung.
+fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+    -> Result<Option<TdmGrant>, CapabilityError>
+{
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
-    let key    = env::var(key_var).ok();
+    let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {
         (true, Some(k)) => Ok(Some(TdmGrant {
             // `secrecy` 0.10: `SecretString::from(String)` replaces the
@@ -152,6 +156,15 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 ```
 
 ### Three resolution rules
+
+The **key** may come from `DOIGET_KEY_<PUBLISHER>` or from
+`[tdm.<publisher>] api_key` in `credentials.toml`, env first
+([`CONFIG.md`](CONFIG.md) §6). The **agreement** has no file rung: it is
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` in the environment or it does not exist, so
+that it is an act taken in the session that runs the fetch rather than a
+boolean written once and forgotten ([`LEGAL.md`](LEGAL.md) §6a.2, ADR-0050).
+The three rules below are unchanged by that — a key from the file still needs
+the agreement, so rule 3 now also fires for a file-supplied key.
 
 1. **`agree=1` + key present** → `Some(TdmGrant)`. The source is enabled this session.
 2. **`agree=1` but key missing** → `Err(AgreedButNoKey)`. Startup fails; user has agreed

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,7 +22,8 @@ A value set higher in the chain overrides any value set lower.
 | `log.path` | POSIX: `$HOME/.config/doiget/access.log`. Windows: `%APPDATA%\doiget\access.log`. |
 | `log.retention_days` | `90` |
 | `network.user_agent` | `doiget/<version> (+https://github.com/QAtlasHub/doiget)` |
-| `network.unpaywall_email` | unset; if unset, Unpaywall calls go to non-polite pool |
+| `network.contact_email` | unset; if unset, every outbound request identifies as `doiget@localhost` and goes to the non-polite pool |
+| `network.unpaywall_email` | unset; falls back to `network.contact_email` |
 | `network.connect_timeout_sec` | `10` |
 | `network.read_timeout_sec` | `60` |
 | `network.total_timeout_sec` | `300` |
@@ -62,6 +63,12 @@ retention_days = 90
 
 [network]
 user_agent = "doiget/0.1.0 (+https://github.com/QAtlasHub/doiget; user=alice@example.org)"
+# Polite-pool contact for every outbound request. Overridden by
+# DOIGET_CONTACT_EMAIL, one rung above. This is what `doiget config doctor`
+# checks, and `doctor` names which rung answered.
+contact_email = "alice@example.org"
+# Only if Unpaywall should see a different address. Overridden by
+# DOIGET_UNPAYWALL_EMAIL; falls back to contact_email above.
 unpaywall_email = "alice@example.org"
 connect_timeout_sec = 10
 read_timeout_sec = 60
@@ -196,18 +203,29 @@ All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` 
 | `DOIGET_LOG_PATH` | `log.path` |
 | `DOIGET_LOG_RETENTION_DAYS` | `log.retention_days` |
 | `DOIGET_USER_AGENT` | `network.user_agent` |
-| `DOIGET_CONTACT_EMAIL` | Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
+| `DOIGET_CONTACT_EMAIL` | `network.contact_email`. Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
 | `DOIGET_UNPAYWALL_EMAIL` | `network.unpaywall_email` |
 | `DOIGET_MODE` | `output.mode` |
 | `NO_COLOR` | Forces `output.color = "never"` (xdg standard). |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | reqwest honors these (system standard). |
 
-With neither email set, doiget still queries Unpaywall — it sends the placeholder
+Both addresses are resolved **per field**, across the §1 chain: the env var, then
+`[network]` in `config.toml`, then the next-broader default. `DOIGET_UNPAYWALL_EMAIL` →
+`[network] unpaywall_email` → whatever `contact_email` resolved to → `doiget@localhost`.
+The more specific field wins at each rung.
+
+With neither set, doiget still queries Unpaywall — it sends the placeholder
 `doiget@localhost`, which lands in the non-polite pool and may be rate-limited or refused.
-Setting `DOIGET_CONTACT_EMAIL` is therefore worth doing before any batch run, and it is what
-`doiget config doctor` flags. It also makes the automatic arXiv preprint fallback reliable:
-when a DOI's OA PDF is blocked, doiget retries via the arXiv preprint that Unpaywall named,
-so a throttled Unpaywall response costs you that fallback too.
+Setting one is worth doing before any batch run, and it is what `doiget config doctor`
+flags. It also makes the automatic arXiv preprint fallback reliable: when a DOI's OA PDF is
+blocked, doiget retries via the arXiv preprint that Unpaywall named, so a throttled
+Unpaywall response costs you that fallback too — and the run still exits 0 saying
+`no OA PDF available`, which is why a degraded search and a true negative looked the same.
+
+`doiget config doctor` reports **which rung answered**, e.g.
+`[ ok ] contact_email set (from: [network] contact_email in config.toml)`. Before #504 the
+file rung did not exist for either address, so a `config.toml` written from the `config init`
+template was inert while `doctor` reported the store root correctly from the same file.
 
 CapabilityProfile-related env vars are documented in [`CAPABILITY.md`](CAPABILITY.md).
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -251,21 +251,21 @@ mode resolution above.
 
 ## 6. Credentials file
 
+This file carries **API keys only**. The per-publisher agreement is
+environment-only and cannot be given here — see below, and ADR-0050.
+
 ```toml
-# ~/.config/doiget/credentials.toml — optional, alternative to env vars
-# Permissions MUST be 0600 on POSIX; doiget warns at startup otherwise.
+# ~/.config/doiget/credentials.toml — optional.
+# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
 
 [tdm.elsevier]
 api_key = "..."
-agreed = true
 
 [tdm.aps]
 api_key = "..."
-agreed = true
 
 [tdm.springer]
 api_key = "..."
-agreed = true
 
 # Requires a build with `--features tdm-ieee`. The endpoint and response
 # shape are INFERRED from IEEE's public developer portal, not confirmed
@@ -274,10 +274,33 @@ agreed = true
 # rather than silently returning nothing.
 [tdm.ieee]
 api_key = "..."
-agreed = true
 ```
 
-If both env var and credentials.toml provide the same key, env var wins.
+**Precedence.** `DOIGET_KEY_<PUBLISHER>` wins over `[tdm.<publisher>] api_key`,
+per §1. A blank value on either rung counts as unset.
+
+**The agreement is not here.** Each TDM source needs
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, in addition to a key
+from either rung. An `agreed` key in this file is read only so doiget can warn
+that it does nothing; it grants nothing. [`LEGAL.md`](LEGAL.md) §6a.2 makes the
+agreement an *enforced control*, and part of why it is meaningful is that it is
+an act taken in the session that runs the fetch — a boolean written once into a
+file and forgotten is weaker, and weakening it as a side effect of adding a
+convenience is not a trade this file is worth (ADR-0050).
+
+So the three states are:
+
+| key | `DOIGET_AGREE_TDM_<PUB>=1` | result |
+|---|---|---|
+| env or file | yes | grant (if the `tdm-*` feature is compiled in) |
+| env or file | no | `KeyButNotAgreed` — refuses, names the variable |
+| none | yes | `AgreedButNoKey` — refuses, names both |
+
+**Before #509 this file was read by nothing.** It was specified here in full,
+including the `0600` warning, and no code path opened it; a user who followed
+this section wrote their key into a file doiget ignored and then reported the
+source unavailable for want of a key. Both the reader and the permission
+warning exist as of 0.8.11.
 
 ## 6.1 Institutional networks: what works and what does not
 

--- a/docs/DECISIONS/0049-invalid-ref-is-misuse.md
+++ b/docs/DECISIONS/0049-invalid-ref-is-misuse.md
@@ -1,0 +1,87 @@
+# 0049 - An unparsable ref is misuse (exit 2), and one function decides it
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #492 (`fetch` exits 1, `graph` exits 2, `ERRORS.md` §4 says 2), found while doing #477
+
+## Context
+
+`docs/ERRORS.md` §4 is `Status: NORMATIVE` and reads:
+
+| Exit | Meaning |
+|---|---|
+| `1` | At least one fetch failed. |
+| `2` | Misuse (bad arguments, missing config). |
+
+Given `doiget <cmd> "not a doi"`, one binary answered two ways:
+
+- `commands/graph.rs` exited **2**, with a comment citing §4 and asserting it
+  was *"consistent with `fetch`'s INVALID_REF path"*.
+- `commands/fetch.rs` exited **1**, because `cli_exit_code` has no
+  `InvalidRef` arm and the value fell through `_ => 1`.
+- The eight commands #477 converted (`info`, `link`, `cite`, `text`, `tag`,
+  `bib`, `csl`, `source`) exited 1 with `fetch`, by design — that conversion
+  changed no exit code.
+
+So `graph`'s comment was false, and `fetch`'s 1 was not a decision: it was the
+catch-all. Against the table, nothing was fetched, so "at least one fetch
+failed" does not describe the run.
+
+`crates/doiget-cli/tests/fetch_error_mapping_e2e.rs` pinned it:
+
+```rust
+fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() { … .code(1) … }
+```
+
+#492 declined to change this in passing, and was right to: someone wrote that
+name and that assertion deliberately for #119, so either it encodes a decision
+§4 does not capture, or §4 is right and the test froze the catch-all. The two
+readings imply opposite changes.
+
+Reading #119 settles it. Its subject is the `error[INVALID_REF]:` *line* —
+replacing an opaque anyhow dump with the cargo-style message. The exit code
+came along as whatever `cli_exit_code` already returned. There is no argument
+in it for 1 over 2.
+
+## Decision
+
+**D1 — `ErrorCode::InvalidRef` maps to exit 2.** An unparsable ref is a bad
+argument. §4's 1 is reserved for a run in which a fetch was attempted and
+failed.
+
+**D2 — One function decides, and the call sites stop choosing.**
+`fetch::cli_exit_code` is the single mapping; `graph` no longer hard-codes its
+own 2. #477 unified the *message* through `render_ref_parse_error` and left the
+exit code per-call-site, which is precisely where the disagreement lived.
+
+**D3 — The rule is asserted across every ref-taking command, not just one.**
+`every_ref_taking_command_exits_2_for_an_invalid_ref` runs the same table as
+the message test, so a new subcommand is covered by both or by neither. A
+single-command assertion is what allowed this to persist: `fetch`'s exit code
+was pinned, and nothing compared it to its siblings.
+
+**D4 — §4 says which class an unparsable *value* is in.** The table listed
+"bad arguments" without settling whether that meant argv shape (what `clap`
+rejects) or a value that fails validation. It now says both are misuse, so the
+next reader does not have to re-derive it from two disagreeing call sites.
+
+## Consequences
+
+**Breaking for scripts keying on 1.** A caller that branched on `$? == 1` to
+mean "invalid ref" now sees 2. That is the point — 1 could equally have meant a
+network failure, a `NO_OA_AVAILABLE`, or any other code under the catch-all, so
+the previous behaviour did not distinguish what such a script believed it did.
+Recorded in `CHANGELOG.md` under **Changed**. Not in `docs/MIGRATION.md`,
+which covers BiblioFetch.jl and machine moves rather than CLI contract
+changes.
+
+**The rejected alternative.** #492's option 2 — keep `fetch` at 1 and move
+`graph` to 1, adding a sentence to §4 saying "misuse" means argv shape only —
+has the smaller blast radius and was not chosen. It would make `INVALID_REF`
+the one closed error code whose exit value is the *unclassified* one, and it
+would leave `Ambiguous` (already 2, for a value that fails to select one
+entity) sitting next to `InvalidRef` at 1, for a value that fails to parse.
+
+**No new code.** The mapping already existed and already had a home; this adds
+one arm and deletes one hard-coded literal.

--- a/docs/DECISIONS/0050-credentials-file-carries-the-key-not-the-agreement.md
+++ b/docs/DECISIONS/0050-credentials-file-carries-the-key-not-the-agreement.md
@@ -1,0 +1,93 @@
+# 0050 - credentials.toml carries the key; the agreement stays in the environment
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0047](0047-legal-claims-are-read-off-the-code.md) — same audit; that ADR corrected the claim, this one closes the gap the claim was about
+- **Source:** #509 (a credentials file documented in full and read by nothing)
+
+## Context
+
+`docs/CONFIG.md` is `Status: NORMATIVE`. Its §6 gave a complete schema for
+`~/.config/doiget/credentials.toml` — four `[tdm.<publisher>]` tables, an
+`api_key` and an `agreed` per table, a precedence rule against the environment,
+and a `0600` permission warning "at startup".
+
+Nothing read the file. The TDM resolver in `crates/doiget-core/src/lib.rs`
+called `std::env::var` and stopped there, `credentials.toml` appeared in exactly
+one non-prose place (a doc comment about the config *directory*), and the
+permission warning did not exist either — the only `permissions()` calls in the
+tree were a store write and a writability probe.
+
+The cost is specific. Follow the NORMATIVE document, write an Elsevier key into
+that file with `agreed = true`, and doiget silently ignores it and reports the
+source unavailable for want of a key. `config doctor` could not help: it points
+at "docs/CONFIG.md §6", the section describing the file that does nothing.
+
+Same shape as #476, #441, #442, #454 and #458 — a documented mechanism with no
+implementation behind it. This one landed on credentials, in a NORMATIVE doc,
+with a security claim attached.
+
+#509 offered two ways out, and they are not equivalent: implement it, or delete
+the documentation.
+
+## Decision
+
+**D1 — Implement the file, for the key.** A long-lived API key is genuinely
+better off in a file than in the environment: it survives a shell restart, it is
+not visible in `ps`, and it does not leak into the environment of every
+subprocess. `crates/doiget-core/src/credentials.rs` reads
+`[tdm.<publisher>] api_key`, and `DOIGET_KEY_<PUBLISHER>` sits one rung above it
+— the same env-then-file order `store_root` (#441) and `contact_email` (#504)
+use, and the order `CONFIG.md` §1 has always claimed.
+
+**D2 — The agreement does not follow the key into the file.**
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` stays environment-only.
+
+`LEGAL.md` §6a.2 lists the per-publisher agreement as an *enforced control*, and
+part of what makes it meaningful is that it is an act taken in the session that
+runs the fetch. A boolean written once into a config file and forgotten is a
+weaker consent for the same word. #509 flagged this and asked for it to be an
+explicit decision rather than a side effect; this is that decision.
+
+The rules in `CAPABILITY.md` §2 are unchanged by the new rung, which is the
+point: a key from the file still needs the agreement, so `KeyButNotAgreed` now
+also fires for a file-supplied key with no agreement variable.
+
+**D3 — An `agreed` key in the file is reported, not discarded.** It is parsed
+solely so doiget can warn that it grants nothing and name the variable that
+does. Silently ignoring a field this document specified is the defect being
+closed; doing it again in the fix would be worse than not fixing it.
+
+**D4 — The `0600` warning exists, and is POSIX-only.** Group- or
+world-accessible modes emit a `tracing::warn!` naming the mode and the `chmod`.
+Off POSIX it is a no-op: Windows ACLs are not a mode, and advice phrased in
+`chmod` terms would be advice the user cannot follow. `CONFIG.md` §6 says
+"SHOULD ... doiget warns" rather than "MUST", because a warning is what is
+enforced.
+
+## Consequences
+
+**Positive.**
+
+- The NORMATIVE document is true again. `LEGAL.md` §6a.1 can state the file as a
+  credential source without #494's correction attached.
+- The security claim is real: the permission check is code, not a sentence.
+- The opt-in is not diluted. §6a.2 still names an act, not a stored boolean.
+
+**Negative.**
+
+- A new file-parsing surface in the credential path. Bounded: absent,
+  unreadable and malformed all yield "no keys" with a `warn`, so one bad line
+  cannot take a fetch down, and there is no accessor for `agreed` at all — the
+  type cannot carry it, so no future caller can be tempted to consult one.
+- Configuration is now in two files. `config doctor` reports which rung answered
+  for the addresses (#504); it does not yet do so for keys, and deliberately
+  will not print a key.
+
+**Testing note, learned here.** Adding a file rung made the existing
+`CapabilityProfile::from_env` tests depend on the developer's real
+`~/.config/doiget/credentials.toml` — green in CI and red on the one machine
+that has TDM configured. They now run under an isolated config home. A rung that
+reads a file outside the test's control is not a detail of the test harness; it
+is a property of the change.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -65,6 +65,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
 | 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
+| 0049 | An unparsable ref is misuse (exit 2), and one function decides it | Accepted | `fix/492-invalid-ref-exit-code` | #492 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -65,6 +65,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
 | 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
+| 0050 | credentials.toml carries the key; the agreement stays in the environment | Accepted | `feat/509-credentials-file` | #509 |
 
 ## Conventions
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -206,8 +206,8 @@ Neither ever renders "no trace" as `[]`.
 | Exit | Meaning |
 |---|---|
 | `0` | Success (all refs ok). |
-| `1` | At least one fetch failed. |
-| `2` | Misuse (bad arguments, missing config). |
+| `1` | At least one fetch was attempted and failed. |
+| `2` | Misuse — a bad argument or missing config. Covers both an argv shape `clap` rejects **and** a well-formed argument whose *value* fails validation, which is why `INVALID_REF` and `AMBIGUOUS` are both 2 (ADR-0049). |
 | `3` | Capability denied (no source could serve). |
 | `4` | I/O failure (store / log unwritable). |
 | `64..=78` | `sysexits.h` mapping for select cases. |

--- a/docs/INTEGRATION/README.md
+++ b/docs/INTEGRATION/README.md
@@ -1,42 +1,58 @@
 # Integration guides
 
-> **Status: INFORMATIVE (placeholder).** Concrete host-integration snippets land
-> in **Phase 3** alongside the MCP server (`doiget serve`). Until then, this
-> directory is a pointer rather than a recipe collection.
+> **Status: INFORMATIVE.** `doiget serve` ships; these are the host-side
+> snippets. Each page states whether it has been exercised against that
+> host, and the ones that have not say so.
 
-## Why this is empty today
+`doiget serve` is a stdio MCP server. It is the same entry point everywhere —
+`mcpb/manifest.json` runs `doiget serve`, and so does the MCP Registry entry.
+The differences between hosts are only where the config file lives and what it
+is called.
 
-Phase 0 ships specifications (see [`../MCP_TOOLS.md`](../MCP_TOOLS.md) and
-[`../PUBLIC_API.md`](../PUBLIC_API.md)) but no functional MCP server. Without a
-runnable `doiget serve`, integration snippets would either be untested aspirational
-config or would lead a reader to a Phase 0 stub error. Phase 3 ships the actual
-server and the corresponding host snippets in this directory.
-
-## Planned files (Phase 3)
-
-| File | Host | Status |
+| File | Host | Exercised? |
 |---|---|---|
-| `claude-desktop.md` | Claude Desktop (stdio MCP) | Phase 3 (stub) |
-| `cursor.md` | Cursor | Phase 3 (stub) |
-| `codex.md` | OpenAI Codex CLI | Phase 3 (stub) |
-| `claude-code.md` | Claude Code (this tool) | Phase 3 (stub) |
-| `obsidian.md` | Obsidian backend export | Phase 7 (optional, stub) |
-| `chain-with-paperqa.md` | Composition with paper-qa for content processing | Phase 3+ (stub) |
+| [`claude-code.md`](./claude-code.md) | Claude Code | **Yes** — this is what the project is developed under |
+| [`claude-desktop.md`](./claude-desktop.md) | Claude Desktop (`.mcpb`, or manual stdio) | **Yes**, for the `.mcpb` route (shipping since 0.8.4) |
+| [`cursor.md`](./cursor.md) | Cursor | No |
+| [`codex.md`](./codex.md) | OpenAI Codex CLI | No |
+| [`obsidian.md`](./obsidian.md) | Obsidian | Not applicable — Obsidian hosts no MCP server; the page says what does work |
+| [`chain-with-paperqa.md`](./chain-with-paperqa.md) | Composition with paper-qa | No, as a chain |
 
-## What to read in the meantime
+## The one setting to get right
 
-- **MCP tool spec:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tool surface
-  Phase 3 will expose. Sufficient to plan a host integration in advance.
-- **Public Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders that
-  link `doiget-core` directly rather than going through the MCP server.
-- **Architecture overview:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — for
-  how tools, transport, and the capability gate fit together.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and the
-  `~/.config/doiget/` layout that any host-side wiring will need to respect.
+`DOIGET_STORE_ROOT`, as an absolute path.
+
+The store root defaults to `./papers` **relative to the process's working
+directory** (ADR-0036). For a CLI run that is exactly right — artifacts land
+where you are working. For an MCP server it is not: the working directory
+belongs to the host, so the store lands somewhere you did not choose and a
+later CLI run does not see it. That is
+[#369](https://github.com/QAtlasHub/doiget/issues/369).
+
+`DOIGET_CONTACT_EMAIL` is the second one. Without it every request goes out as
+`doiget@localhost` on the non-polite pool, where a throttled answer is
+indistinguishable from "this paper has no OA copy"
+([#504](https://github.com/QAtlasHub/doiget/issues/504)).
+
+Everything else is off by default and documented in
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Also worth reading
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — every tool with its
+  JSON Schema. `doiget_capability_profile` reports the same thing at runtime
+  for the build you actually have.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — precedence and the
+  `config.toml` schema.
+- **Errors:** [`../ERRORS.md`](../ERRORS.md) — the closed set of error codes
+  and what an agent should do with each.
+- **Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders linking
+  `doiget-core` directly instead of going through MCP.
 
 ## Contributing a snippet
 
-If you have a working integration with an MCP host that is not in the planned list,
-open a GitHub Discussion describing the host, the JSON-RPC trace, and any
-host-specific config quirks. PRs adding a new file under `docs/INTEGRATION/` will
-be accepted in Phase 3+ once `doiget serve` is real and the snippet is verifiable.
+A working configuration for a host not listed here is welcome. Open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+host, the config file and its path, and anything host-specific that bit you —
+or a PR adding a page in the shape of the others, including an honest
+"exercised?" line.

--- a/docs/INTEGRATION/chain-with-paperqa.md
+++ b/docs/INTEGRATION/chain-with-paperqa.md
@@ -1,43 +1,55 @@
 # Chaining with paper-qa
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table this composition guide is scoped to
-> **Phase 3+** — `doiget serve` ships first, then a verified chain recipe.
+> **Status: UNTESTED as a chain.** Both halves are real — doiget writes PDFs to
+> a directory, paper-qa reads a directory of PDFs — but nobody has run the
+> composition end to end and reported back. Treat the shape below as the
+> intended design, not a verified recipe. Last checked 2026-08-26.
 
-[paper-qa](https://github.com/Future-House/paper-qa) is a retrieval-augmented
-question-answering system over scientific papers. The chain pattern this
-guide will document keeps `doiget`'s role narrow — DOI resolution, metadata,
-and content fetch via the tools in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — and
-hands the resulting documents to paper-qa for embedding, retrieval, and
-answer synthesis. Composition keeps each tool single-purpose and avoids
-duplicating retrieval logic inside `doiget`.
+[paper-qa](https://github.com/Future-House/paper-qa) does retrieval-augmented
+question answering over scientific papers. It handles embedding, retrieval and
+answer synthesis; doiget handles getting the papers, legally and with a
+provenance trail. Neither needs to know about the other, because the interface
+is a directory.
 
-## Configuration (Phase 3)
+## The shape
 
-The example below is intentionally empty. The chain shape depends on the
-final Phase 3 tool surface and on paper-qa's MCP/CLI ingestion entry point.
+```sh
+export DOIGET_STORE_ROOT="$HOME/papers"
+export DOIGET_CONTACT_EMAIL="you@institution.edu"
 
-```toml
-<!-- TODO Phase 3: paste verified doiget + paper-qa chain config here. -->
+# 1. Resolve and fetch a bibliography's references (OA only).
+doiget batch refs.bib
+
+# 2. Point paper-qa at the store.
+pqa -i "$HOME/papers" ask "what do these papers say about X?"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+`doiget batch` reports per-reference outcomes; the ones it could not fetch are
+named rather than dropped, so the corpus paper-qa sees is one you can account
+for.
 
-## What to read in the meantime
+## Why compose rather than integrate
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+doiget's job stops at "the bytes are on disk, and here is where they came
+from". Embedding and retrieval are a different problem with different
+dependencies, and duplicating either inside doiget would widen its network
+surface and its supply chain for no gain — see [`../SCOPE.md`](../SCOPE.md).
+
+The same argument means doiget will not ship a paper-qa plugin. The directory
+is the integration.
+
+## What doiget gives you that a scraper does not
+
+- **Provenance.** Every fetch is a hash-chained row in the append-only log
+  ([`../PROVENANCE_LOG.md`](../PROVENANCE_LOG.md)), so the corpus behind an
+  answer is auditable.
+- **Licence, per entry.** The sidecar records it, which matters as soon as an
+  answer is quoted.
+- **A refusal you can read.** A blocked paper produces a named reason and a
+  remediation, not a silent gap in the corpus.
 
 ## Contributing
 
-If you have a working `doiget` + paper-qa chain ahead of Phase 3, open a
-GitHub Discussion with the orchestration script and any host-specific quirks
-rather than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you run this, the useful thing to report is the orchestration script and
+any paper-qa-side quirks — open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions).

--- a/docs/INTEGRATION/claude-code.md
+++ b/docs/INTEGRATION/claude-code.md
@@ -1,40 +1,99 @@
 # Claude Code integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED.** The `claude mcp add` form below is the configuration
+> this project is developed under. Last checked 2026-08-26 against
+> `doiget 0.8.10`.
 
-[Claude Code](https://www.anthropic.com/claude-code) is Anthropic's official
-CLI and supports MCP servers. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as an MCP server in Claude Code (via
-`claude mcp add` or a project-scoped `.mcp.json`) so that the tool surface
-listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) is callable from Claude Code
-sessions.
+[Claude Code](https://www.anthropic.com/claude-code) hosts MCP servers over
+stdio. `doiget serve` is the entry point — the same one
+[`mcpb/manifest.json`](../../mcpb/manifest.json) and the
+[MCP Registry](https://registry.modelcontextprotocol.io/) use.
 
-## Configuration (Phase 3)
+Install `doiget` first (see [`../../README.md`](../../README.md) §Installation);
+it must be on `PATH`, or give an absolute path below.
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+## One line
+
+```sh
+claude mcp add doiget -- doiget serve
+```
+
+With the environment set at the same time, and available in every project
+rather than only this one:
+
+```sh
+claude mcp add doiget --scope user \
+  -e DOIGET_STORE_ROOT="$HOME/papers" \
+  -e DOIGET_CONTACT_EMAIL="you@institution.edu" \
+  -- doiget serve
+```
+
+`--scope` is `local` (this project, private) by default; `user` is every
+project, `project` writes the committed `.mcp.json` below. `claude mcp add
+--help` lists the rest.
+
+## Project-scoped `.mcp.json`
+
+Committed at the repository root, this shares the server with everyone who
+opens the project:
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Code .mcp.json entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "type": "stdio",
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "${HOME}/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+On Windows, `command` is the full path if `doiget` is not on `PATH`, e.g.
+`"C:/Users/<you>/AppData/Local/Programs/doiget/doiget"`.
+
+## Environment
+
+`DOIGET_STORE_ROOT` is the one to set. Without it the store root defaults to
+`./papers` **relative to the process's working directory** (ADR-0036), which
+for an MCP server is the host's, not yours — #369 is that mistake. Set it to
+an absolute path and the store is the same one `doiget` on the command line
+uses.
+
+| Variable | Why |
+|---|---|
+| `DOIGET_STORE_ROOT` | Absolute path to the paper store. Set this. |
+| `DOIGET_CONTACT_EMAIL` | Polite-pool contact for Crossref / Unpaywall. Without it requests go out as `doiget@localhost` from the non-polite pool, where a throttled answer is indistinguishable from "no OA copy" (#504). |
+| `DOIGET_UNPAYWALL_EMAIL` | Only if it differs from the contact address. |
+| `DOIGET_ENABLE_OPENALEX`, `DOIGET_ENABLE_EUROPE_PMC`, `DOIGET_ENABLE_CORE`, `DOIGET_ENABLE_OPENAIRE`, `DOIGET_ENABLE_HAL`, `DOIGET_ENABLE_DATACITE`, `DOIGET_ENABLE_S2`, `DOIGET_ENABLE_DOAJ` | Widen the search past the three always-on sources. **All off by default** (ADR-0040) — with none of them set, `no OA PDF available` means only that Crossref, Unpaywall and arXiv had nothing. |
+| `DOIGET_CORE_API_KEY` | Optional free CORE key; raises that source's rate limit. |
+
+Full precedence and the complete list: [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+**A build caveat, once.** Those `DOIGET_ENABLE_*` flags need the `metadata`
+feature compiled in. The official release binaries and the `.mcpb` are built
+`--features oa-only,citation` (which implies `metadata`), so they work there.
+A binary you built yourself with the default `oa-only` will log a warning and
+leave the source unavailable — `doiget_capability_profile` reports the truth
+for the binary you actually have.
+
+## Checking it worked
+
+```
+/mcp
 ```
 
-## What to read in the meantime
+should list `doiget`. Then ask the model to call `doiget_health` — it reports
+the version, whether the store is writable, and where the store actually is,
+which is the fastest way to catch a wrong `DOIGET_STORE_ROOT`.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Tool surface
 
-## Contributing
-
-If you have a working Claude Code integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+22 tools, enumerated with their JSON Schemas in
+[`../MCP_TOOLS.md`](../MCP_TOOLS.md). `doiget_capability_profile` reports which
+sources this particular build and environment may use.

--- a/docs/INTEGRATION/claude-desktop.md
+++ b/docs/INTEGRATION/claude-desktop.md
@@ -1,39 +1,75 @@
 # Claude Desktop integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED for the `.mcpb` route** (shipping since 0.8.4; attached to
+> every GitHub Release). The manual JSON route below is the same stdio
+> invocation and is included for people who would rather not install an
+> extension. Last checked 2026-08-26.
 
-[Claude Desktop](https://claude.ai/download) is Anthropic's desktop client and
-hosts MCP servers over stdio. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as a tool provider in Claude Desktop's
-MCP configuration so that `resolve_doi`, `fetch_metadata`, and the rest of the
-tool surface in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are callable from a chat.
+[Claude Desktop](https://claude.ai/download) hosts MCP servers over stdio.
 
-## Configuration (Phase 3)
+## Recommended: install the `.mcpb` extension
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+Each [GitHub Release](https://github.com/QAtlasHub/doiget/releases) attaches
+`doiget-<version>.mcpb`. Download it and open it — Claude Desktop installs it
+as an extension. The bundle carries the binaries for macOS, Windows and Linux
+and picks the right one, so there is no PATH to configure.
+
+It asks for one setting, **Paper store location**, which becomes
+`DOIGET_STORE_ROOT`. Point it at a real directory you own; the default is
+`~/Documents/doiget-papers`.
+
+Requires Claude Desktop **0.10.0 or newer**
+(`mcpb/manifest.json` → `compatibility.claude_desktop`).
+
+## Manual: `claude_desktop_config.json`
+
+Settings → Developer → Edit Config. The file lives at:
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Desktop MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "/usr/local/bin/doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an **absolute** `command` path. A desktop app does not inherit the `PATH`
+your shell has, so a bare `doiget` frequently fails to launch with no visible
+error.
 
-## What to read in the meantime
+Restart Claude Desktop after editing.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Environment
 
-## Contributing
+`DOIGET_STORE_ROOT` matters more here than anywhere else: the working
+directory of a GUI-launched process is not a directory you chose, so the
+`./papers` default (ADR-0036) lands somewhere arbitrary. That was #369.
 
-If you have a working Claude Desktop integration ahead of Phase 3, open a
-GitHub Discussion with the JSON-RPC trace and host-side config rather than a
-PR — see [`README.md`](./README.md) §Contributing a snippet.
+The remaining variables are the same as for Claude Code — see
+[`claude-code.md`](./claude-code.md) §Environment,
+[`../CONFIG.md`](../CONFIG.md) and [`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Checking it worked
+
+Ask for `doiget_health`. It reports the version, store writability and the
+resolved store path.
+
+## Verifying the download
+
+Every release asset except the `.mcpb` currently ships `.sha256` and
+`.cosign.bundle` sidecars; [#483](https://github.com/QAtlasHub/doiget/issues/483)
+adds them for the `.mcpb` too. Until it lands, verify the raw binary if you
+need a signature check, and install that manually per above.

--- a/docs/INTEGRATION/codex.md
+++ b/docs/INTEGRATION/codex.md
@@ -1,39 +1,33 @@
 # OpenAI Codex CLI integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Codex CLI as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server, and the snippet below is the standard stdio shape,
+> but this specific host has not been exercised. Report success or failure on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512).
 
-[OpenAI Codex CLI](https://github.com/openai/codex) is OpenAI's terminal-native
-coding agent and supports MCP servers. Once `doiget serve` ships in Phase 3,
-this guide will document how to register `doiget` as an MCP server in Codex
-CLI so that the tools enumerated in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Codex sessions.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative TOML from
-elsewhere — wait for the verified Phase 3 snippet.
+[Codex CLI](https://github.com/openai/codex) reads `~/.codex/config.toml`.
+MCP servers go under `[mcp_servers.<name>]`:
 
 ```toml
-<!-- TODO Phase 3: paste verified Codex CLI MCP server entry here. -->
+[mcp_servers.doiget]
+command = "doiget"
+args = ["serve"]
+
+[mcp_servers.doiget.env]
+DOIGET_STORE_ROOT = "/home/you/papers"
+DOIGET_CONTACT_EMAIL = "you@institution.edu"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on `PATH`.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment, [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
 
-## Contributing
+## Checking it worked
 
-If you have a working Codex CLI integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Ask for `doiget_health`, then `doiget_capability_profile`.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/cursor.md
+++ b/docs/INTEGRATION/cursor.md
@@ -1,39 +1,44 @@
 # Cursor integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Cursor as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server with no host-specific behaviour, and the snippet
+> below is the standard stdio shape — but nobody has run it in Cursor and
+> reported back. If you do, please say so on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512) and this banner
+> comes off.
 
-[Cursor](https://www.cursor.com/) is an AI-first code editor that supports MCP
-servers. Once `doiget serve` ships in Phase 3, this guide will show how to
-register `doiget` as an MCP server in Cursor so that DOI resolution, metadata
-fetch, and the other tools listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Cursor's agent.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+[Cursor](https://www.cursor.com/) supports MCP servers. Configuration is a
+`mcp.json` file: `.cursor/mcp.json` inside a project, or `~/.cursor/mcp.json`
+for every project.
 
 ```json
-<!-- TODO Phase 3: paste verified Cursor MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on the `PATH` the editor
+inherits.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment. `DOIGET_STORE_ROOT` is the one that silently misbehaves if
+omitted (ADR-0036, #369).
 
-## Contributing
+## Checking it worked
 
-If you have a working Cursor integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Have the agent call `doiget_health`. If Cursor's own MCP panel reports the
+server as connected but no tool is callable, `doiget_capability_profile` will
+say what this build is allowed to do.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/obsidian.md
+++ b/docs/INTEGRATION/obsidian.md
@@ -1,42 +1,42 @@
-# Obsidian backend export
+# Obsidian
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table, an Obsidian backend export is scoped to
-> **Phase 7 (optional)** — this stub exists so future contributors have an
-> obvious landing place rather than a 404.
+> **Status: NOT IMPLEMENTED, and this page says what does work instead.**
+> There is no Obsidian backend export and none is in progress. The
+> "Phase 7 (optional)" marker in the planned-files table is the only
+> commitment, and it is not a schedule. Last checked 2026-08-26.
 
-[Obsidian](https://obsidian.md/) is a markdown-based knowledge base. The
-Phase 7 Obsidian backend export will, when shipped, let `doiget` write
-metadata and citation records into an Obsidian vault as plain Markdown notes
-with frontmatter, so that the same data exposed by the MCP tools in
-[`../MCP_TOOLS.md`](../MCP_TOOLS.md) can be browsed inside Obsidian.
+Obsidian does not host MCP servers, so there is nothing to register. What
+exists today is that doiget's store is **plain files**, so a vault can sit on
+top of it with no integration at all.
 
-## Configuration (Phase 3)
+## What doiget writes
 
-The example below is intentionally empty. The Obsidian backend export is a
-Phase 7 deliverable; even the Phase 3 wiring is not yet implemented.
+One TOML sidecar and one PDF per entry, under `DOIGET_STORE_ROOT`. The layout
+and the field contract are in [`../STORE.md`](../STORE.md).
 
-```toml
-<!-- TODO Phase 3: paste verified Obsidian export config block here. -->
+Point the store at a folder inside your vault:
+
+```sh
+export DOIGET_STORE_ROOT="$HOME/Vault/papers"
+doiget fetch 10.1103/PhysRevLett.130.200601
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+The PDFs are then openable from Obsidian, and the sidecars are readable text.
+They are **TOML, not Markdown with YAML frontmatter**, so Obsidian will not
+index them as notes and Dataview will not see them.
 
-## What to read in the meantime
+## What is missing, precisely
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+A Markdown-with-frontmatter projection of the sidecar. That is the whole of
+the "Obsidian backend export" idea, and it is not implemented — not the wiring,
+not the frontmatter schema, not a `doiget` subcommand.
+
+`doiget csl <ref>` and `doiget bib <ref>` emit CSL-JSON and BibTeX from the
+same records, which is enough to script a projection yourself.
 
 ## Contributing
 
-If you have a working Obsidian export workflow ahead of Phase 7, open a
-GitHub Discussion describing the vault layout and frontmatter shape rather
-than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you build one, open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+vault layout and the frontmatter shape before a PR — the schema is the part
+worth agreeing on first.

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -211,30 +211,44 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from **environment variables**
-   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
-   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
-   `tracing` redactor.
+   binary. Keys are read at runtime from `DOIGET_KEY_<PUBLISHER>` or, one rung
+   below it, `[tdm.<publisher>] api_key` in `~/.config/doiget/credentials.toml`;
+   either way they are wrapped in `secrecy::Secret` and never logged in raw
+   form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the `tracing`
+   redactor; `doiget_core::credentials`.
 
-   Two corrections here (#494):
+   Two corrections here (#494), one of which has since been closed the other way:
 
    - This said credentials are also read from `~/.config/doiget/credentials.toml`.
-     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
-     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
-     specifies it in full anyway, which is tracked as #509. A user following that
-     section today writes a key into a file doiget ignores.
+     At the time they were not — `docs/CONFIG.md` §6 specified the file in full
+     and no code path opened it (#509). **As of 0.8.11 the sentence is true
+     again**, because the reader was built rather than the specification
+     deleted: a long-lived key is better off in a `0600` file than in the
+     environment of every subprocess, and the permission warning §6 promised now
+     exists too (ADR-0050). The **agreement** did not move — see §6a.2.
    - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
      check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
-     imports, telemetry imports and non-rustls TLS backends; there is no secret
-     scanner in the tree. §6a is defined as controls a machine enforces, so an
-     enforcement clause that names nothing does not belong in it. The safeguard
-     itself stands on the type-level ones that are real.
+     imports, telemetry imports, non-rustls TLS backends and the npm platform
+     mapping; there is no secret scanner in the tree. §6a is defined as controls
+     a machine enforces, so an enforcement clause that names nothing does not
+     belong in it. The safeguard itself stands on the type-level ones that are
+     real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
-   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
-   `DOIGET_KEY_<PUBLISHER>`. Missing or partial configurations fail closed at
-   `CapabilityProfile::from_env`. *Enforced by:* `CapabilityProfile`
-   resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
+   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, AND
+   to provide a key (env var or `credentials.toml`, §6a.1). Missing or partial
+   configurations fail closed at `CapabilityProfile::from_env`. *Enforced by:*
+   `CapabilityProfile` resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2
+   rules 2 and 3).
+
+   **The agreement is environment-only, and deliberately did not follow the key
+   into the file** (ADR-0050). Part of what makes this control meaningful is
+   that it is an act taken in the session that runs the fetch; a boolean written
+   once into a config file and forgotten is a weaker consent, and letting a
+   convenience dilute an enforced control is the kind of accident ADR-0048 was
+   written about. An `agreed` key in `credentials.toml` is parsed only so doiget
+   can warn that it grants nothing — a documented field with no reader being the
+   defect #509 was about in the first place.
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
    (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -186,7 +186,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
 | `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
-| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). OA subset only: gated on `isOpenAccess`, **not** `inEPMC` — a record can be in the archive while its full text is subscription-only (#415). |
+| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). Gated on the record advertising a retrievable PDF — a `fullTextUrlList` entry with `documentStyle = pdf` and `availabilityCode` `F` or `OA` (#503) — **not** on `inEPMC` (presence is not openness, #415) and **not** on `isOpenAccess` (bulk-subset membership, which is reported rather than a veto). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -133,9 +133,13 @@ impl CapabilityProfile {
     }
 }
 
-fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, CapabilityError> {
+// `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
+// BELOW the env var (#509, ADR-0050). The agreement has no file rung.
+fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+    -> Result<Option<TdmGrant>, CapabilityError>
+{
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
-    let key    = env::var(key_var).ok();
+    let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {
         (true, Some(k)) => Ok(Some(TdmGrant {
             // `secrecy` 0.10: `SecretString::from(String)` replaces the
@@ -158,6 +162,15 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 ```
 
 ### Three resolution rules
+
+The **key** may come from `DOIGET_KEY_<PUBLISHER>` or from
+`[tdm.<publisher>] api_key` in `credentials.toml`, env first
+([`CONFIG.md`](CONFIG.md) §6). The **agreement** has no file rung: it is
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` in the environment or it does not exist, so
+that it is an act taken in the session that runs the fetch rather than a
+boolean written once and forgotten ([`LEGAL.md`](LEGAL.md) §6a.2, ADR-0050).
+The three rules below are unchanged by that — a key from the file still needs
+the agreement, so rule 3 now also fires for a file-supplied key.
 
 1. **`agree=1` + key present** → `Some(TdmGrant)`. The source is enabled this session.
 2. **`agree=1` but key missing** → `Err(AgreedButNoKey)`. Startup fails; user has agreed

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -257,21 +257,21 @@ mode resolution above.
 
 ## 6. Credentials file
 
+This file carries **API keys only**. The per-publisher agreement is
+environment-only and cannot be given here — see below, and ADR-0050.
+
 ```toml
-# ~/.config/doiget/credentials.toml — optional, alternative to env vars
-# Permissions MUST be 0600 on POSIX; doiget warns at startup otherwise.
+# ~/.config/doiget/credentials.toml — optional.
+# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
 
 [tdm.elsevier]
 api_key = "..."
-agreed = true
 
 [tdm.aps]
 api_key = "..."
-agreed = true
 
 [tdm.springer]
 api_key = "..."
-agreed = true
 
 # Requires a build with `--features tdm-ieee`. The endpoint and response
 # shape are INFERRED from IEEE's public developer portal, not confirmed
@@ -280,10 +280,33 @@ agreed = true
 # rather than silently returning nothing.
 [tdm.ieee]
 api_key = "..."
-agreed = true
 ```
 
-If both env var and credentials.toml provide the same key, env var wins.
+**Precedence.** `DOIGET_KEY_<PUBLISHER>` wins over `[tdm.<publisher>] api_key`,
+per §1. A blank value on either rung counts as unset.
+
+**The agreement is not here.** Each TDM source needs
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, in addition to a key
+from either rung. An `agreed` key in this file is read only so doiget can warn
+that it does nothing; it grants nothing. [`LEGAL.md`](LEGAL.md) §6a.2 makes the
+agreement an *enforced control*, and part of why it is meaningful is that it is
+an act taken in the session that runs the fetch — a boolean written once into a
+file and forgotten is weaker, and weakening it as a side effect of adding a
+convenience is not a trade this file is worth (ADR-0050).
+
+So the three states are:
+
+| key | `DOIGET_AGREE_TDM_<PUB>=1` | result |
+|---|---|---|
+| env or file | yes | grant (if the `tdm-*` feature is compiled in) |
+| env or file | no | `KeyButNotAgreed` — refuses, names the variable |
+| none | yes | `AgreedButNoKey` — refuses, names both |
+
+**Before #509 this file was read by nothing.** It was specified here in full,
+including the `0600` warning, and no code path opened it; a user who followed
+this section wrote their key into a file doiget ignored and then reported the
+source unavailable for want of a key. Both the reader and the permission
+warning exist as of 0.8.11.
 
 ## 6.1 Institutional networks: what works and what does not
 

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -28,7 +28,8 @@ A value set higher in the chain overrides any value set lower.
 | `log.path` | POSIX: `$HOME/.config/doiget/access.log`. Windows: `%APPDATA%\doiget\access.log`. |
 | `log.retention_days` | `90` |
 | `network.user_agent` | `doiget/<version> (+https://github.com/QAtlasHub/doiget)` |
-| `network.unpaywall_email` | unset; if unset, Unpaywall calls go to non-polite pool |
+| `network.contact_email` | unset; if unset, every outbound request identifies as `doiget@localhost` and goes to the non-polite pool |
+| `network.unpaywall_email` | unset; falls back to `network.contact_email` |
 | `network.connect_timeout_sec` | `10` |
 | `network.read_timeout_sec` | `60` |
 | `network.total_timeout_sec` | `300` |
@@ -68,6 +69,12 @@ retention_days = 90
 
 [network]
 user_agent = "doiget/0.1.0 (+https://github.com/QAtlasHub/doiget; user=alice@example.org)"
+# Polite-pool contact for every outbound request. Overridden by
+# DOIGET_CONTACT_EMAIL, one rung above. This is what `doiget config doctor`
+# checks, and `doctor` names which rung answered.
+contact_email = "alice@example.org"
+# Only if Unpaywall should see a different address. Overridden by
+# DOIGET_UNPAYWALL_EMAIL; falls back to contact_email above.
 unpaywall_email = "alice@example.org"
 connect_timeout_sec = 10
 read_timeout_sec = 60
@@ -202,18 +209,29 @@ All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` 
 | `DOIGET_LOG_PATH` | `log.path` |
 | `DOIGET_LOG_RETENTION_DAYS` | `log.retention_days` |
 | `DOIGET_USER_AGENT` | `network.user_agent` |
-| `DOIGET_CONTACT_EMAIL` | Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
+| `DOIGET_CONTACT_EMAIL` | `network.contact_email`. Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
 | `DOIGET_UNPAYWALL_EMAIL` | `network.unpaywall_email` |
 | `DOIGET_MODE` | `output.mode` |
 | `NO_COLOR` | Forces `output.color = "never"` (xdg standard). |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | reqwest honors these (system standard). |
 
-With neither email set, doiget still queries Unpaywall — it sends the placeholder
+Both addresses are resolved **per field**, across the §1 chain: the env var, then
+`[network]` in `config.toml`, then the next-broader default. `DOIGET_UNPAYWALL_EMAIL` →
+`[network] unpaywall_email` → whatever `contact_email` resolved to → `doiget@localhost`.
+The more specific field wins at each rung.
+
+With neither set, doiget still queries Unpaywall — it sends the placeholder
 `doiget@localhost`, which lands in the non-polite pool and may be rate-limited or refused.
-Setting `DOIGET_CONTACT_EMAIL` is therefore worth doing before any batch run, and it is what
-`doiget config doctor` flags. It also makes the automatic arXiv preprint fallback reliable:
-when a DOI's OA PDF is blocked, doiget retries via the arXiv preprint that Unpaywall named,
-so a throttled Unpaywall response costs you that fallback too.
+Setting one is worth doing before any batch run, and it is what `doiget config doctor`
+flags. It also makes the automatic arXiv preprint fallback reliable: when a DOI's OA PDF is
+blocked, doiget retries via the arXiv preprint that Unpaywall named, so a throttled
+Unpaywall response costs you that fallback too — and the run still exits 0 saying
+`no OA PDF available`, which is why a degraded search and a true negative looked the same.
+
+`doiget config doctor` reports **which rung answered**, e.g.
+`[ ok ] contact_email set (from: [network] contact_email in config.toml)`. Before #504 the
+file rung did not exist for either address, so a `config.toml` written from the `config init`
+template was inert while `doctor` reported the store root correctly from the same file.
 
 CapabilityProfile-related env vars are documented in [`CAPABILITY.md`](CAPABILITY.md).
 

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -212,8 +212,8 @@ Neither ever renders "no trace" as `[]`.
 | Exit | Meaning |
 |---|---|
 | `0` | Success (all refs ok). |
-| `1` | At least one fetch failed. |
-| `2` | Misuse (bad arguments, missing config). |
+| `1` | At least one fetch was attempted and failed. |
+| `2` | Misuse — a bad argument or missing config. Covers both an argv shape `clap` rejects **and** a well-formed argument whose *value* fails validation, which is why `INVALID_REF` and `AMBIGUOUS` are both 2 (ADR-0049). |
 | `3` | Capability denied (no source could serve). |
 | `4` | I/O failure (store / log unwritable). |
 | `64..=78` | `sysexits.h` mapping for select cases. |

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -217,30 +217,44 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from **environment variables**
-   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
-   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
-   `tracing` redactor.
+   binary. Keys are read at runtime from `DOIGET_KEY_<PUBLISHER>` or, one rung
+   below it, `[tdm.<publisher>] api_key` in `~/.config/doiget/credentials.toml`;
+   either way they are wrapped in `secrecy::Secret` and never logged in raw
+   form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the `tracing`
+   redactor; `doiget_core::credentials`.
 
-   Two corrections here (#494):
+   Two corrections here (#494), one of which has since been closed the other way:
 
    - This said credentials are also read from `~/.config/doiget/credentials.toml`.
-     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
-     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
-     specifies it in full anyway, which is tracked as #509. A user following that
-     section today writes a key into a file doiget ignores.
+     At the time they were not — `docs/CONFIG.md` §6 specified the file in full
+     and no code path opened it (#509). **As of 0.8.11 the sentence is true
+     again**, because the reader was built rather than the specification
+     deleted: a long-lived key is better off in a `0600` file than in the
+     environment of every subprocess, and the permission warning §6 promised now
+     exists too (ADR-0050). The **agreement** did not move — see §6a.2.
    - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
      check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
-     imports, telemetry imports and non-rustls TLS backends; there is no secret
-     scanner in the tree. §6a is defined as controls a machine enforces, so an
-     enforcement clause that names nothing does not belong in it. The safeguard
-     itself stands on the type-level ones that are real.
+     imports, telemetry imports, non-rustls TLS backends and the npm platform
+     mapping; there is no secret scanner in the tree. §6a is defined as controls
+     a machine enforces, so an enforcement clause that names nothing does not
+     belong in it. The safeguard itself stands on the type-level ones that are
+     real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
-   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
-   `DOIGET_KEY_<PUBLISHER>`. Missing or partial configurations fail closed at
-   `CapabilityProfile::from_env`. *Enforced by:* `CapabilityProfile`
-   resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
+   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, AND
+   to provide a key (env var or `credentials.toml`, §6a.1). Missing or partial
+   configurations fail closed at `CapabilityProfile::from_env`. *Enforced by:*
+   `CapabilityProfile` resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2
+   rules 2 and 3).
+
+   **The agreement is environment-only, and deliberately did not follow the key
+   into the file** (ADR-0050). Part of what makes this control meaningful is
+   that it is an act taken in the session that runs the fetch; a boolean written
+   once into a config file and forgotten is a weaker consent, and letting a
+   convenience dilute an enforced control is the kind of accident ADR-0048 was
+   written about. An `agreed` key in `credentials.toml` is parsed only so doiget
+   can warn that it grants nothing — a documented field with no reader being the
+   defect #509 was about in the first place.
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
    (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and


### PR DESCRIPTION
Closes #492. Adds **ADR-0049**.

## Three sources disagreed

`docs/ERRORS.md` §4 is NORMATIVE:

| Exit | Meaning |
|---|---|
| `1` | At least one fetch failed. |
| `2` | Misuse (bad arguments, missing config). |

Given `"not a doi"`:

| site | exit | what its own comment said |
|---|---|---|
| `commands/graph.rs` | **2** | *"consistent with `fetch`'s INVALID_REF path"* |
| `commands/fetch.rs` | **1** | — it fell through `cli_exit_code`'s `_ => 1` |
| the eight #477 commands | **1** | by design; that conversion changed no exit code |

`graph`'s comment was false. And `fetch`'s 1 was not a decision — the mapping simply had no `InvalidRef` arm. Against the table, nothing was fetched, so "at least one fetch failed" does not describe the run.

## Why this needed a decision and not a patch

`crates/doiget-cli/tests/fetch_error_mapping_e2e.rs` pinned it:

```rust
fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() { … .code(1) … }
```

Someone wrote that name and that assertion deliberately for #119, so either it encoded a decision §4 does not capture, or §4 is right and the test froze the catch-all — opposite changes.

Reading #119 settles it. Its subject is the `error[INVALID_REF]:` *line*, replacing an opaque anyhow dump. The exit code came along as whatever `cli_exit_code` already returned. There is no argument in it for 1 over 2.

## What lands

- `ErrorCode::InvalidRef => 2` — the one arm the mapping was missing.
- `graph` stops hard-coding its own `2` and routes through `cli_exit_code`, so there is nothing left to disagree.
- The eight #477 commands move with `fetch` for free: they already share `parse_ref_or_exit`.
- `ERRORS.md` §4 now says which class an unparsable **value** belongs to — the table said "bad arguments" without settling argv-shape vs failed-validation, which is the ambiguity that let two readings coexist. `INVALID_REF` and `AMBIGUOUS` are both 2 and now visibly so.
- **ADR-0049**, recording the rejected alternative too: keeping `fetch` at 1 and moving `graph` down has the smaller blast radius, and would make `INVALID_REF` the one closed code whose exit value is the *unclassified* one — sitting at 1 next to `AMBIGUOUS` at 2, for a value that fails to select an entity vs a value that fails to parse.

## Breaking

A script branching on `$? == 1` to mean "invalid ref" now sees 2. That script was already wrong: 1 was equally a network failure, a `NO_OA_AVAILABLE`, or any other code under the catch-all. `CHANGELOG.md` records it under **Changed**.

Not filed in `docs/MIGRATION.md` — that covers BiblioFetch.jl and machine moves, not CLI contract changes.

## Tests

`every_ref_taking_command_exits_2_for_an_invalid_ref`, running the **same table** as the existing message-contract test, so a new ref-taking subcommand is covered by both or by neither. A single-command assertion is exactly what let this persist: `fetch`'s exit code was pinned and nothing ever compared it to its siblings.

Plus `invalid_ref_maps_to_exit_code_2` next to the existing `ambiguous_maps_to_exit_code_2`, and the #119 test renamed to match what it now asserts.

## Verified locally

`stable-x86_64-pc-windows-gnu`:

- `fetch_error_mapping_e2e` under `oa-only,citation` (so `graph` is in the table): 5 passed, 0 failed
- `cargo test --workspace --all-targets --features oa-only`: green
- `cargo clippy --workspace --all-targets --features oa-only,citation -- -D warnings`: clean
- `cargo fmt --all --check`: clean
- checked that no other test pins exit 1 for an invalid ref (`verify_e2e`'s three are absent-reference verdicts; `batch` reports `INVALID_REF` per row and exits on its own failure count)

Refs #477, #119, #149, ADR-0023

🤖 Generated with [Claude Code](https://claude.com/claude-code)