### PR TITLE
ci(backmerge): classify the gh pr create failure instead of dumping GraphQL

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -16,6 +16,18 @@ name: backmerge
 # trigger the required CI checks (GitHub recursion guard), so they could
 # never be merged into the protected `next`. (Same constraint the release-plz
 # era already hit; the secret is reused.)
+#
+# The QAtlasHub org refuses fine-grained PATs with a lifetime over 366 days
+# (#426). A PAT minted under the personal account before the migration is
+# rejected with a raw GraphQL error, and every such token expires eventually,
+# so this failure recurs by construction. `gh pr create` is therefore trapped
+# below and the reason is classified into an actionable `::error::` — the
+# 0.8.7 promotion failed here and read as a bare `backmerge / failure` in the
+# Actions list, with the notices above it never reaching the log.
+#
+# A GitHub App installation token (`actions/create-github-app-token`) removes
+# the expiry treadmill and is org-policy clean; it needs an App created and
+# installed, which is a maintainer action, so it is not done here.
 
 on:
   push:
@@ -67,7 +79,42 @@ jobs:
             echo "**Expected merge-time conflict (every back-merge):** \`[workspace.package].version\` and \`Cargo.lock\` conflict — \`next\` carries \`X.Y.Z-beta.N\`, \`main\` carries the clean stable \`X.Y.Z\`. **Keep \`next\`'s \`-beta.N\` version**; take \`main\`'s other changes. Resolve any non-version conflict on its merits."
           } > "$body_file"
 
-          gh pr create --repo "$GITHUB_REPOSITORY" --base next --head main \
-            --title "chore: back-merge main → next (ADR-0025 §D6)" \
-            --body-file "$body_file"
-          echo "::notice::opened main → next back-merge PR."
+          # Trap rather than let `set -e` kill the step on a raw GraphQL
+          # dump. What a reader needs from the Actions list is which of the
+          # three recurring causes it was and what to do, not a log dive.
+          err_file="$(mktemp)"
+          if gh pr create --repo "$GITHUB_REPOSITORY" --base next --head main \
+               --title "chore: back-merge main → next (ADR-0025 §D6)" \
+               --body-file "$body_file" 2>"$err_file"; then
+            echo "::notice::opened main → next back-merge PR."
+            exit 0
+          fi
+
+          err="$(cat "$err_file")"
+          echo "$err" >&2
+
+          cause="gh pr create failed"
+          fix="Open it by hand: gh pr create --base next --head main"
+          case "$err" in
+            *"forbids access via a fine-grained personal access token"*|*"token's lifetime"*)
+              cause="RELEASE_PLZ_TOKEN refused by the QAtlasHub PAT-lifetime policy (max 366 days)"
+              fix="Re-mint the fine-grained PAT with lifetime <= 366 days (contents + pull-requests: write) and update the RELEASE_PLZ_TOKEN repo secret. To stop this recurring on every expiry, move to a GitHub App installation token (actions/create-github-app-token). See #426."
+              ;;
+            *"Bad credentials"*|*"401"*)
+              cause="RELEASE_PLZ_TOKEN is invalid or expired"
+              fix="Re-mint the PAT and update the RELEASE_PLZ_TOKEN repo secret. See #426."
+              ;;
+            *"Resource not accessible"*|*"403"*)
+              cause="RELEASE_PLZ_TOKEN is missing a permission"
+              fix="It needs contents: write and pull-requests: write on this repository. See #426."
+              ;;
+            *"No commits between"*)
+              cause="GitHub reports no diff between main and next"
+              fix="Nothing to do; the branches agree despite the rev-list count above."
+              ;;
+          esac
+
+          echo "::error::back-merge PR could not be opened: $cause"
+          echo "::error::$fix"
+          echo "::error::next is $behind commit(s) behind main and stays there until a PR is opened."
+          exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.1"
+version       = "0.8.11-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/INTEGRATION/README.md
+++ b/docs/INTEGRATION/README.md
@@ -1,42 +1,58 @@
 # Integration guides
 
-> **Status: INFORMATIVE (placeholder).** Concrete host-integration snippets land
-> in **Phase 3** alongside the MCP server (`doiget serve`). Until then, this
-> directory is a pointer rather than a recipe collection.
+> **Status: INFORMATIVE.** `doiget serve` ships; these are the host-side
+> snippets. Each page states whether it has been exercised against that
+> host, and the ones that have not say so.
 
-## Why this is empty today
+`doiget serve` is a stdio MCP server. It is the same entry point everywhere —
+`mcpb/manifest.json` runs `doiget serve`, and so does the MCP Registry entry.
+The differences between hosts are only where the config file lives and what it
+is called.
 
-Phase 0 ships specifications (see [`../MCP_TOOLS.md`](../MCP_TOOLS.md) and
-[`../PUBLIC_API.md`](../PUBLIC_API.md)) but no functional MCP server. Without a
-runnable `doiget serve`, integration snippets would either be untested aspirational
-config or would lead a reader to a Phase 0 stub error. Phase 3 ships the actual
-server and the corresponding host snippets in this directory.
-
-## Planned files (Phase 3)
-
-| File | Host | Status |
+| File | Host | Exercised? |
 |---|---|---|
-| `claude-desktop.md` | Claude Desktop (stdio MCP) | Phase 3 (stub) |
-| `cursor.md` | Cursor | Phase 3 (stub) |
-| `codex.md` | OpenAI Codex CLI | Phase 3 (stub) |
-| `claude-code.md` | Claude Code (this tool) | Phase 3 (stub) |
-| `obsidian.md` | Obsidian backend export | Phase 7 (optional, stub) |
-| `chain-with-paperqa.md` | Composition with paper-qa for content processing | Phase 3+ (stub) |
+| [`claude-code.md`](./claude-code.md) | Claude Code | **Yes** — this is what the project is developed under |
+| [`claude-desktop.md`](./claude-desktop.md) | Claude Desktop (`.mcpb`, or manual stdio) | **Yes**, for the `.mcpb` route (shipping since 0.8.4) |
+| [`cursor.md`](./cursor.md) | Cursor | No |
+| [`codex.md`](./codex.md) | OpenAI Codex CLI | No |
+| [`obsidian.md`](./obsidian.md) | Obsidian | Not applicable — Obsidian hosts no MCP server; the page says what does work |
+| [`chain-with-paperqa.md`](./chain-with-paperqa.md) | Composition with paper-qa | No, as a chain |
 
-## What to read in the meantime
+## The one setting to get right
 
-- **MCP tool spec:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tool surface
-  Phase 3 will expose. Sufficient to plan a host integration in advance.
-- **Public Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders that
-  link `doiget-core` directly rather than going through the MCP server.
-- **Architecture overview:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — for
-  how tools, transport, and the capability gate fit together.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and the
-  `~/.config/doiget/` layout that any host-side wiring will need to respect.
+`DOIGET_STORE_ROOT`, as an absolute path.
+
+The store root defaults to `./papers` **relative to the process's working
+directory** (ADR-0036). For a CLI run that is exactly right — artifacts land
+where you are working. For an MCP server it is not: the working directory
+belongs to the host, so the store lands somewhere you did not choose and a
+later CLI run does not see it. That is
+[#369](https://github.com/QAtlasHub/doiget/issues/369).
+
+`DOIGET_CONTACT_EMAIL` is the second one. Without it every request goes out as
+`doiget@localhost` on the non-polite pool, where a throttled answer is
+indistinguishable from "this paper has no OA copy"
+([#504](https://github.com/QAtlasHub/doiget/issues/504)).
+
+Everything else is off by default and documented in
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Also worth reading
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — every tool with its
+  JSON Schema. `doiget_capability_profile` reports the same thing at runtime
+  for the build you actually have.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — precedence and the
+  `config.toml` schema.
+- **Errors:** [`../ERRORS.md`](../ERRORS.md) — the closed set of error codes
+  and what an agent should do with each.
+- **Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders linking
+  `doiget-core` directly instead of going through MCP.
 
 ## Contributing a snippet
 
-If you have a working integration with an MCP host that is not in the planned list,
-open a GitHub Discussion describing the host, the JSON-RPC trace, and any
-host-specific config quirks. PRs adding a new file under `docs/INTEGRATION/` will
-be accepted in Phase 3+ once `doiget serve` is real and the snippet is verifiable.
+A working configuration for a host not listed here is welcome. Open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+host, the config file and its path, and anything host-specific that bit you —
+or a PR adding a page in the shape of the others, including an honest
+"exercised?" line.

--- a/docs/INTEGRATION/chain-with-paperqa.md
+++ b/docs/INTEGRATION/chain-with-paperqa.md
@@ -1,43 +1,55 @@
 # Chaining with paper-qa
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table this composition guide is scoped to
-> **Phase 3+** — `doiget serve` ships first, then a verified chain recipe.
+> **Status: UNTESTED as a chain.** Both halves are real — doiget writes PDFs to
+> a directory, paper-qa reads a directory of PDFs — but nobody has run the
+> composition end to end and reported back. Treat the shape below as the
+> intended design, not a verified recipe. Last checked 2026-08-26.
 
-[paper-qa](https://github.com/Future-House/paper-qa) is a retrieval-augmented
-question-answering system over scientific papers. The chain pattern this
-guide will document keeps `doiget`'s role narrow — DOI resolution, metadata,
-and content fetch via the tools in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — and
-hands the resulting documents to paper-qa for embedding, retrieval, and
-answer synthesis. Composition keeps each tool single-purpose and avoids
-duplicating retrieval logic inside `doiget`.
+[paper-qa](https://github.com/Future-House/paper-qa) does retrieval-augmented
+question answering over scientific papers. It handles embedding, retrieval and
+answer synthesis; doiget handles getting the papers, legally and with a
+provenance trail. Neither needs to know about the other, because the interface
+is a directory.
 
-## Configuration (Phase 3)
+## The shape
 
-The example below is intentionally empty. The chain shape depends on the
-final Phase 3 tool surface and on paper-qa's MCP/CLI ingestion entry point.
+```sh
+export DOIGET_STORE_ROOT="$HOME/papers"
+export DOIGET_CONTACT_EMAIL="you@institution.edu"
 
-```toml
-<!-- TODO Phase 3: paste verified doiget + paper-qa chain config here. -->
+# 1. Resolve and fetch a bibliography's references (OA only).
+doiget batch refs.bib
+
+# 2. Point paper-qa at the store.
+pqa -i "$HOME/papers" ask "what do these papers say about X?"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+`doiget batch` reports per-reference outcomes; the ones it could not fetch are
+named rather than dropped, so the corpus paper-qa sees is one you can account
+for.
 
-## What to read in the meantime
+## Why compose rather than integrate
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+doiget's job stops at "the bytes are on disk, and here is where they came
+from". Embedding and retrieval are a different problem with different
+dependencies, and duplicating either inside doiget would widen its network
+surface and its supply chain for no gain — see [`../SCOPE.md`](../SCOPE.md).
+
+The same argument means doiget will not ship a paper-qa plugin. The directory
+is the integration.
+
+## What doiget gives you that a scraper does not
+
+- **Provenance.** Every fetch is a hash-chained row in the append-only log
+  ([`../PROVENANCE_LOG.md`](../PROVENANCE_LOG.md)), so the corpus behind an
+  answer is auditable.
+- **Licence, per entry.** The sidecar records it, which matters as soon as an
+  answer is quoted.
+- **A refusal you can read.** A blocked paper produces a named reason and a
+  remediation, not a silent gap in the corpus.
 
 ## Contributing
 
-If you have a working `doiget` + paper-qa chain ahead of Phase 3, open a
-GitHub Discussion with the orchestration script and any host-specific quirks
-rather than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you run this, the useful thing to report is the orchestration script and
+any paper-qa-side quirks — open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions).

--- a/docs/INTEGRATION/claude-code.md
+++ b/docs/INTEGRATION/claude-code.md
@@ -1,40 +1,99 @@
 # Claude Code integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED.** The `claude mcp add` form below is the configuration
+> this project is developed under. Last checked 2026-08-26 against
+> `doiget 0.8.10`.
 
-[Claude Code](https://www.anthropic.com/claude-code) is Anthropic's official
-CLI and supports MCP servers. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as an MCP server in Claude Code (via
-`claude mcp add` or a project-scoped `.mcp.json`) so that the tool surface
-listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) is callable from Claude Code
-sessions.
+[Claude Code](https://www.anthropic.com/claude-code) hosts MCP servers over
+stdio. `doiget serve` is the entry point — the same one
+[`mcpb/manifest.json`](../../mcpb/manifest.json) and the
+[MCP Registry](https://registry.modelcontextprotocol.io/) use.
 
-## Configuration (Phase 3)
+Install `doiget` first (see [`../../README.md`](../../README.md) §Installation);
+it must be on `PATH`, or give an absolute path below.
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+## One line
+
+```sh
+claude mcp add doiget -- doiget serve
+```
+
+With the environment set at the same time, and available in every project
+rather than only this one:
+
+```sh
+claude mcp add doiget --scope user \
+  -e DOIGET_STORE_ROOT="$HOME/papers" \
+  -e DOIGET_CONTACT_EMAIL="you@institution.edu" \
+  -- doiget serve
+```
+
+`--scope` is `local` (this project, private) by default; `user` is every
+project, `project` writes the committed `.mcp.json` below. `claude mcp add
+--help` lists the rest.
+
+## Project-scoped `.mcp.json`
+
+Committed at the repository root, this shares the server with everyone who
+opens the project:
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Code .mcp.json entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "type": "stdio",
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "${HOME}/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+On Windows, `command` is the full path if `doiget` is not on `PATH`, e.g.
+`"C:/Users/<you>/AppData/Local/Programs/doiget/doiget"`.
+
+## Environment
+
+`DOIGET_STORE_ROOT` is the one to set. Without it the store root defaults to
+`./papers` **relative to the process's working directory** (ADR-0036), which
+for an MCP server is the host's, not yours — #369 is that mistake. Set it to
+an absolute path and the store is the same one `doiget` on the command line
+uses.
+
+| Variable | Why |
+|---|---|
+| `DOIGET_STORE_ROOT` | Absolute path to the paper store. Set this. |
+| `DOIGET_CONTACT_EMAIL` | Polite-pool contact for Crossref / Unpaywall. Without it requests go out as `doiget@localhost` from the non-polite pool, where a throttled answer is indistinguishable from "no OA copy" (#504). |
+| `DOIGET_UNPAYWALL_EMAIL` | Only if it differs from the contact address. |
+| `DOIGET_ENABLE_OPENALEX`, `DOIGET_ENABLE_EUROPE_PMC`, `DOIGET_ENABLE_CORE`, `DOIGET_ENABLE_OPENAIRE`, `DOIGET_ENABLE_HAL`, `DOIGET_ENABLE_DATACITE`, `DOIGET_ENABLE_S2`, `DOIGET_ENABLE_DOAJ` | Widen the search past the three always-on sources. **All off by default** (ADR-0040) — with none of them set, `no OA PDF available` means only that Crossref, Unpaywall and arXiv had nothing. |
+| `DOIGET_CORE_API_KEY` | Optional free CORE key; raises that source's rate limit. |
+
+Full precedence and the complete list: [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+**A build caveat, once.** Those `DOIGET_ENABLE_*` flags need the `metadata`
+feature compiled in. The official release binaries and the `.mcpb` are built
+`--features oa-only,citation` (which implies `metadata`), so they work there.
+A binary you built yourself with the default `oa-only` will log a warning and
+leave the source unavailable — `doiget_capability_profile` reports the truth
+for the binary you actually have.
+
+## Checking it worked
+
+```
+/mcp
 ```
 
-## What to read in the meantime
+should list `doiget`. Then ask the model to call `doiget_health` — it reports
+the version, whether the store is writable, and where the store actually is,
+which is the fastest way to catch a wrong `DOIGET_STORE_ROOT`.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Tool surface
 
-## Contributing
-
-If you have a working Claude Code integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+22 tools, enumerated with their JSON Schemas in
+[`../MCP_TOOLS.md`](../MCP_TOOLS.md). `doiget_capability_profile` reports which
+sources this particular build and environment may use.

--- a/docs/INTEGRATION/claude-desktop.md
+++ b/docs/INTEGRATION/claude-desktop.md
@@ -1,39 +1,75 @@
 # Claude Desktop integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED for the `.mcpb` route** (shipping since 0.8.4; attached to
+> every GitHub Release). The manual JSON route below is the same stdio
+> invocation and is included for people who would rather not install an
+> extension. Last checked 2026-08-26.
 
-[Claude Desktop](https://claude.ai/download) is Anthropic's desktop client and
-hosts MCP servers over stdio. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as a tool provider in Claude Desktop's
-MCP configuration so that `resolve_doi`, `fetch_metadata`, and the rest of the
-tool surface in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are callable from a chat.
+[Claude Desktop](https://claude.ai/download) hosts MCP servers over stdio.
 
-## Configuration (Phase 3)
+## Recommended: install the `.mcpb` extension
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+Each [GitHub Release](https://github.com/QAtlasHub/doiget/releases) attaches
+`doiget-<version>.mcpb`. Download it and open it — Claude Desktop installs it
+as an extension. The bundle carries the binaries for macOS, Windows and Linux
+and picks the right one, so there is no PATH to configure.
+
+It asks for one setting, **Paper store location**, which becomes
+`DOIGET_STORE_ROOT`. Point it at a real directory you own; the default is
+`~/Documents/doiget-papers`.
+
+Requires Claude Desktop **0.10.0 or newer**
+(`mcpb/manifest.json` → `compatibility.claude_desktop`).
+
+## Manual: `claude_desktop_config.json`
+
+Settings → Developer → Edit Config. The file lives at:
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Desktop MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "/usr/local/bin/doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an **absolute** `command` path. A desktop app does not inherit the `PATH`
+your shell has, so a bare `doiget` frequently fails to launch with no visible
+error.
 
-## What to read in the meantime
+Restart Claude Desktop after editing.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Environment
 
-## Contributing
+`DOIGET_STORE_ROOT` matters more here than anywhere else: the working
+directory of a GUI-launched process is not a directory you chose, so the
+`./papers` default (ADR-0036) lands somewhere arbitrary. That was #369.
 
-If you have a working Claude Desktop integration ahead of Phase 3, open a
-GitHub Discussion with the JSON-RPC trace and host-side config rather than a
-PR — see [`README.md`](./README.md) §Contributing a snippet.
+The remaining variables are the same as for Claude Code — see
+[`claude-code.md`](./claude-code.md) §Environment,
+[`../CONFIG.md`](../CONFIG.md) and [`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Checking it worked
+
+Ask for `doiget_health`. It reports the version, store writability and the
+resolved store path.
+
+## Verifying the download
+
+Every release asset except the `.mcpb` currently ships `.sha256` and
+`.cosign.bundle` sidecars; [#483](https://github.com/QAtlasHub/doiget/issues/483)
+adds them for the `.mcpb` too. Until it lands, verify the raw binary if you
+need a signature check, and install that manually per above.

--- a/docs/INTEGRATION/codex.md
+++ b/docs/INTEGRATION/codex.md
@@ -1,39 +1,33 @@
 # OpenAI Codex CLI integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Codex CLI as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server, and the snippet below is the standard stdio shape,
+> but this specific host has not been exercised. Report success or failure on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512).
 
-[OpenAI Codex CLI](https://github.com/openai/codex) is OpenAI's terminal-native
-coding agent and supports MCP servers. Once `doiget serve` ships in Phase 3,
-this guide will document how to register `doiget` as an MCP server in Codex
-CLI so that the tools enumerated in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Codex sessions.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative TOML from
-elsewhere — wait for the verified Phase 3 snippet.
+[Codex CLI](https://github.com/openai/codex) reads `~/.codex/config.toml`.
+MCP servers go under `[mcp_servers.<name>]`:
 
 ```toml
-<!-- TODO Phase 3: paste verified Codex CLI MCP server entry here. -->
+[mcp_servers.doiget]
+command = "doiget"
+args = ["serve"]
+
+[mcp_servers.doiget.env]
+DOIGET_STORE_ROOT = "/home/you/papers"
+DOIGET_CONTACT_EMAIL = "you@institution.edu"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on `PATH`.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment, [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
 
-## Contributing
+## Checking it worked
 
-If you have a working Codex CLI integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Ask for `doiget_health`, then `doiget_capability_profile`.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/cursor.md
+++ b/docs/INTEGRATION/cursor.md
@@ -1,39 +1,44 @@
 # Cursor integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Cursor as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server with no host-specific behaviour, and the snippet
+> below is the standard stdio shape — but nobody has run it in Cursor and
+> reported back. If you do, please say so on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512) and this banner
+> comes off.
 
-[Cursor](https://www.cursor.com/) is an AI-first code editor that supports MCP
-servers. Once `doiget serve` ships in Phase 3, this guide will show how to
-register `doiget` as an MCP server in Cursor so that DOI resolution, metadata
-fetch, and the other tools listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Cursor's agent.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+[Cursor](https://www.cursor.com/) supports MCP servers. Configuration is a
+`mcp.json` file: `.cursor/mcp.json` inside a project, or `~/.cursor/mcp.json`
+for every project.
 
 ```json
-<!-- TODO Phase 3: paste verified Cursor MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on the `PATH` the editor
+inherits.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment. `DOIGET_STORE_ROOT` is the one that silently misbehaves if
+omitted (ADR-0036, #369).
 
-## Contributing
+## Checking it worked
 
-If you have a working Cursor integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Have the agent call `doiget_health`. If Cursor's own MCP panel reports the
+server as connected but no tool is callable, `doiget_capability_profile` will
+say what this build is allowed to do.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/obsidian.md
+++ b/docs/INTEGRATION/obsidian.md
@@ -1,42 +1,42 @@
-# Obsidian backend export
+# Obsidian
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table, an Obsidian backend export is scoped to
-> **Phase 7 (optional)** — this stub exists so future contributors have an
-> obvious landing place rather than a 404.
+> **Status: NOT IMPLEMENTED, and this page says what does work instead.**
+> There is no Obsidian backend export and none is in progress. The
+> "Phase 7 (optional)" marker in the planned-files table is the only
+> commitment, and it is not a schedule. Last checked 2026-08-26.
 
-[Obsidian](https://obsidian.md/) is a markdown-based knowledge base. The
-Phase 7 Obsidian backend export will, when shipped, let `doiget` write
-metadata and citation records into an Obsidian vault as plain Markdown notes
-with frontmatter, so that the same data exposed by the MCP tools in
-[`../MCP_TOOLS.md`](../MCP_TOOLS.md) can be browsed inside Obsidian.
+Obsidian does not host MCP servers, so there is nothing to register. What
+exists today is that doiget's store is **plain files**, so a vault can sit on
+top of it with no integration at all.
 
-## Configuration (Phase 3)
+## What doiget writes
 
-The example below is intentionally empty. The Obsidian backend export is a
-Phase 7 deliverable; even the Phase 3 wiring is not yet implemented.
+One TOML sidecar and one PDF per entry, under `DOIGET_STORE_ROOT`. The layout
+and the field contract are in [`../STORE.md`](../STORE.md).
 
-```toml
-<!-- TODO Phase 3: paste verified Obsidian export config block here. -->
+Point the store at a folder inside your vault:
+
+```sh
+export DOIGET_STORE_ROOT="$HOME/Vault/papers"
+doiget fetch 10.1103/PhysRevLett.130.200601
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+The PDFs are then openable from Obsidian, and the sidecars are readable text.
+They are **TOML, not Markdown with YAML frontmatter**, so Obsidian will not
+index them as notes and Dataview will not see them.
 
-## What to read in the meantime
+## What is missing, precisely
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+A Markdown-with-frontmatter projection of the sidecar. That is the whole of
+the "Obsidian backend export" idea, and it is not implemented — not the wiring,
+not the frontmatter schema, not a `doiget` subcommand.
+
+`doiget csl <ref>` and `doiget bib <ref>` emit CSL-JSON and BibTeX from the
+same records, which is enough to script a projection yourself.
 
 ## Contributing
 
-If you have a working Obsidian export workflow ahead of Phase 7, open a
-GitHub Discussion describing the vault layout and frontmatter shape rather
-than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you build one, open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+vault layout and the frontmatter shape before a PR — the schema is the part
+worth agreeing on first.


### PR DESCRIPTION
Refs #426 — the "worth fixing regardless" half. **Does not close it**: the token itself needs a maintainer action, see below.

## What happened

The 0.8.7 promotion's back-merge failed and read as a bare `backmerge / failure` in the Actions list. `set -e` killed the step on the raw GraphQL text, so the `::notice::` lines above it never ran, and the cause needed a log dive:

```
GraphQL: The 'QAtlasHub' organization forbids access via a fine-grained personal
access tokens if the token's lifetime is greater than 366 days.
```

## What lands

`gh pr create` is trapped, and its stderr matched against the causes that actually recur:

| matched | reported |
|---|---|
| org PAT-lifetime policy | re-mint at ≤ 366 days with contents + pull-requests write, **or** move to a GitHub App token to stop the recurrence |
| `Bad credentials` / 401 | the token is invalid or expired |
| `Resource not accessible` / 403 | it is missing a permission, and which |
| `No commits between` | nothing to do |

Each emits `::error::` lines that show in the run summary. The last one always says **how far behind `next` now is** — the cost of the failure is exactly what the old summary did not show.

The header comment now records the constraint that makes this recur by construction: the org refuses fine-grained PATs over 366 days, and every PAT expires, so this failure comes back on a timer. It also keeps the existing note on why `GITHUB_TOKEN` is not an option — a PR it opens does not trigger the required checks, so it could never be merged into the protected `next`.

## Still needs the maintainer

Pick one:

1. **Re-mint `RELEASE_PLZ_TOKEN`** as a fine-grained PAT with lifetime ≤ 366 days (contents: write, pull-requests: write on `QAtlasHub/doiget`) and update the repo secret. Smallest change; returns on expiry — though now with an error that says so.
2. **A GitHub App installation token** (`actions/create-github-app-token`). No expiry treadmill, org-policy clean; needs an App created and installed.

#426 recommends (2) if this is meant to keep working unattended. Either is outside what a PR can do.

## Verified locally

- the workflow parses as YAML with the new structure intact
- the `run:` block extracted from it passes `bash -n`
- the PAT-policy branch simulated against the verbatim GraphQL string from #426 emits the three expected `::error::` lines

The first attempt broke the YAML — backslash-continued shell strings de-indented to column 0 and ended the block scalar. Rewritten with `cause` / `fix` variables on single lines, which also reads better in the summary.

Refs #426, #392, ADR-0025

🤖 Generated with [Claude Code](https://claude.com/claude-code)