### PR TITLE
Promotion: next → main for 0.8.11

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,12 @@
 # Reproducible-build settings. See docs/SECURITY.md §1.9.
-# Per-developer overrides may go in .cargo/config.local.toml (gitignored).
-
-[build]
-# Default to the host triple. CI overrides per matrix entry.
+#
+# Per-developer overrides do NOT go in a sibling file here. Cargo reads only
+# `config.toml` from a `.cargo` directory, and the `include = [...]` that
+# would make a sibling real is a HARD ERROR before any cargo command runs
+# when the included file is absent — which it is in every fresh clone and on
+# every CI runner, because such a file would be gitignored. See
+# CONTRIBUTING.md "Per-developer settings" for the two mechanisms that work
+# ($CARGO_HOME/config.toml and CARGO_TARGET_DIR).
 
 [net]
 git-fetch-with-cli = false

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "doiget",
+  "metadata": {
+    "description": "The doiget marketplace — one plugin: an OA-first paper fetcher for DOIs and arXiv IDs.",
+    "version": "0.8.11"
+  },
+  "owner": {
+    "name": "QAtlasHub",
+    "email": "souta.shimozono@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "doiget",
+      "source": "./",
+      "description": "Turn DOIs and arXiv IDs into local PDFs and structured metadata via official Open-Access APIs. Never bypasses paywalls.",
+      "category": "research",
+      "homepage": "https://github.com/QAtlasHub/doiget"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "doiget",
+  "description": "Turn DOIs and arXiv IDs into local PDFs and structured metadata via official Open-Access APIs. Never bypasses paywalls.",
+  "version": "0.8.11",
+  "author": {
+    "name": "Sota Shimozono",
+    "url": "https://github.com/QAtlasHub/doiget"
+  },
+  "homepage": "https://github.com/QAtlasHub/doiget",
+  "repository": "https://github.com/QAtlasHub/doiget",
+  "license": "MIT",
+  "keywords": ["doi", "arxiv", "open-access", "bibliography", "crossref", "unpaywall", "research"]
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,6 +50,7 @@ in the same PR or in a paired PR and link it here.
 - [ ] No accidental NORMATIVE doc edits (per ADR-0014)
 - [ ] If a workflow file is added/modified, all third-party Actions are SHA-pinned (ADR-0013)
 - [ ] If Cargo.toml/Cargo.lock changed, dep churn reviewed
+- [ ] Every commit is signed off (`git commit -s`) — CONTRIBUTING.md, CLA §4
 - [ ] Reviewer checklist: maintainer auto-assigned via CODEOWNERS
 
 ## Posture checks

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -16,6 +16,18 @@ name: backmerge
 # trigger the required CI checks (GitHub recursion guard), so they could
 # never be merged into the protected `next`. (Same constraint the release-plz
 # era already hit; the secret is reused.)
+#
+# The QAtlasHub org refuses fine-grained PATs with a lifetime over 366 days
+# (#426). A PAT minted under the personal account before the migration is
+# rejected with a raw GraphQL error, and every such token expires eventually,
+# so this failure recurs by construction. `gh pr create` is therefore trapped
+# below and the reason is classified into an actionable `::error::` — the
+# 0.8.7 promotion failed here and read as a bare `backmerge / failure` in the
+# Actions list, with the notices above it never reaching the log.
+#
+# A GitHub App installation token (`actions/create-github-app-token`) removes
+# the expiry treadmill and is org-policy clean; it needs an App created and
+# installed, which is a maintainer action, so it is not done here.
 
 on:
   push:
@@ -67,7 +79,42 @@ jobs:
             echo "**Expected merge-time conflict (every back-merge):** \`[workspace.package].version\` and \`Cargo.lock\` conflict — \`next\` carries \`X.Y.Z-beta.N\`, \`main\` carries the clean stable \`X.Y.Z\`. **Keep \`next\`'s \`-beta.N\` version**; take \`main\`'s other changes. Resolve any non-version conflict on its merits."
           } > "$body_file"
 
-          gh pr create --repo "$GITHUB_REPOSITORY" --base next --head main \
-            --title "chore: back-merge main → next (ADR-0025 §D6)" \
-            --body-file "$body_file"
-          echo "::notice::opened main → next back-merge PR."
+          # Trap rather than let `set -e` kill the step on a raw GraphQL
+          # dump. What a reader needs from the Actions list is which of the
+          # three recurring causes it was and what to do, not a log dive.
+          err_file="$(mktemp)"
+          if gh pr create --repo "$GITHUB_REPOSITORY" --base next --head main \
+               --title "chore: back-merge main → next (ADR-0025 §D6)" \
+               --body-file "$body_file" 2>"$err_file"; then
+            echo "::notice::opened main → next back-merge PR."
+            exit 0
+          fi
+
+          err="$(cat "$err_file")"
+          echo "$err" >&2
+
+          cause="gh pr create failed"
+          fix="Open it by hand: gh pr create --base next --head main"
+          case "$err" in
+            *"forbids access via a fine-grained personal access token"*|*"token's lifetime"*)
+              cause="RELEASE_PLZ_TOKEN refused by the QAtlasHub PAT-lifetime policy (max 366 days)"
+              fix="Re-mint the fine-grained PAT with lifetime <= 366 days (contents + pull-requests: write) and update the RELEASE_PLZ_TOKEN repo secret. To stop this recurring on every expiry, move to a GitHub App installation token (actions/create-github-app-token). See #426."
+              ;;
+            *"Bad credentials"*|*"401"*)
+              cause="RELEASE_PLZ_TOKEN is invalid or expired"
+              fix="Re-mint the PAT and update the RELEASE_PLZ_TOKEN repo secret. See #426."
+              ;;
+            *"Resource not accessible"*|*"403"*)
+              cause="RELEASE_PLZ_TOKEN is missing a permission"
+              fix="It needs contents: write and pull-requests: write on this repository. See #426."
+              ;;
+            *"No commits between"*)
+              cause="GitHub reports no diff between main and next"
+              fix="Nothing to do; the branches agree despite the rev-list count above."
+              ;;
+          esac
+
+          echo "::error::back-merge PR could not be opened: $cause"
+          echo "::error::$fix"
+          echo "::error::next is $behind commit(s) behind main and stays there until a PR is opened."
+          exit 1

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,114 @@
+name: dco
+
+# ADR-0045 D4 — the Contributor License Agreement in CONTRIBUTING.md is agreed to
+# by a `Signed-off-by` trailer on each commit, and this job is what makes that
+# record real rather than aspirational.
+#
+# Deliberately NOT a required status check. The required checks stay the two
+# `test` jobs, so adding this does not perturb the auto-merge chain (ADR-0025).
+# It blocks inside its own job, which is enough to make a missing sign-off
+# obvious on the PR before a human merges.
+#
+# Exemptions, both structural rather than discretionary:
+#   * merge commits  — created by GitHub, not by a contributor (`--no-merges`).
+#   * bot authors    — Dependabot and github-actions are not legal persons and
+#                      cannot grant a copyright license, so asking them to
+#                      certify one is meaningless. Matched on the `[bot]`
+#                      suffix GitHub appends to every App author name.
+#
+# Third-party Actions are SHA-pinned (repo invariant / ADR-0013 supply-chain).
+
+on:
+  pull_request:
+    branches: [next, main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dco-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dco:
+    name: dco (ADR-0045 — is every commit signed off?)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout PR head (full history so the base merge-base resolves)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Fetch the base branch
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Every non-bot, non-merge commit carries a Signed-off-by trailer
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          base_sha="$(git merge-base "origin/${BASE_REF}" "${HEAD_SHA}")"
+          echo "range: ${base_sha}..${HEAD_SHA}"
+          echo
+
+          # A well-formed trailer: a name, then an <addr@host> carrying no
+          # spaces. Matched case-insensitively — `Signed-Off-By` is an equally
+          # valid trailer key, and `git commit -s` is not the only way to write
+          # one. Fed by here-string, never by a pipe: `grep -q` exits on first
+          # match, and under `pipefail` a SIGPIPE'd upstream would turn a
+          # *found* trailer into a non-zero status.
+          trailer_re='^signed-off-by:[[:space:]]+[^<]+[[:space:]]+<[^[:space:]@<>]+@[^[:space:]@<>]+>[[:space:]]*$'
+
+          missing=0
+          checked=0
+
+          while read -r sha; do
+            [ -n "$sha" ] || continue
+            author_name="$(git show -s --format='%an' "$sha")"
+            subject="$(git show -s --format='%s' "$sha")"
+            short="${sha:0:8}"
+
+            case "$author_name" in
+              *'[bot]')
+                echo "skip  ${short}  ${subject}  (bot author: ${author_name})"
+                continue
+                ;;
+            esac
+
+            checked=$((checked + 1))
+            body="$(git show -s --format='%B' "$sha" | tr -d '\r')"
+
+            if grep -qiE "$trailer_re" <<< "$body"; then
+              echo "ok    ${short}  ${subject}"
+            else
+              echo "FAIL  ${short}  ${subject}"
+              echo "::error::dco: commit ${short} has no well-formed Signed-off-by trailer"
+              missing=$((missing + 1))
+            fi
+          done < <(git rev-list --no-merges "${base_sha}..${HEAD_SHA}")
+
+          echo
+          echo "checked ${checked} commit(s); ${missing} missing a sign-off."
+
+          if [ "$missing" -gt 0 ]; then
+            cat >&2 <<'EOF'
+
+          Every commit must agree to the Contributor License Agreement
+          (CONTRIBUTING.md, "Contributor License Agreement") by carrying a
+          sign-off trailer. To add one to the commits already on this branch:
+
+              git rebase --signoff origin/<base branch>
+              git push --force-with-lease
+
+          and use `git commit -s` from here on.
+          EOF
+            exit 1
+          fi

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,6 +15,17 @@ name: dco
 #                      cannot grant a copyright license, so asking them to
 #                      certify one is meaningless. Matched on the `[bot]`
 #                      suffix GitHub appends to every App author name.
+#   * promotion PRs  — `next` -> `main` is not a contribution. It re-presents
+#                      commits this same job already gated when they landed
+#                      on `next`, so checking them again asks one question
+#                      twice and can answer it differently: a promotion's
+#                      range is the whole release, and for any release
+#                      spanning ADR-0051's own introduction that range holds
+#                      commits which predate the CLA and can never acquire a
+#                      trailer — `next` is protected, its history cannot be
+#                      rewritten. A job that is red whatever the author does
+#                      is not a gate; it is noise that teaches people to
+#                      ignore the gate.
 #
 # Third-party Actions are SHA-pinned (repo invariant / ADR-0013 supply-chain).
 
@@ -47,7 +58,27 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
+      # Structural, not discretionary — see the exemption list in the header.
+      # `head_ref` is compared too, so a topic branch that merely targets
+      # `main` is still checked; only the literal `next` -> `main` promotion
+      # is exempt.
+      - name: Is this the next -> main promotion?
+        id: promotion
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$BASE_REF" = "main" ] && [ "$HEAD_REF" = "next" ]; then
+            echo "promotion=true" >> "$GITHUB_OUTPUT"
+            echo "next -> main promotion: every commit here was sign-off gated when it landed on next."
+          else
+            echo "promotion=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Every non-bot, non-merge commit carries a Signed-off-by trailer
+        if: steps.promotion.outputs.promotion != 'true'
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -165,8 +165,29 @@ jobs:
             printf 'package.json:\n%s\nnpm/:\n%s\n' "$declared" "$onDisk"
             fail=1
           fi
+          # Without this edge the checks form TWO disjoint clusters —
+          # {assets,staged} and {pkgs,shimmed} versus {declared,onDisk} — so
+          # renaming both halves consistently but differently from each other
+          # passed every check while the wrapper depended on a package the
+          # staging script never produces.
+          if [ "$pkgs" != "$declared" ]; then
+            echo "::error::posture-lint npm: scripts/stage-npm.sh and npm/doiget/package.json name different packages (#511)"
+            printf 'stage-npm.sh:\n%s\npackage.json:\n%s\n' "$pkgs" "$declared"
+            fail=1
+          fi
           [ "$fail" -eq 0 ]
           echo "npm mapping OK: $(echo "$pkgs" | tr '\n' ' ')"
+
+      - name: npm packaging tests (#511)
+        shell: bash
+        # The name-list greps above cannot catch a wrong binary name, a
+        # mis-forwarded exit code, or a staging script that produces the
+        # wrong layout. These actually run. node is preinstalled on the
+        # runner, so no action is pinned for it.
+        run: |
+          set -euo pipefail
+          node npm/doiget/test/platform.test.js
+          bash npm/doiget/test/stage-npm.test.sh
 
   network-purity:
     # Phase 0 must make zero outbound network calls from the unit / integration

--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -119,6 +119,55 @@ jobs:
           fi
           echo "LICENSE OK: verbatim SPDX MIT, no trailing prose, ends at SOFTWARE., LF."
 
+      - name: npm platform packages cover every release binary (#511)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The npm `os`/`cpu` names (darwin/win32, x64/arm64) and the release
+          # asset names (macos/windows, x86_64/aarch64) are different
+          # vocabularies for the same four targets, so the mapping is written
+          # twice: `scripts/stage-npm.sh` (MAP) and `npm/doiget/bin/doiget.js`
+          # (PACKAGES). Two hand-maintained copies of one table is the #454 /
+          # #504 shape, so it is checked rather than trusted.
+          #
+          # Third copy, and the one that moves: the `sign` matrix in
+          # release-plz.yml. A new target added there with no npm package
+          # would publish a wrapper that cannot run on it.
+          assets="$(grep -oE 'artifact: doiget-[a-z0-9_.-]+' .github/workflows/release-plz.yml \
+                    | sed 's/artifact: //' | sort -u)"
+          staged="$(grep -oE '^doiget-[a-z0-9-]+:doiget-[a-z0-9_.-]+:' scripts/stage-npm.sh \
+                    | cut -d: -f2 | sort -u)"
+          shimmed="$(grep -oE '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/bin/doiget.js \
+                     | tr -d '"' | sort -u)"
+          pkgs="$(grep -oE '^doiget-[a-z0-9-]+:' scripts/stage-npm.sh | tr -d ':' | sort -u)"
+
+          fail=0
+          # `.exe` is appended by the matrix `ext:` field, so compare stems.
+          if [ "$(echo "$assets" | sed 's/\.exe$//' | sort -u)" \
+               != "$(echo "$staged" | sed 's/\.exe$//' | sort -u)" ]; then
+            echo "::error::posture-lint npm: release-plz.yml assets and scripts/stage-npm.sh disagree (#511)"
+            printf 'release-plz.yml:\n%s\nstage-npm.sh:\n%s\n' "$assets" "$staged"
+            fail=1
+          fi
+          if [ "$pkgs" != "$shimmed" ]; then
+            echo "::error::posture-lint npm: scripts/stage-npm.sh and npm/doiget/bin/doiget.js name different packages (#511)"
+            printf 'stage-npm.sh:\n%s\nshim:\n%s\n' "$pkgs" "$shimmed"
+            fail=1
+          fi
+          # Every package the wrapper declares must exist as a directory, and
+          # vice versa — an optionalDependency that resolves to nothing fails
+          # SILENTLY at install time, which is the whole failure mode.
+          declared="$(grep -oE '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/package.json \
+                      | tr -d '"' | sort -u)"
+          onDisk="$(find npm -maxdepth 1 -mindepth 1 -type d -name 'doiget-*' -printf '%f\n' | sort -u)"
+          if [ "$declared" != "$onDisk" ]; then
+            echo "::error::posture-lint npm: optionalDependencies and npm/ directories disagree (#511)"
+            printf 'package.json:\n%s\nnpm/:\n%s\n' "$declared" "$onDisk"
+            fail=1
+          fi
+          [ "$fail" -eq 0 ]
+          echo "npm mapping OK: $(echo "$pkgs" | tr '\n' ' ')"
+
   network-purity:
     # Phase 0 must make zero outbound network calls from the unit / integration
     # test suite. See `docs/PHASES.md` §3 working principle ("No external

--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -126,20 +126,37 @@ jobs:
           # The npm `os`/`cpu` names (darwin/win32, x64/arm64) and the release
           # asset names (macos/windows, x86_64/aarch64) are different
           # vocabularies for the same four targets, so the mapping is written
-          # twice: `scripts/stage-npm.sh` (MAP) and `npm/doiget/bin/doiget.js`
+          # twice: `scripts/stage-npm.sh` (MAP) and `npm/doiget/bin/platform.js`
           # (PACKAGES). Two hand-maintained copies of one table is the #454 /
           # #504 shape, so it is checked rather than trusted.
           #
           # Third copy, and the one that moves: the `sign` matrix in
           # release-plz.yml. A new target added there with no npm package
           # would publish a wrapper that cannot run on it.
-          assets="$(grep -oE 'artifact: doiget-[a-z0-9_.-]+' .github/workflows/release-plz.yml \
+          #
+          # `capture` exists because each of these greps is itself a silent
+          # failure waiting to happen: under `set -euo pipefail` a grep that
+          # matches nothing exits 1 and kills the step with NO output at all.
+          # Not hypothetical — the PACKAGES table moved from `doiget.js` to
+          # `platform.js` and this step went red with an empty log, which
+          # reads as infrastructure flake rather than as the drift it was
+          # actually detecting.
+          capture() {
+            local out
+            out="$(grep -oE "$1" "$2" || true)"
+            if [ -z "$out" ]; then
+              echo "::error::posture-lint npm: /$1/ matched nothing in $2 — the table it reads has moved or been renamed (#511)"
+              exit 1
+            fi
+            printf '%s\n' "$out"
+          }
+          assets="$(capture 'artifact: doiget-[a-z0-9_.-]+' .github/workflows/release-plz.yml \
                     | sed 's/artifact: //' | sort -u)"
-          staged="$(grep -oE '^doiget-[a-z0-9-]+:doiget-[a-z0-9_.-]+:' scripts/stage-npm.sh \
+          staged="$(capture '^doiget-[a-z0-9-]+:doiget-[a-z0-9_.-]+:' scripts/stage-npm.sh \
                     | cut -d: -f2 | sort -u)"
-          shimmed="$(grep -oE '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/bin/doiget.js \
+          shimmed="$(capture '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/bin/platform.js \
                      | tr -d '"' | sort -u)"
-          pkgs="$(grep -oE '^doiget-[a-z0-9-]+:' scripts/stage-npm.sh | tr -d ':' | sort -u)"
+          pkgs="$(capture '^doiget-[a-z0-9-]+:' scripts/stage-npm.sh | tr -d ':' | sort -u)"
 
           fail=0
           # `.exe` is appended by the matrix `ext:` field, so compare stems.
@@ -150,14 +167,14 @@ jobs:
             fail=1
           fi
           if [ "$pkgs" != "$shimmed" ]; then
-            echo "::error::posture-lint npm: scripts/stage-npm.sh and npm/doiget/bin/doiget.js name different packages (#511)"
+            echo "::error::posture-lint npm: scripts/stage-npm.sh and npm/doiget/bin/platform.js name different packages (#511)"
             printf 'stage-npm.sh:\n%s\nshim:\n%s\n' "$pkgs" "$shimmed"
             fail=1
           fi
           # Every package the wrapper declares must exist as a directory, and
           # vice versa — an optionalDependency that resolves to nothing fails
           # SILENTLY at install time, which is the whole failure mode.
-          declared="$(grep -oE '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/package.json \
+          declared="$(capture '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/package.json \
                       | tr -d '"' | sort -u)"
           onDisk="$(find npm -maxdepth 1 -mindepth 1 -type d -name 'doiget-*' -printf '%f\n' | sort -u)"
           if [ "$declared" != "$onDisk" ]; then
@@ -177,6 +194,10 @@ jobs:
           fi
           [ "$fail" -eq 0 ]
           echo "npm mapping OK: $(echo "$pkgs" | tr '\n' ' ')"
+
+      - name: release checksum verification test (#511)
+        shell: bash
+        run: bash npm/doiget/test/release-checksums.test.sh
 
       - name: npm packaging tests (#511)
         shell: bash

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -513,7 +513,10 @@ jobs:
   mcp-registry:
     name: publish to MCP registry (OIDC)
     runs-on: ubuntu-latest
-    needs: publish
+    # Also waits on `desktop-extension`, which produces the .mcpb and its
+    # `.sha256`. That job is best-effort, so its absence must not block the
+    # publish — the step below degrades to a cargo-only `packages` array.
+    needs: [publish, desktop-extension]
     if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
     continue-on-error: true
     permissions:
@@ -533,17 +536,59 @@ jobs:
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
             | tar xz mcp-publisher
           test -x ./mcp-publisher && echo "mcp-publisher ${MCP_PUBLISHER_VERSION} installed"
-      - name: Pin server.json version to the released tag
+      - name: Build server.json for the released tag
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           ver="${TAG#v}"
-          # Pin server.json's version to the released tag. Source-only entry
-          # (no `packages` array): the live MCP Registry does not yet accept the
-          # `cargo` registry type (400 "unsupported registry type: cargo"),
-          # though the 2025-12-11 schema lists it. Re-add a cargo package once
-          # the registry deploys cargo support.
-          jq --arg v "$ver" '.version = $v' server.json > server.tmp
+
+          # Two first-class distribution paths for a Rust MCP server, per the
+          # registry's own package-types guidance:
+          #
+          #   cargo — source via crates.io; the user needs a Rust toolchain.
+          #           Ownership is proven by the `mcp-name:` token in the
+          #           crate README, which must be VISIBLE markdown: crates.io
+          #           strips HTML comments, so the `<!-- ... -->` form that
+          #           works for PyPI/NuGet silently fails here.
+          #   mcpb  — the prebuilt bundle from this Release; no toolchain.
+          #           `identifier` must contain "mcp" (the extension does) and
+          #           `fileSha256` is REQUIRED.
+          #
+          # Emitting both means neither audience is excluded. Publishing with
+          # no `packages` array at all — which is what shipped through 0.8.9 —
+          # leaves the server discoverable but not installable.
+          #
+          # Historical note: cargo used to 400 with "unsupported registry
+          # type". If it does again, this job is continue-on-error, so record
+          # the error here rather than rediscovering it.
+          mcpb="doiget-${ver}.mcpb"
+          digest=""
+          if gh release download "$TAG" -p "${mcpb}.sha256" -D . --clobber 2>/dev/null; then
+            # `openssl dgst -r` writes `<hash> *<file>`.
+            digest="$(cut -d' ' -f1 < "${mcpb}.sha256")"
+          fi
+
+          if [ -n "$digest" ]; then
+            url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${mcpb}"
+            jq --arg v "$ver" --arg url "$url" --arg sha "$digest" '
+              .version = $v
+              | .packages = [
+                  { registryType: "mcpb", identifier: $url,
+                    fileSha256: $sha, transport: { type: "stdio" } },
+                  { registryType: "cargo", identifier: "doiget-cli",
+                    version: $v, transport: { type: "stdio" } }
+                ]' server.json > server.tmp
+          else
+            echo "::warning::no ${mcpb}.sha256 on the Release — publishing the cargo package only"
+            jq --arg v "$ver" '
+              .version = $v
+              | .packages = [
+                  { registryType: "cargo", identifier: "doiget-cli",
+                    version: $v, transport: { type: "stdio" } }
+                ]' server.json > server.tmp
+          fi
           mv server.tmp server.json
           echo "---- server.json ----"; cat server.json
       - name: Authenticate to the MCP registry (GitHub OIDC)
@@ -583,11 +628,14 @@ jobs:
     continue-on-error: true
     permissions:
       contents: write   # download release binaries + upload the .mcpb
+      id-token: write   # cosign keyless: mint Fulcio cert from OIDC token
     steps:
       - name: Checkout the tagged commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ env.TAG }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
       - name: Install the mcpb CLI
         shell: bash
         # node/npm are preinstalled on the GitHub-hosted macOS runner.
@@ -607,8 +655,30 @@ jobs:
       - name: Build the .mcpb bundle
         shell: bash
         run: bash scripts/build-mcpb.sh "${TAG#v}" bin "doiget-${TAG#v}.mcpb"
+      - name: Digest + cosign sign-blob (keyless)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Every other release artefact ships a `.sha256` and a
+          # `.cosign.bundle`; the .mcpb shipped with neither, which made the
+          # artefact a user is most likely to double-click the only one they
+          # could not verify.
+          #
+          # The digest is also load-bearing, not just hygiene: an `mcpb`
+          # entry in the MCP Registry REQUIRES `fileSha256`, and the
+          # `mcp-registry` job reads it back off the Release rather than
+          # passing it between jobs.
+          #
+          # `openssl dgst -r` matches release-sign.yml's convention — the
+          # `<hash> *<file>` form — because `sha256sum` is absent on macOS.
+          MCPB="doiget-${TAG#v}.mcpb"
+          openssl dgst -sha256 -r "$MCPB" > "$MCPB.sha256"
+          cosign sign-blob --yes --bundle "$MCPB.cosign.bundle" "$MCPB"
       - name: Upload the .mcpb to the Release
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$TAG" "doiget-${TAG#v}.mcpb" --clobber
+        run: |
+          set -euo pipefail
+          MCPB="doiget-${TAG#v}.mcpb"
+          gh release upload "$TAG"             "$MCPB"             "$MCPB.sha256"             "$MCPB.cosign.bundle"             --clobber

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -725,7 +725,10 @@ jobs:
             -p 'doiget-macos-aarch64' \
             -p 'doiget-macos-x86_64' \
             -p 'doiget-windows-x86_64.exe' \
-            -p 'doiget-*.sha256'
+            -p 'doiget-linux-x86_64.sha256' \
+            -p 'doiget-macos-aarch64.sha256' \
+            -p 'doiget-macos-x86_64.sha256' \
+            -p 'doiget-windows-x86_64.exe.sha256'
       - name: Verify every checksum before it goes into a package
         shell: bash
         # The whole argument for optionalDependencies over a postinstall
@@ -735,7 +738,16 @@ jobs:
         run: |
           set -euo pipefail
           cd dl
+          # The list above is four EXACT names, not a wildcard. The release
+          # also carries `doiget-sbom-<tag>.cdx.json.sha256` and
+          # `doiget-<ver>.mcpb.sha256`, which a `doiget-*.sha256` glob matches
+          # while their binaries are never fetched — `openssl dgst` on the
+          # missing file then aborts this job under `set -e`, and because the
+          # job is `continue-on-error` the release still reports green with
+          # npm silently unpublished.
+          verified=0
           for f in *.sha256; do
+            [ -e "$f" ] || { echo "::error::no .sha256 files were downloaded"; exit 1; }
             read -r want _rest < "$f"
             got="$(openssl dgst -sha256 -r "${f%.sha256}" | cut -d' ' -f1)"
             if [ "$want" != "$got" ]; then
@@ -743,7 +755,14 @@ jobs:
               exit 1
             fi
             echo "ok ${f%.sha256}"
+            verified=$((verified + 1))
           done
+          # A partial download is exactly what this step exists to catch; it
+          # must not read as a clean run over fewer files.
+          if [ "$verified" -ne 4 ]; then
+            echo "::error::verified $verified checksum(s), expected 4 — a platform binary is missing from the release"
+            exit 1
+          fi
       - name: Stage the packages
         shell: bash
         run: bash scripts/stage-npm.sh "${TAG#v}" dl npm-stage

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -612,3 +612,85 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$TAG" "doiget-${TAG#v}.mcpb" --clobber
+
+  npm-publish:
+    name: publish to npm (Trusted Publishing)
+    runs-on: ubuntu-latest
+    needs: [github-release, sign]
+    # Runs for betas too — they publish under the `beta` dist-tag, never
+    # `latest`. ADR-0033's cadence means most tags are betas, so gating this
+    # on stable would leave the npm channel months behind the binaries.
+    #
+    # `continue-on-error` matches `mcp-registry` / `desktop-extension`: a
+    # publish failure must not fail a release whose crates and binaries are
+    # already out. Read the log, do not assume it succeeded (#472).
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write   # npm Trusted Publishing (no long-lived NPM_TOKEN)
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ env.TAG }}
+      - name: Upgrade npm for Trusted Publishing
+        shell: bash
+        # node/npm are preinstalled on the GitHub-hosted runner, so no
+        # `setup-node` action is pinned here — same reasoning as the
+        # `desktop-extension` job. Trusted Publishing needs a recent npm;
+        # `npm@latest` is the documented instruction.
+        run: |
+          set -euo pipefail
+          npm install -g npm@latest
+          npm --version
+      - name: Download the signed release binaries
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p dl
+          gh release download "$TAG" -D dl \
+            -p 'doiget-linux-x86_64' \
+            -p 'doiget-macos-aarch64' \
+            -p 'doiget-macos-x86_64' \
+            -p 'doiget-windows-x86_64.exe' \
+            -p 'doiget-*.sha256'
+      - name: Verify every checksum before it goes into a package
+        shell: bash
+        # The whole argument for optionalDependencies over a postinstall
+        # download is that the bytes are inside the registry, covered by npm
+        # integrity. That is only worth anything if what goes in is what the
+        # release signed.
+        run: |
+          set -euo pipefail
+          cd dl
+          for f in *.sha256; do
+            read -r want _rest < "$f"
+            got="$(openssl dgst -sha256 -r "${f%.sha256}" | cut -d' ' -f1)"
+            if [ "$want" != "$got" ]; then
+              echo "::error::checksum mismatch for ${f%.sha256}: release says $want, got $got"
+              exit 1
+            fi
+            echo "ok ${f%.sha256}"
+          done
+      - name: Stage the packages
+        shell: bash
+        run: bash scripts/stage-npm.sh "${TAG#v}" dl npm-stage
+      - name: Publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A pre-release version must not move `latest`.
+          case "$TAG" in
+            *-*) DIST_TAG=beta ;;
+            *)   DIST_TAG=latest ;;
+          esac
+          echo "publishing ${TAG#v} under dist-tag $DIST_TAG"
+          # Platform packages first: the wrapper pins them by exact version
+          # in optionalDependencies, so publishing it first would leave a
+          # window in which `npm i doiget` resolves nothing to run.
+          for p in npm-stage/doiget-*; do
+            npm publish "$p" --provenance --access public --tag "$DIST_TAG"
+          done
+          npm publish npm-stage/doiget --provenance --access public --tag "$DIST_TAG"

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ lcov.info
 *.crt
 
 # Local config (per-developer)
-.cargo/config.local.toml
+# NOT .cargo/config.local.toml — cargo never reads it, and reserving the name
+# is what made three people believe it worked. See CONTRIBUTING.md.
 .envrc
 .env
 .env.local

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "doiget",
+      "args": [
+        "serve"
+      ]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+
+- **[config]** `~/.config/doiget/credentials.toml` is **read**. `docs/CONFIG.md` §6
+  had specified it in full — schema, precedence, a `0600` warning "at startup" — and
+  nothing opened it, so a user who followed a NORMATIVE document wrote their Elsevier
+  key into a file doiget ignored and then reported the source unavailable for want of
+  a key. `[tdm.<publisher>] api_key` now sits one rung below
+  `DOIGET_KEY_<PUBLISHER>`, and the permission warning exists. **The agreement did
+  not move**: `DOIGET_AGREE_TDM_<PUBLISHER>=1` stays environment-only, so it remains
+  an act taken in the session that runs the fetch rather than a boolean written once
+  into a file — an `agreed` key there is parsed only so doiget can warn that it
+  grants nothing (#509, ADR-0050).
+
 ## [0.8.10] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[transport]** `HttpClient::fetch_pdf_with_headers`. The magic-byte check is not
   optional on a credentialed endpoint: publisher error pages and WAF holding
   responses are 200s with a body.
+- **[ci]** `dco.yml` fails a PR whose commits lack a well-formed `Signed-off-by`
+  trailer. Merge commits and bot authors are exempt — GitHub writes the former, and
+  neither Dependabot nor github-actions is a legal person who could certify a
+  license grant. Deliberately not a required status check: it blocks in its own job,
+  so a missing sign-off is visible before a human merges without disturbing the
+  auto-merge chain (ADR-0045 D4).
 
 ### Changed
 
@@ -78,6 +84,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   put an open-licence claim on a file obtained by a route it does not describe.
 - **[docs]** ADR-0044, which also records that ADR-0041's rejection of
   Crossref-based publisher routing rested on a premise this change removes.
+- **[docs]** `CONTRIBUTING.md`'s one-line "your contribution is MIT" clause becomes a
+  Contributor License Agreement: a sublicensable copyright grant permitting
+  distribution under any license terms, an Apache-ICLA-shaped patent grant with
+  defensive termination, and a written promise that public releases stay under an
+  OSI-approved open source license. Inbound = outbound made the outbound license a
+  one-way door — changing it later needs permission from every past contributor, and
+  one unreachable contributor pins it forever. doiget is at the single moment when
+  reopening that door costs nothing: `git shortlog -sne --all` lists exactly one
+  human. Assent is a commit sign-off, and the change is not retroactive — everything
+  merged before it stays MIT-only (ADR-0045).
 
 ### Retracted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,10 +162,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   each read `DOIGET_CONTACT_EMAIL` directly, so a user who configured the
   address in `config.toml` got the polite pool from `doiget fetch` and the
   non-polite pool from every MCP tool — the interface doiget leads with. All
-  four now go through the same ladder. `config doctor` also reported
+  four now go through the same ladder. `config show` also reported
   `unpaywall_email: unset` in the commonest configuration of all (only
   `DOIGET_CONTACT_EMAIL` set) while the fetch it describes was sending the
   contact address; it now reports `inherited from contact_email`.
+
+  Round 2 found that fix had stopped at the MCP boundary: `graph`, `frontier`,
+  `link`, `search` and `resolve-citation` still read `DOIGET_CONTACT_EMAIL`
+  directly and so still ignored `config.toml`, with the fallback hand-copied five
+  times into two mutually inconsistent policies. All of them, and the dormant copy
+  in `OrchestratorConfig`, now go through the core resolver. `config doctor` also
+  gained the `unpaywall_email` line it never had — the round-1 note above credited
+  `doctor` for a change that landed in `show`, and `doctor` is the surface meant to
+  be worth trusting.
 - **[ci]** **The npm publish would have failed on every release, silently.** The
   `npm-publish` job downloaded `doiget-*.sha256`, a glob that also matches the SBOM's
   and the `.mcpb`'s checksums — whose binaries it never downloads — so the verify
@@ -185,15 +194,71 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[config]** `credentials.toml`'s failure modes reached only `tracing::warn!`, which
   the CLI's default `EnvFilter` suppresses — so a malformed or group-readable file
   produced no warning, no `doctor` line, and only the downstream "source unavailable"
-  the feature exists to prevent. `config doctor` now reports it the same way it already
-  reported `config.toml`, and a present-but-blank `api_key` — the one case with no log
-  call at all — is named rather than dropped (#509).
+  the feature exists to prevent. Everything a reader can learn about the file is now
+  data rather than a log record: file-level failures are a `CredentialsError`, and
+  per-entry problems — a world-readable mode, an `api_key` the user typed and left
+  blank, an `agreed` doiget does not read — are `Advisory` values `config doctor`
+  prints as failing lines (#509).
+
+  Round 1 of the pre-release review claimed both halves of this and delivered
+  neither in full. `config doctor` surfaced only whole-file parse and IO errors: a
+  `chmod 644` on a file holding publisher keys still reported `[ ok ]`, which made
+  "the `0600` check is a real control rather than a sentence" untrue in the module
+  whose own doc comment says it. And the blank-key warning did not fire for
+  `api_key = ""` — `Option::unwrap_or_default()` collapses `None` and `Some("")` to
+  one empty string, so the commonest form of the case was still the silent one. Its
+  test used that exact input and asserted only the key count, so it passed.
 - **[core]** `Credentials` no longer derives `Debug` over plain-`String` API keys; a
   hand-written impl redacts them, applying one hop earlier the same protection
-  `secrecy::SecretString` gives the value once it reaches `TdmGrant`. The TDM env-var
-  pair also moved behind `AgreeVar`/`KeyVar` newtypes: they were adjacent `&str`
-  parameters, so transposing them at a call site type-checked and would have made the
-  KEY the agreement signal for a control `docs/LEGAL.md` §6a.2 calls enforced (#509).
+  `secrecy::SecretString` gives the value once it reaches `TdmGrant`. The two raw
+  deserialisation structs, which hold the key untrimmed and unredacted one hop before
+  that, no longer derive `Debug` either. The TDM env-var pair also moved behind
+  `AgreeVar`/`KeyVar` newtypes: they were adjacent `&str` parameters, so transposing
+  them at a call site type-checked and would have made the KEY the agreement signal
+  for a control `docs/LEGAL.md` §6a.2 calls enforced (#509).
+
+  Round 1 of the review closed that hole and **opened a more direct one**: making
+  `parse` fallible put a `toml::de::Error` inside `CredentialsError::Parse`, and that
+  error's `Display` quotes the offending source line verbatim. The commonest way this
+  file is malformed is a pasted key with a stray quote in it — so the error most
+  likely to reach a terminal was the one whose quoted line *is* the key, and `config
+  doctor` printed it. Its `Debug` is worse: it carries the whole file. The variant now
+  carries the path, line, column and the parser's own message, and a test asserts a
+  planted key appears in neither `Display` nor `Debug`.
+- **[ci]** `posture-lint`'s npm mapping check went red **with an empty log**. Its
+  grep read the platform table out of `npm/doiget/bin/doiget.js` after that table had
+  moved to `platform.js`; under `set -euo pipefail` a grep matching nothing exits 1
+  and kills the step before it can print anything, so a check that had correctly
+  detected drift looked like infrastructure flake — and the packaging tests queued
+  behind it never ran at all. Every grep in the step now goes through a helper that
+  turns "matched nothing" into a named error (#511).
+- **[ci]** `dco` could never pass on a `next → main` promotion. A promotion's commit
+  range is the whole release, and for the release that introduces ADR-0051 that range
+  holds commits predating the CLA which can never acquire a trailer — `next` is
+  protected and its history cannot be rewritten. A job that is red whatever the author
+  does is not a gate. Promotions are now exempt on the same structural grounds as
+  merge commits and bots: they re-present commits this job already gated when they
+  landed on `next` (ADR-0051).
+- **[cli]** `fetch` and `graph` were the last two commands carrying
+  `parse_ref_or_exit`'s body hand-inlined rather than calling it, which is how they
+  came to disagree about the exit code in the first place (#492).
+- **[core]** The whole rule set for `resolve_tdm_grant` — `docs/CAPABILITY.md` §2's
+  behaviour, the `AgreedButNoKey` / `KeyButNotAgreed` cases, the `credentials.toml`
+  precedence note — was rendering as the documentation of a one-line newtype. The
+  round-1 commit put `AgreeVar`'s doc block directly after the function's with no
+  separator, and rustdoc attaches a `///` run to the next item only, so the function
+  it describes had none at all. `AgreeVar`/`KeyVar` are `pub(crate)` with private
+  fields now: their only consumer is a private `fn`, and the public tuple field left
+  `AgreeVar("DOIGET_KEY_ELSEVIER")` — the same transposition expressed as content
+  rather than position — compiling cleanly (#509).
+- **[ci]** The `npm-publish` checksum loop and `stage-npm.sh`'s missing-asset guard
+  both gained tests that fail when they are broken. The guard's existing test checked
+  only the exit code, which stays non-zero when the guard is deleted because the `cp`
+  behind it fails too — so deleting it outright still passed, while leaving a
+  half-staged package on disk. The checksum loop, the fix for the defect this cluster
+  started from, had no test at all: it is now extracted from the workflow and run
+  against synthetic release directories, including the orphaned-checksum case that
+  caused the original silent failure (#511).
 - **[cli/mcp]** The config-directory resolver existed as two hand-maintained copies whose
   own comment warned that divergence "would silently desync the user-extension allowlist
   surfaces". They had already diverged: the CLI accepted `XDG_CONFIG_HOME=""` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[metadata]** `MetadataOnlyOutcome.oa_url` handed callers **Similarity Check and
+  TDM URLs under the name `oa_url`** — to the MCP surface and to anyone reading
+  `metadata_only` output, whose own doc comment invites acting on the field "for
+  separate action". The extractor returned the first `message.link[]` entry with no
+  filtering, and Crossref's `intended-application` distinguishes a general-purpose link
+  from ones a publisher scoped to Similarity Check, syndication or its TDM programme.
+  Only `unspecified` is accepted now; an unlabelled entry is refused too, because
+  ADR-0048 D2 draws the line at documented-by-the-vendor versus guessed-by-us. Seven
+  real-world fixtures asserted the old value, which is the strongest evidence it was
+  behaviour rather than an accident (#517, ADR-0052).
+
+### Changed
+
+- **[docs]** `CONFIG.md` §6.1 named two things standing between an entitled network and
+  a paywalled paper — the allowlist, and the publisher bot wall — and **neither was
+  reached**. A third sits in front of both: for a closed work no candidate URL is ever
+  formed, so the leg ends before any host is chosen and the run exits 0 with `no OA PDF
+  available`. The section now leads with that, and says why it is not a bug awaiting a
+  fix: measured across six live DOIs and eight captured responses, **every** Crossref
+  `link[]` entry is programme-scoped and none is general-purpose, so there is nothing
+  legitimate to follow. The supported route for a closed work is a TDM credential
+  (#517, ADR-0052).
+
 ## [0.8.10] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   to mean "invalid ref" was already wrong: 1 was also every network failure and
   every other code under the catch-all (#492, ADR-0049).
 
+  Pre-release review found the claim was not yet true: `tex-source` and
+  `frontier` never routed through the shared parser, so both still exited 1 and
+  `tex-source` leaked the `Caused by:` chain #477's contract replaced. Both are
+  fixed, `annotate`'s missing-argument path moves from 1 to 2 with them, and the
+  test's command table is now **read back from clap's `--help`** instead of
+  hand-listed — a second hand-maintained copy of the subcommand set is what let
+  three commands go uncovered in the first place.
+
 - **[docs]** `CONFIG.md` §6.1 named two things standing between an entitled network and
   a paywalled paper — the allowlist, and the publisher bot wall — and **neither was
   reached**. A third sits in front of both: for a closed work no candidate URL is ever
@@ -148,6 +156,44 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   saying `no OA PDF available`. Both addresses now resolve env → `config.toml` →
   default, `config doctor` names **which rung answered**, and `contact_email` — absent
   from the generated template entirely — is in it (#504).
+
+  Pre-release review found the fix stopped at the CLI: `doiget_paper_search`,
+  `doiget_link`, `doiget_expand_citation_graph` and `doiget_resolve_citation`
+  each read `DOIGET_CONTACT_EMAIL` directly, so a user who configured the
+  address in `config.toml` got the polite pool from `doiget fetch` and the
+  non-polite pool from every MCP tool — the interface doiget leads with. All
+  four now go through the same ladder. `config doctor` also reported
+  `unpaywall_email: unset` in the commonest configuration of all (only
+  `DOIGET_CONTACT_EMAIL` set) while the fetch it describes was sending the
+  contact address; it now reports `inherited from contact_email`.
+- **[ci]** **The npm publish would have failed on every release, silently.** The
+  `npm-publish` job downloaded `doiget-*.sha256`, a glob that also matches the SBOM's
+  and the `.mcpb`'s checksums — whose binaries it never downloads — so the verify
+  step ran `openssl dgst` on a missing file and aborted under `set -euo pipefail`
+  before staging anything. The job is `continue-on-error`, so the release would have
+  reported green with npm unpublished, while the entry above says npm packages ship.
+  The four platform checksums are now named exactly, and the step asserts it verified
+  all four rather than reporting a clean run over fewer (#511).
+- **[ci]** `posture-lint`'s npm mapping check compared two disjoint clusters of names,
+  so renaming both halves consistently-but-differently passed while the wrapper
+  depended on a package the staging script never produces. The four names now form one
+  connected chain. The packaging also gained **executable** tests — the name-list greps
+  could not catch a wrong binary name or a staging bug, and the first run of the new
+  `stage-npm.sh` test immediately caught one: the script copied only `doiget.js`, so
+  the shim's `require("./platform.js")` would have thrown `MODULE_NOT_FOUND` on the
+  first `npx doiget` (#511).
+- **[config]** `credentials.toml`'s failure modes reached only `tracing::warn!`, which
+  the CLI's default `EnvFilter` suppresses — so a malformed or group-readable file
+  produced no warning, no `doctor` line, and only the downstream "source unavailable"
+  the feature exists to prevent. `config doctor` now reports it the same way it already
+  reported `config.toml`, and a present-but-blank `api_key` — the one case with no log
+  call at all — is named rather than dropped (#509).
+- **[core]** `Credentials` no longer derives `Debug` over plain-`String` API keys; a
+  hand-written impl redacts them, applying one hop earlier the same protection
+  `secrecy::SecretString` gives the value once it reaches `TdmGrant`. The TDM env-var
+  pair also moved behind `AgreeVar`/`KeyVar` newtypes: they were adjacent `&str`
+  parameters, so transposing them at a call site type-checked and would have made the
+  KEY the agreement signal for a control `docs/LEGAL.md` §6a.2 calls enforced (#509).
 - **[cli/mcp]** The config-directory resolver existed as two hand-maintained copies whose
   own comment warned that divergence "would silently desync the user-extension allowlist
   surfaces". They had already diverged: the CLI accepted `XDG_CONFIG_HOME=""` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Changed
+
+- **[cli]** **Breaking for scripts.** An unparsable ref now exits **2** (misuse) on
+  every ref-taking command, not 1. `docs/ERRORS.md` §4 already reserved 1 for "at
+  least one fetch was attempted and failed", and an unparsable ref fetches nothing —
+  but `cli_exit_code` had no `INVALID_REF` arm, so `fetch` and the eight commands
+  #477 converted fell through to the catch-all 1 while `graph` hard-coded the 2 the
+  table prescribes. One binary, two answers for the same input, and a comment at
+  each site asserting agreement with the other. A caller that branched on `$? == 1`
+  to mean "invalid ref" was already wrong: 1 was also every network failure and
+  every other code under the catch-all (#492, ADR-0049).
+
 ## [0.8.10] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,42 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+## [0.8.11] - 2026-08-27
+
 ### Added
+
+- **[config]** `~/.config/doiget/credentials.toml` is **read**. `docs/CONFIG.md` §6
+  had specified it in full — schema, precedence, a `0600` warning "at startup" — and
+  nothing opened it, so a user who followed a NORMATIVE document wrote their Elsevier
+  key into a file doiget ignored and then reported the source unavailable for want of
+  a key. `[tdm.<publisher>] api_key` now sits one rung below
+  `DOIGET_KEY_<PUBLISHER>`, and the permission warning exists. **The agreement did
+  not move**: `DOIGET_AGREE_TDM_<PUBLISHER>=1` stays environment-only, so it remains
+  an act taken in the session that runs the fetch rather than a boolean written once
+  into a file — an `agreed` key there is parsed only so doiget can warn that it
+  grants nothing (#509, ADR-0050).
+- **[dist]** **npm packages.** `npx -y doiget serve` is now the one-line MCP entry,
+  and `npm i -g doiget` puts the CLI on PATH with no Rust toolchain and no C linker.
+  The four platform binaries ship as `optionalDependencies` carrying the same signed
+  release artifacts, with **no postinstall download** — so it installs under
+  `--ignore-scripts`, through a corporate registry mirror, and inside npm's integrity
+  hashes. A postinstall fetch would have been the shorter route and is the exact
+  supply-chain shape a reviewer is trained to reject. Published by the release
+  workflow over npm Trusted Publishing (OIDC, no long-lived token), after verifying
+  each binary against the release's own `.sha256` (#511).
+- **[dist]** **Claude Code plugin.** `/plugin marketplace add QAtlasHub/doiget` then
+  `/plugin install doiget@doiget`. Self-hosted, so it needs approval from nobody;
+  both manifests pass `claude plugin validate` (#513).
+- **[ci]** `posture-lint` fails when the npm platform mapping drifts. The npm and
+  release vocabularies (`darwin`/`x64` vs `macos`/`x86_64`) are written in three
+  places — the release matrix, `scripts/stage-npm.sh` and the bin shim — and three
+  hand-maintained copies of one table is the #454 / #504 shape (#511).
+- **[dist]** **MCP Registry entry carries packages.** `server.json` was source-only, so
+  `io.github.QAtlasHub/doiget` was discoverable in the registry but not installable
+  from it. It now emits both a `cargo` and an `mcpb` package, and the release signs
+  the `.mcpb` and publishes its `.sha256` alongside — previously the one artifact a
+  user is most likely to double-click was the only one they could not verify
+  (#483).
 
 ### Changed
 
@@ -39,6 +74,26 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   as completed; the README now carries a status table naming what ships, what does
   not (Homebrew, `.deb`, Docker) and what is unverified (the Nix flake's outputs),
   with the remainder tracked in the open #501 (#501).
+- **[docs]** All six `docs/INTEGRATION/` host guides were `PLACEHOLDER (Phase 3)` and
+  told the reader to stop and wait — for a phase that shipped long ago. `claude-code.md`
+  said "Do not copy speculative JSON from elsewhere — wait for the verified Phase 3
+  snippet", which made it worse than a missing page: a missing page invites a guess and
+  this one forbade one. Each guide now carries a working configuration and an explicit
+  **exercised / not exercised** line with a date, rather than a blanket disclaimer
+  (#512).
+- **[docs]** `.cargo/config.toml` advertised `.cargo/config.local.toml` as the
+  per-developer override channel and `.gitignore` reserved the name. Cargo never reads
+  it, and the `include` that would make it real is a hard error before any cargo command
+  when the file is absent — which it is in every fresh clone. Both the promise and the
+  reserved filename are gone; `CONTRIBUTING.md` documents the two mechanisms that work
+  (`$CARGO_HOME/config.toml`, `CARGO_TARGET_DIR`), with the 195 GB this cost on one
+  machine as the reason to bound a shared target directory (#521).
+- **[ci]** The `main → next` back-merge died on a raw GraphQL dump and read as a bare
+  `backmerge / failure` in the Actions list. `gh pr create` is now trapped and its
+  stderr classified — org PAT-lifetime policy, expired token, missing scope, no diff —
+  each emitting an actionable error, with a closing line saying how far behind `next`
+  now is (#426).
+
 ### Fixed
 
 - **[metadata]** `MetadataOnlyOutcome.oa_url` handed callers **Similarity Check and
@@ -51,6 +106,37 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   ADR-0048 D2 draws the line at documented-by-the-vendor versus guessed-by-us. Seven
   real-world fixtures asserted the old value, which is the strongest evidence it was
   behaviour rather than an accident (#517, ADR-0052).
+- **[transport]** In a `--features metadata` build **every Tier-2 optional source died
+  at `UnknownSource`**. `build_http_client` registered `tier_2_allowlist()` under
+  `#[cfg(feature = "citation")]` while the sources it serves — OpenAlex, Semantic
+  Scholar, DOAJ, DataCite, HAL, OpenAIRE, CORE, Europe PMC — are compiled under
+  `metadata`, so the chain ran, `can_serve` passed, and the request was rejected for
+  want of an allowlist entry. CI's clippy matrix builds that configuration explicitly.
+  Fixing it also required `doiget-cli`'s `citation` to imply its own `metadata`, which
+  it did not — so `doiget capabilities` had been under-reporting the compiled feature
+  set too. Guarded in both crates by a test that asserts the **client** a fetch goes
+  through, not the list (#516).
+- **[source]** Europe PMC refused any record with `isOpenAccess = N` before consulting
+  `fullTextUrlList`, discarding a **Free PDF at `europepmc.org`** — a host already on
+  the `oa-publisher` allowlist — one line before the code written to find it.
+  `isOpenAccess` describes membership of the bulk OA subset; single-article
+  retrievability is a strictly weaker property Europe PMC reports per entry, and it is
+  now the gate. Measured on 10.1098/rspa.2014.0585 (PMC4277194), whose Free entry
+  returns 670 kB of `application/pdf` (#503).
+- **[config]** `[network] unpaywall_email` was written by `config init`, called STRONGLY
+  RECOMMENDED by the template's own prose, and **read by nothing** — so on a machine
+  configured from the template every request went out as `doiget@localhost` from the
+  non-polite pool, while `config doctor` reported the store root correctly from the same
+  file. The cost is not politeness: the arXiv-preprint fallback fires on what Unpaywall
+  reports, so a throttled answer quietly costs that fallback and the run still exits 0
+  saying `no OA PDF available`. Both addresses now resolve env → `config.toml` →
+  default, `config doctor` names **which rung answered**, and `contact_email` — absent
+  from the generated template entirely — is in it (#504).
+- **[cli/mcp]** The config-directory resolver existed as two hand-maintained copies whose
+  own comment warned that divergence "would silently desync the user-extension allowlist
+  surfaces". They had already diverged: the CLI accepted `XDG_CONFIG_HOME=""` and
+  resolved a **relative** `doiget/config.toml` under the cwd. Consolidated into
+  `doiget_core::user_extension::config_dir`, which keeps blank-is-unset (#504).
 
 ## [0.8.10] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+
+- **[dist]** **npm packages.** `npx -y doiget serve` is now the one-line MCP entry,
+  and `npm i -g doiget` puts the CLI on PATH with no Rust toolchain and no C linker.
+  The four platform binaries ship as `optionalDependencies` carrying the same signed
+  release artifacts, with **no postinstall download** — so it installs under
+  `--ignore-scripts`, through a corporate registry mirror, and inside npm's integrity
+  hashes. A postinstall fetch would have been the shorter route and is the exact
+  supply-chain shape a reviewer is trained to reject. Published by the release
+  workflow over npm Trusted Publishing (OIDC, no long-lived token), after verifying
+  each binary against the release's own `.sha256` (#511).
+- **[dist]** **Claude Code plugin.** `/plugin marketplace add QAtlasHub/doiget` then
+  `/plugin install doiget@doiget`. Self-hosted, so it needs approval from nobody;
+  both manifests pass `claude plugin validate` (#513).
+- **[ci]** `posture-lint` fails when the npm platform mapping drifts. The npm and
+  release vocabularies (`darwin`/`x64` vs `macos`/`x86_64`) are written in three
+  places — the release matrix, `scripts/stage-npm.sh` and the bin shim — and three
+  hand-maintained copies of one table is the #454 / #504 shape (#511).
+
+### Changed
+
+- **[docs]** `README.md` no longer points readers at closed issue #247 for the
+  install channels it promised. Four of its five did not exist when it was closed
+  as completed; the README now carries a status table naming what ships, what does
+  not (Homebrew, `.deb`, Docker) and what is unverified (the Nix flake's outputs),
+  with the remainder tracked in the open #501 (#501).
+
 ## [0.8.10] - 2026-08-26
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,91 @@ By participating in this project, you agree to abide by the
 [Contributor Covenant](https://www.contributor-covenant.org/) v2.1. Reports of
 unacceptable behavior may be sent to the maintainer at the contact email above.
 
-## License
+## Contributor License Agreement
 
-By submitting a PR, you agree that your contribution is licensed under the MIT License
-(see [LICENSE](LICENSE)).
+doiget's public releases are, and will remain, available under an OSI-approved open
+source license — today the MIT License (see [LICENSE](LICENSE)). That promise binds the
+maintainer, not you, and it is written here so it is checkable.
+
+The grant below is broader than "MIT in, MIT out". It exists so the project can change
+its outbound license later — a copyleft core with separately licensed connectors, say —
+without having to find and re-ask every past contributor. The alternatives that were
+considered and rejected are recorded in
+[ADR-0045](docs/DECISIONS/0045-contributor-license-agreement.md).
+
+### 1. Copyright grant
+
+You grant the maintainer (Sota Shimozono) and recipients of software distributed by the
+project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute your contribution and such derivative works, **under
+any license terms, including terms that differ from those in effect when you
+contributed**.
+
+You keep your copyright. This is a license, not an assignment, and it is non-exclusive:
+your contribution remains yours to use anywhere else, under any terms you like.
+
+### 2. Patent grant
+
+You grant the maintainer and recipients of software distributed by the project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated below) patent license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer your contribution. This license covers only those patent claims
+licensable by you that are necessarily infringed by your contribution alone, or by the
+combination of your contribution with the project.
+
+If any entity institutes patent litigation alleging that your contribution, or the
+project it was contributed to, constitutes direct or contributory patent infringement,
+every patent license granted to that entity under this section terminates as of the date
+the litigation is filed.
+
+### 3. What you certify
+
+By signing off (§4) you certify that:
+
+1. The contribution is your original work, or you have the right to submit it under this
+   agreement — including, where the work is not entirely yours, that its license is
+   compatible with this grant and that you have identified that license and its origin
+   in the contribution itself.
+2. You are legally entitled to grant the licenses above. If your employer holds rights
+   to intellectual property you create, you have permission to contribute on their
+   behalf, or your employer has waived those rights.
+3. You know of no third-party claim, patent, or license that your contribution
+   infringes.
+
+Tooling does not change this. A patch drafted with AI assistance is still submitted
+under your certification, and item 1 is yours to satisfy.
+
+If any of this later turns out to be untrue, tell the maintainer (see
+[CONTACT.md](CONTACT.md)) rather than leaving it in the tree.
+
+### 4. How you agree: commit sign-off
+
+Put a `Signed-off-by` trailer on every commit in your PR, with your real name and an
+email address you control:
+
+```bash
+git commit -s -m "fix(store): ..."
+#   -s writes:  Signed-off-by: Your Name <you@example.com>
+#               taken from your git user.name / user.email
+
+git rebase --signoff origin/next   # sign off commits you already made
+```
+
+A sign-off means: *"I agree to the Contributor License Agreement in this file, as it
+read when I contributed."*
+
+The trailer is deliberately the whole mechanism. It lives in `git log`, so the record is
+auditable from a clone alone, and no signature service has to outlive the project.
+[`dco.yml`](.github/workflows/dco.yml) checks it on every PR; commits authored by bots
+and merge commits created by GitHub are exempt.
+
+### 5. Scope
+
+This section governs contributions to this repository. It does not change the terms
+under which you received doiget, and it is not retroactive — contributions merged before
+it was added are licensed under the MIT License alone, per the text it replaces.
+
+**This is not legal advice, and the maintainer is not a lawyer.** If your employer needs
+a countersigned agreement rather than a commit trailer, contact the maintainer before
+opening a PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,42 @@ subcommand list, and any `doiget <subcommand>` returns a `Phase 0 stub` error.
 `cargo test` runs the four smoke tests in
 `crates/doiget-core/src/lib.rs::tests`.
 
+### Per-developer settings
+
+**Do not put them in the repository.** `.cargo/config.toml` is tracked and pins
+the reproducibility settings ([`docs/SECURITY.md`](docs/SECURITY.md) §1.9); it is
+not a place for your machine's preferences. There is no
+`.cargo/config.local.toml` — cargo reads only `config.toml` from a `.cargo`
+directory, and the `include = [...]` that would make a sibling file real is a
+hard error before any cargo command runs when the file is missing, which it
+would be in every fresh clone and on every CI runner (#521).
+
+Two mechanisms work and need no change to this repository:
+
+**`$CARGO_HOME/config.toml`** (`~/.cargo/config.toml`) — cargo merges it into
+the config hierarchy automatically for every project. Per cargo's documented
+precedence it sits *below* the repository's `.cargo/config.toml`, so the pinned
+`[net]` / `[term]` / reproducibility values still win where the two overlap.
+That is the right way round: your defaults apply to everything the repo does
+not deliberately fix.
+
+**`CARGO_TARGET_DIR`** (or `--target-dir`) for build output. Worth being
+deliberate about:
+
+```sh
+# per-checkout, and it goes away with the checkout
+cargo build                       # -> ./target
+
+# shared across checkouts — pick a path you will actually look at
+export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/doiget"
+```
+
+A shared target directory grows without bound and nothing prunes it. On
+2026-08-26 two of them — set ad hoc to fixed paths under `%TEMP%` — held
+**115 GB and 81 GB** on one machine and took it to 95% full; deleting them
+recovered 195 GB. If you share one, put it somewhere you will notice, and
+`cargo clean --target-dir <path>` occasionally.
+
 ## Before you open a PR
 
 1. Read [docs/SCOPE.md](docs/SCOPE.md) for the **Permanent non-goals** list. PRs that move

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.7"
+version = "0.8.10-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.1"
+version = "0.8.11-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10-beta.3"
+version = "0.8.10-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.12"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.12"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.12"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11-beta.2"
+version = "0.8.11-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.12"
+version       = "0.8.11"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.12" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.12" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.12" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.3"
+version       = "0.8.10-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10-beta.7"
+version       = "0.8.10-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.10-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.1"
+version       = "0.8.11-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.10"
+version       = "0.8.11-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.10" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.10" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.10" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11-beta.2"
+version       = "0.8.11-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.11-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -111,9 +111,48 @@ linker is mandatory — `cargo install` cannot link a binary without one):
 If you don't have (or don't want) a build toolchain, use one of the prebuilt
 installers above — they need no compiler.
 
-Further prebuilt-binary channels (Homebrew tap, `cargo binstall`, npm/npx, Nix flake,
-`.deb`) are tracked in [#247](https://github.com/QAtlasHub/doiget/issues/247). Every
-release asset is cosign-keyless signed (`<asset>.cosign.bundle`) for optional verification.
+### npm / npx — one line in an agent config
+
+```sh
+npx -y doiget serve          # MCP server, no install step
+npm install -g doiget        # or put `doiget` on PATH
+```
+
+The npm packages carry the same signed release binaries as `optionalDependencies`
+— npm resolves the one matching your platform, and there is **no postinstall
+download**, so this works under `--ignore-scripts` and through a corporate
+registry mirror. `npm view doiget version` tells you what is published; the
+packages ship from tagged releases, so a very new commit may be ahead of them.
+
+### Claude Code plugin
+
+```
+/plugin marketplace add QAtlasHub/doiget
+/plugin install doiget@doiget
+```
+
+Reads `.claude-plugin/` from this repository's default branch. The plugin's
+`.mcp.json` runs `doiget serve`, so install the binary by one of the routes
+above first.
+
+### Channel status
+
+| Channel | Status |
+|---|---|
+| Shell / PowerShell installer | shipping |
+| GitHub Release binaries (signed, SBOM) | shipping |
+| `cargo install doiget-cli` | shipping (needs a C linker) |
+| `.mcpb` Claude Desktop extension | shipping since 0.8.4 |
+| MCP Registry | listed |
+| npm / npx | publishes from the next tagged release |
+| Claude Code plugin | self-hosted marketplace, as above |
+| Homebrew tap, `.deb`, Docker | **not built** |
+| Nix | `flake.nix` exists; whether it exposes an installable package rather than a dev shell is unverified |
+
+[#247](https://github.com/QAtlasHub/doiget/issues/247) was closed as completed
+while four of its five channels did not exist; the remaining ones are tracked in
+[#501](https://github.com/QAtlasHub/doiget/issues/501). Every release asset is
+cosign-keyless signed (`<asset>.cosign.bundle`) for optional verification.
 
 ## Quick start
 

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -23,7 +23,11 @@ workspace = true
 default  = ["oa-only"]
 oa-only  = ["doiget-core/oa-only"]
 metadata = ["doiget-core/metadata"]
-citation = ["doiget-core/citation"]
+# Mirrors `doiget-core`'s own `citation = ["metadata"]`. Without the
+# CLI-level implication `cfg(feature = "metadata")` is FALSE in a
+# `--features citation` build, so anything gated on `metadata` here
+# silently drops out of the richer build (#516).
+citation = ["metadata", "doiget-core/citation"]
 # The `doiget-mcp/*` half matters: `doiget serve` builds its client
 # through the MCP twin of `build_http_client`, so a CLI-only feature
 # would leave the MCP surface without the Tier-3 transport gate (#454).

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -54,9 +54,64 @@ pub struct ResolvedConfig {
     /// Contact email for the polite User-Agent header (and Unpaywall fallback).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contact_email: Option<String>,
+    /// Which rung produced `contact_email` (#504) — same reason
+    /// `store_root_source` exists (#441): a setting that did nothing must
+    /// not look like a setting that worked.
+    pub contact_email_source: String,
     /// Unpaywall-specific contact email; falls back to `contact_email` when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unpaywall_email: Option<String>,
+    /// Which rung produced `unpaywall_email` (#504).
+    pub unpaywall_email_source: String,
+}
+
+/// Which rung of the #504 ladder produced an address.
+///
+/// Reported for the reason [`super::StoreRootSource`] is: `config init`
+/// wrote `[network] unpaywall_email`, the template called it STRONGLY
+/// RECOMMENDED, `doctor` never mentioned it, and nothing read it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmailSource {
+    /// The env var for this field.
+    Env(&'static str),
+    /// `[network] <field>` in the user's `config.toml`.
+    ConfigFile(&'static str),
+    /// Nothing set it.
+    Unset,
+}
+
+impl EmailSource {
+    /// Short label for `config show` / `doctor`.
+    fn label(self) -> String {
+        match self {
+            Self::Env(v) => v.to_string(),
+            Self::ConfigFile(k) => format!("[network] {k} in config.toml"),
+            Self::Unset => "unset".to_string(),
+        }
+    }
+}
+
+/// Resolve one address across env → `config.toml` → nothing.
+///
+/// Mirrors `doiget_core::orchestrator::resolve_contact_email`. Two
+/// separate readers is the hazard #441 named, so the shared half — which
+/// file, and how it parses — lives in `doiget_core::user_extension`, and
+/// only the rung order is restated here. Both ends are pinned:
+/// `contact_email_comes_from_config_toml_when_the_env_is_unset` below,
+/// and `resolve_contact_email_reads_the_config_file_rung` in
+/// `doiget-core`.
+fn resolve_email(
+    env_var: &'static str,
+    key: &'static str,
+    from_file: Option<String>,
+) -> (Option<String>, EmailSource) {
+    if let Some(v) = std::env::var(env_var).ok().filter(|s| !s.trim().is_empty()) {
+        return (Some(v), EmailSource::Env(env_var));
+    }
+    match from_file {
+        Some(v) => (Some(v), EmailSource::ConfigFile(key)),
+        None => (None, EmailSource::Unset),
+    }
 }
 
 impl ResolvedConfig {
@@ -113,6 +168,19 @@ impl ResolvedConfig {
         let config_dir = cfg.join("doiget");
         let config_path = config_dir.join("config.toml");
 
+        // #504: the two addresses have a `config.toml` rung, like
+        // `store_root` since #441. Read once — a parse failure loses every
+        // file rung at once, and `doctor`'s user-extension check reports it
+        // separately, so this stays quiet and reports `unset`.
+        let file = doiget_core::user_extension::load(&config_path).unwrap_or_default();
+        let (contact_email, contact_email_source) =
+            resolve_email("DOIGET_CONTACT_EMAIL", "contact_email", file.contact_email);
+        let (unpaywall_email, unpaywall_email_source) = resolve_email(
+            "DOIGET_UNPAYWALL_EMAIL",
+            "unpaywall_email",
+            file.unpaywall_email,
+        );
+
         Ok(Self {
             store_root,
             store_root_source: store_root_source.label().to_string(),
@@ -120,8 +188,10 @@ impl ResolvedConfig {
             log_path,
             config_dir,
             config_path,
-            contact_email: std::env::var("DOIGET_CONTACT_EMAIL").ok(),
-            unpaywall_email: std::env::var("DOIGET_UNPAYWALL_EMAIL").ok(),
+            contact_email,
+            contact_email_source: contact_email_source.label(),
+            unpaywall_email,
+            unpaywall_email_source: unpaywall_email_source.label(),
         })
     }
 }
@@ -261,12 +331,14 @@ pub async fn run(
                 &mut all_ok,
             );
             check(
-                "contact_email set",
+                &format!("contact_email set (from: {})", cfg.contact_email_source),
                 cfg.contact_email.is_some(),
                 Some(
-                    "set DOIGET_CONTACT_EMAIL to your email address\n               \
+                    "set DOIGET_CONTACT_EMAIL, or [network] contact_email in config.toml\n               \
                      e.g. export DOIGET_CONTACT_EMAIL=you@institution.edu\n               \
-                     (required for the polite User-Agent header and Unpaywall API)",
+                     (polite User-Agent header + Unpaywall API; without it requests go\n               \
+                     out as doiget@localhost from the non-polite pool, where a throttled\n               \
+                     answer is indistinguishable from `no OA copy` — #504)",
                 ),
                 &mut all_ok,
             );
@@ -417,10 +489,19 @@ pub(crate) fn config_template() -> &'static str {
 [network]
 # Contact address for the polite pool. STRONGLY RECOMMENDED.
 #
-# Without it doiget still queries Unpaywall, but as `doiget@localhost`, from
-# the non-polite pool — where you may be throttled or refused. Since the
-# automatic arXiv-preprint fallback fires on what Unpaywall reports, a
-# throttled response quietly costs you that fallback too.
+# Without it doiget still queries Unpaywall and Crossref, but as
+# `doiget@localhost`, from the non-polite pool — where you may be throttled
+# or refused. Since the automatic arXiv-preprint fallback fires on what
+# Unpaywall reports, a throttled response quietly costs you that fallback
+# too, and the run still exits 0 saying `no OA PDF available`.
+#
+# This is also what `doiget config doctor` checks. Overridden by
+# DOIGET_CONTACT_EMAIL, one rung above.
+# contact_email = "you@institution.edu"
+
+# Only if Unpaywall should see a DIFFERENT address from contact_email above
+# — most people should leave this alone. Overridden by
+# DOIGET_UNPAYWALL_EMAIL.
 # unpaywall_email = "you@institution.edu"
 
 # Allow the curated academic-repository suffixes, i.e. where institutions
@@ -605,7 +686,9 @@ fn contact_report_lines(contact_email: Option<&str>) -> Vec<String> {
             "  contact         polite User-Agent as {e} (all outbound requests)"
         )],
         None => vec![
-            "  contact         no DOIGET_CONTACT_EMAIL — every outbound request, metadata"
+            "  contact         unset — set DOIGET_CONTACT_EMAIL or [network] contact_email"
+                .to_string(),
+            "                  in config.toml. Until then every outbound request, metadata"
                 .to_string(),
             "                  AND publisher content, goes out on the non-polite pool and"
                 .to_string(),
@@ -777,6 +860,15 @@ mod tests {
         .collect()
     }
 
+    /// Point every config-dir rung at `dir`, so `config_dir_utf8()`
+    /// resolves there on any host. Returns guards that restore prior values.
+    fn scoped_config_home(dir: &str) -> Vec<EnvGuard> {
+        ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"]
+            .iter()
+            .map(|v| EnvGuard::set(v, dir))
+            .collect()
+    }
+
     #[test]
     #[serial_test::serial]
     fn from_env_uses_cwd_default_when_unset() {
@@ -796,6 +888,64 @@ mod tests {
         );
         assert_eq!(cfg.contact_email, None);
         assert_eq!(cfg.unpaywall_email, None);
+        assert_eq!(cfg.contact_email_source, "unset");
+        assert_eq!(cfg.unpaywall_email_source, "unset");
+    }
+
+    /// #504, and the exact shape #441 needed: a `config.toml` carrying only
+    /// `[network] contact_email` must produce a non-default contact.
+    ///
+    /// The old tests asserted the env-derived values and the template's key
+    /// list, and **both passed with the rung missing** — so on a machine
+    /// configured from the template every fetch went out as
+    /// `doiget@localhost` while `doctor` reported the store root correctly
+    /// from the very same file.
+    #[test]
+    #[serial_test::serial]
+    fn contact_email_comes_from_config_toml_when_the_env_is_unset() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+        std::fs::write(
+            dir.join("doiget").join("config.toml").as_std_path(),
+            "[network]\ncontact_email = \"file@institution.edu\"\nunpaywall_email = \"up@institution.edu\"\n",
+        )
+        .expect("write config");
+        let _scoped = scoped_config_home(dir.as_str());
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        assert_eq!(cfg.contact_email.as_deref(), Some("file@institution.edu"));
+        assert_eq!(cfg.unpaywall_email.as_deref(), Some("up@institution.edu"));
+        assert_eq!(
+            cfg.contact_email_source, "[network] contact_email in config.toml",
+            "doctor must name the rung that answered, or an inert setting looks like a live one"
+        );
+    }
+
+    /// The env rung stays above the file rung, per field.
+    #[test]
+    #[serial_test::serial]
+    fn the_env_var_outranks_the_config_file_for_each_address() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+        std::fs::write(
+            dir.join("doiget").join("config.toml").as_std_path(),
+            "[network]\ncontact_email = \"file@institution.edu\"\n",
+        )
+        .expect("write config");
+        let _scoped = scoped_config_home(dir.as_str());
+        std::env::set_var("DOIGET_CONTACT_EMAIL", "env@institution.edu");
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        std::env::remove_var("DOIGET_CONTACT_EMAIL");
+
+        assert_eq!(cfg.contact_email.as_deref(), Some("env@institution.edu"));
+        assert_eq!(cfg.contact_email_source, "DOIGET_CONTACT_EMAIL");
     }
 
     /// Issue #405: `config show` / `config path` / `doctor` MUST name the
@@ -889,6 +1039,7 @@ mod tests {
         for key in [
             "[store]",
             "root =",
+            "contact_email",
             "unpaywall_email",
             "trust_academic_repos",
             "trust_oa_registries",
@@ -1250,9 +1401,17 @@ mod tests {
     /// #443: the wording must not pin the cost of an unset contact address
     /// on the metadata leg — the 429 that prompted this came from the
     /// publisher, on the content leg.
+    ///
+    /// #504 adds the second half: the advisory must name **both** rungs, or
+    /// it sends a user who configured from `config init` to the one place
+    /// they were not looking.
     #[test]
     fn the_contact_advisory_names_every_outbound_request_not_just_unpaywall() {
         let joined = contact_report_lines(None).join("\n");
+        assert!(
+            joined.contains("DOIGET_CONTACT_EMAIL") && joined.contains("[network] contact_email"),
+            "both rungs must be named, not only the env var:\n{joined}"
+        );
         assert!(
             joined.contains("every outbound request") && joined.contains("publisher content"),
             "the advisory must cover the content leg too:\n{joined}"

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -58,7 +58,12 @@ pub struct ResolvedConfig {
     /// `store_root_source` exists (#441): a setting that did nothing must
     /// not look like a setting that worked.
     pub contact_email_source: String,
-    /// Unpaywall-specific contact email; falls back to `contact_email` when unset.
+    /// Unpaywall-specific contact email. Inherits `contact_email` when no
+    /// Unpaywall-specific rung is set, matching
+    /// `doiget_core::orchestrator::resolve_unpaywall_email` — the reporting
+    /// side used to omit that fallback and print `unset` for the commonest
+    /// configuration of all (only `DOIGET_CONTACT_EMAIL` set), while the
+    /// fetch it describes was sending the contact address.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unpaywall_email: Option<String>,
     /// Which rung produced `unpaywall_email` (#504).
@@ -76,6 +81,9 @@ pub(crate) enum EmailSource {
     Env(&'static str),
     /// `[network] <field>` in the user's `config.toml`.
     ConfigFile(&'static str),
+    /// No Unpaywall-specific rung is set, so it inherits `contact_email`.
+    /// Only ever produced for `unpaywall_email`.
+    InheritedFromContact,
     /// Nothing set it.
     Unset,
 }
@@ -86,6 +94,7 @@ impl EmailSource {
         match self {
             Self::Env(v) => v.to_string(),
             Self::ConfigFile(k) => format!("[network] {k} in config.toml"),
+            Self::InheritedFromContact => "inherited from contact_email".to_string(),
             Self::Unset => "unset".to_string(),
         }
     }
@@ -175,11 +184,24 @@ impl ResolvedConfig {
         let file = doiget_core::user_extension::load(&config_path).unwrap_or_default();
         let (contact_email, contact_email_source) =
             resolve_email("DOIGET_CONTACT_EMAIL", "contact_email", file.contact_email);
-        let (unpaywall_email, unpaywall_email_source) = resolve_email(
+        let (unpaywall_email, unpaywall_email_source) = match resolve_email(
             "DOIGET_UNPAYWALL_EMAIL",
             "unpaywall_email",
             file.unpaywall_email,
-        );
+        ) {
+            // No Unpaywall-specific rung: the fetch path falls back to the
+            // resolved contact address, so the report has to say so rather
+            // than `unset`.
+            (None, _) => (
+                contact_email.clone(),
+                if contact_email.is_some() {
+                    EmailSource::InheritedFromContact
+                } else {
+                    EmailSource::Unset
+                },
+            ),
+            found => found,
+        };
 
         Ok(Self {
             store_root,
@@ -398,6 +420,47 @@ pub async fn run(
                         "fix {} — see docs/CONFIG.md §3 for the \
                          [[network.additional_hosts]] schema",
                         cfg.config_path
+                    )),
+                    &mut all_ok,
+                ),
+            }
+            // #509 gave `credentials.toml` a reader; this gives it the same
+            // doctor visibility its sibling above already had. Without it
+            // the file's failure modes reach only `tracing::warn!`, which
+            // `EnvFilter::from_default_env()` suppresses at the default
+            // level — so a malformed or world-readable credentials file
+            // produced no warning, no doctor line, and only the downstream
+            // "source unavailable" the whole feature exists to prevent.
+            //
+            // A missing file is normal and reports `[ ok ]` with a count of
+            // zero: TDM is opt-in, and most installs have no such file.
+            // Keys are counted, never printed.
+            let cred_path = cfg.config_dir.join("credentials.toml");
+            match doiget_core::credentials::load(&cred_path) {
+                Ok(creds) => {
+                    check(
+                        &format!(
+                            "credentials.toml keys loaded: {} ({})",
+                            creds.len(),
+                            if creds.is_empty() {
+                                "none — TDM sources need DOIGET_KEY_* or this file"
+                            } else {
+                                "publisher names only; keys are never printed"
+                            }
+                        ),
+                        true,
+                        None,
+                        &mut all_ok,
+                    );
+                }
+                Err(e) => check(
+                    &format!("credentials.toml invalid: {e}"),
+                    false,
+                    Some(&format!(
+                        "fix {cred_path} — see docs/CONFIG.md §6 for the \
+                         [tdm.<publisher>] schema. Only `api_key` is read; \
+                         the agreement is DOIGET_AGREE_TDM_<PUBLISHER>=1 in \
+                         the environment (ADR-0050)"
                     )),
                     &mut all_ok,
                 ),
@@ -922,6 +985,46 @@ mod tests {
             cfg.contact_email_source, "[network] contact_email in config.toml",
             "doctor must name the rung that answered, or an inert setting looks like a live one"
         );
+    }
+
+    /// The commonest configuration of all: only `DOIGET_CONTACT_EMAIL` is
+    /// set. The fetch path sends that address to Unpaywall
+    /// (`resolve_unpaywall_email` falls back to the resolved contact), so
+    /// `doctor` and `show` must say so. They used to print `unset`, which
+    /// described a request doiget does not make.
+    #[test]
+    #[serial_test::serial]
+    fn an_unset_unpaywall_address_reports_the_contact_it_actually_inherits() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        let _scoped = scoped_config_home(dir.as_str());
+        let _c = EnvGuard::set("DOIGET_CONTACT_EMAIL", "only@institution.edu");
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        assert_eq!(
+            cfg.unpaywall_email.as_deref(),
+            Some("only@institution.edu"),
+            "the report must match what the fetch path sends"
+        );
+        assert_eq!(cfg.unpaywall_email_source, "inherited from contact_email");
+    }
+
+    /// With nothing set at all there is nothing to inherit, so `unset` is
+    /// still the honest answer.
+    #[test]
+    #[serial_test::serial]
+    fn with_no_address_anywhere_unpaywall_still_reports_unset() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        let _scoped = scoped_config_home(dir.as_str());
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        assert_eq!(cfg.unpaywall_email, None);
+        assert_eq!(cfg.unpaywall_email_source, "unset");
     }
 
     /// The env rung stays above the file rung, per field.

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -60,7 +60,7 @@ pub struct ResolvedConfig {
     pub contact_email_source: String,
     /// Unpaywall-specific contact email. Inherits `contact_email` when no
     /// Unpaywall-specific rung is set, matching
-    /// `doiget_core::orchestrator::resolve_unpaywall_email` — the reporting
+    /// `doiget_core::orchestrator::resolve_contact_emails` — the reporting
     /// side used to omit that fallback and print `unset` for the commonest
     /// configuration of all (only `DOIGET_CONTACT_EMAIL` set), while the
     /// fetch it describes was sending the contact address.
@@ -102,7 +102,7 @@ impl EmailSource {
 
 /// Resolve one address across env → `config.toml` → nothing.
 ///
-/// Mirrors `doiget_core::orchestrator::resolve_contact_email`. Two
+/// Mirrors `doiget_core::orchestrator::configured_contact_email`. Two
 /// separate readers is the hazard #441 named, so the shared half — which
 /// file, and how it parses — lives in `doiget_core::user_extension`, and
 /// only the rung order is restated here. Both ends are pinned:
@@ -364,6 +364,21 @@ pub async fn run(
                 ),
                 &mut all_ok,
             );
+            // `config show` reports which rung answered for Unpaywall;
+            // doctor did not mention the address at all, so the surface
+            // meant to be the trustworthy one was silent about a request
+            // doiget actually makes. Never a failure on its own — it
+            // inherits `contact_email`, whose line above carries the remedy.
+            check(
+                &format!(
+                    "unpaywall_email: {} (from: {})",
+                    cfg.unpaywall_email.as_deref().unwrap_or("unset"),
+                    cfg.unpaywall_email_source
+                ),
+                true,
+                None,
+                &mut all_ok,
+            );
             // ADR-0028 D2: surface user-extension allowlist health. A
             // missing config.toml is normal (curated set only); a
             // present-but-malformed config.toml is a doctor failure so
@@ -452,6 +467,23 @@ pub async fn run(
                         None,
                         &mut all_ok,
                     );
+                    // A file that parses can still be wrong in ways that
+                    // cost the user a key: mode 0644 on a file holding
+                    // publisher credentials, an `api_key = ""` they believe
+                    // is set, an `agreed` this tool does not read. Each was
+                    // a `tracing::warn!` and nothing else, which the
+                    // default `EnvFilter` throws away — so the `0600` check
+                    // `docs/CONFIG.md` §6 promises reached nobody. Each is
+                    // a failing line here, because each is a thing the user
+                    // has to act on.
+                    for advisory in creds.advisories() {
+                        check(
+                            &format!("credentials.toml: {advisory}"),
+                            false,
+                            None,
+                            &mut all_ok,
+                        );
+                    }
                 }
                 Err(e) => check(
                     &format!("credentials.toml invalid: {e}"),
@@ -989,7 +1021,7 @@ mod tests {
 
     /// The commonest configuration of all: only `DOIGET_CONTACT_EMAIL` is
     /// set. The fetch path sends that address to Unpaywall
-    /// (`resolve_unpaywall_email` falls back to the resolved contact), so
+    /// (`resolve_contact_emails` falls back to the resolved contact), so
     /// `doctor` and `show` must say so. They used to print `unset`, which
     /// described a request doiget does not make.
     #[test]
@@ -1368,6 +1400,90 @@ mod tests {
             .downcast_ref::<CliExit>()
             .expect("failing doctor must carry a CliExit");
         assert_eq!(cli_exit.0, 2);
+    }
+
+    /// `credentials.toml`'s reader is unit-tested; its WIRING into doctor
+    /// was not. Nothing failed if `cred_path` were built from the wrong
+    /// directory, or if the `Err` arm stopped setting `all_ok = false` —
+    /// which is the whole reason the check was added.
+    ///
+    /// Linux only, for the same reason as
+    /// `doctor_fails_with_malformed_user_extension_config`: `XDG_CONFIG_HOME`
+    /// is the only hermetic way to redirect the config dir.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn doctor_fails_when_credentials_toml_is_malformed() {
+        let _g = unset_all_doiget_config_env();
+        let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        // An unterminated string: the commonest way a pasted key breaks
+        // this file, and the case whose parser message must not be echoed.
+        std::fs::write(
+            doiget_dir.join("credentials.toml").as_std_path(),
+            "[tdm.elsevier]\napi_key = \"sk-unterminated\n",
+        )
+        .expect("write credentials.toml");
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+
+        let err = run(
+            "doctor".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("doctor must fail when credentials.toml is malformed");
+        assert_eq!(
+            err.downcast_ref::<CliExit>()
+                .expect("failing doctor must carry a CliExit")
+                .0,
+            2
+        );
+    }
+
+    /// A file that parses but carries an advisory must fail doctor too.
+    /// Otherwise `[ ok ] credentials.toml keys loaded: 0` is the entire
+    /// report for a user who typed a key and did not get one.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn doctor_fails_when_credentials_toml_carries_an_advisory() {
+        let _g = unset_all_doiget_config_env();
+        let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        // Well-formed TOML; the key is present and blank.
+        std::fs::write(
+            doiget_dir.join("credentials.toml").as_std_path(),
+            "[tdm.aps]\napi_key = \"\"\n",
+        )
+        .expect("write credentials.toml");
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+
+        let err = run(
+            "doctor".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("a blank api_key must be reported, not passed over");
+        assert_eq!(
+            err.downcast_ref::<CliExit>()
+                .expect("failing doctor must carry a CliExit")
+                .0,
+            2
+        );
     }
 
     /// Issue #322: `check` must emit a `tip:` line to stderr when the

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -138,24 +138,21 @@ fn home_dir_utf8() -> Result<Utf8PathBuf> {
     Err(anyhow!("neither HOME nor USERPROFILE is set"))
 }
 
-/// Best-effort config-dir resolution. Honors `XDG_CONFIG_HOME` first
-/// (POSIX), then `APPDATA` (Windows), then falls back to `$HOME/.config`.
+/// Config-dir resolution, delegated to `doiget_core::user_extension`.
 ///
-/// Crate-visible so sibling modules (`commands::capabilities`,
-/// `commands::config`) can resolve the same `<config_dir>/doiget/`
-/// path the production HTTP-client builder reads from. Keep the
-/// signature stable: any divergence between this and the MCP-side
-/// copy (`crates/doiget-mcp/src/lib.rs::config_dir_utf8`) would
-/// silently desync the user-extension allowlist surfaces.
+/// This used to be one of three copies. The previous comment here asked
+/// the reader to "keep the signature stable" because divergence from the
+/// MCP-side copy "would silently desync the user-extension allowlist
+/// surfaces" — and they had already diverged, this one accepting
+/// `XDG_CONFIG_HOME=""` and resolving a *relative* config path under the
+/// cwd where the MCP copy treated blank as unset. The shared resolver
+/// keeps blank-is-unset, so a blank variable no longer silently selects a
+/// different file.
+///
+/// Kept as a crate-visible wrapper so the ~20 call sites in
+/// `commands::capabilities` / `commands::config` are unchanged.
 pub(crate) fn config_dir_utf8() -> Result<Utf8PathBuf> {
-    if let Some(s) = read_env_utf8("XDG_CONFIG_HOME")? {
-        return Ok(Utf8PathBuf::from(s));
-    }
-    if let Some(s) = read_env_utf8("APPDATA")? {
-        return Ok(Utf8PathBuf::from(s));
-    }
-    let home = home_dir_utf8()?;
-    Ok(home.join(".config"))
+    Ok(doiget_core::user_extension::config_dir()?)
 }
 
 /// Best-effort resolver-cache root (`docs/CACHE.md`). Honors
@@ -377,10 +374,11 @@ pub(crate) fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> 
 
 /// Resolved configuration derived from the environment.
 ///
-/// Slice 2: `contact_email` / `unpaywall_email` are now read by the
-/// `doiget-core::orchestrator::fetch_paper` orchestrator directly from
-/// the env (`contact_email_from_env` / `unpaywall_email_from_env` in
-/// that module), so the CLI no longer threads them through. The fields
+/// Slice 2: `contact_email` / `unpaywall_email` are read by the
+/// `doiget-core::orchestrator::fetch_paper` orchestrator itself
+/// (`resolve_contact_email` / `resolve_unpaywall_email` in that module —
+/// env var, then `[network]` in `config.toml`, then the default since
+/// #504), so the CLI no longer threads them through. The fields
 /// stay here so a future slice that adds CLI-flag overrides has a
 /// natural attachment point — the `#[allow(dead_code)]` is the minimal
 /// intervention until that slice lands.

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -46,7 +46,7 @@ use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 
 use super::output::print_err;
-#[cfg(feature = "citation")]
+#[cfg(feature = "metadata")]
 use doiget_core::http::tier_2_allowlist;
 use doiget_core::http::{
     discovery_allowlist, fulltext_allowlist, oa_publisher_allowlist, tier_1_allowlist,
@@ -258,13 +258,18 @@ pub(crate) fn build_http_client(user_agent: Option<&str>) -> Result<HttpClient> 
         // `"ar5iv"` source key unconditionally so `paper_text::paper_text`
         // can reach ar5iv in `oa-only` builds.
         allowlists.extend(fulltext_allowlist());
-        // Slice 16: when the `citation` feature is compiled in, the
-        // graph subcommand walks OpenAlex Work IDs via
-        // `ctx.http.fetch_bytes("openalex", ...)`. The Tier 2
-        // allowlist registers the `api.openalex.org` host under
-        // that source key. CapabilityProfile.metadata.openalex is
-        // the runtime gate; the allowlist is the transport gate.
-        #[cfg(feature = "citation")]
+        // The Tier-2 transport gate. The sources it serves — OpenAlex,
+        // Semantic Scholar, DOAJ, DataCite, HAL, OpenAIRE, CORE and
+        // Europe PMC — are compiled under `metadata`, and
+        // `resolve_optional_chain` is `#[cfg(feature = "metadata")]`,
+        // so this extend MUST be gated on `metadata` too. It was gated
+        // on `citation` for six releases: in a `--features metadata`
+        // build (which CI's clippy matrix builds explicitly) the chain
+        // ran, `can_serve` passed, and the request died at
+        // `UnknownSource` because no allowlist entry existed for the
+        // key (#516). CapabilityProfile.metadata.* is the runtime gate;
+        // this is the transport gate, and the two must agree.
+        #[cfg(feature = "metadata")]
         allowlists.extend(tier_2_allowlist());
         // #454: the Tier-3 transport gate. #444 made the orchestrator
         // reach these sources; without this line the fetch it then issues
@@ -1383,6 +1388,62 @@ mod tests {
         }
     }
 
+    /// #516: the Tier-2 half of the same guard, and the reason it is
+    /// needed is that the Tier-3 lesson was not applied one tier up.
+    ///
+    /// `every_tier_2_source_has_a_transport_allowlist_entry` (in
+    /// `http.rs`) asserts that `tier_2_allowlist()` *contains* every
+    /// source key. That stayed true while the extend into the production
+    /// client was gated on `citation` rather than `metadata`, so in a
+    /// `--features metadata` build — which CI's clippy matrix builds
+    /// explicitly — `resolve_optional_chain` ran, `can_serve` passed,
+    /// and the request died at `UnknownSource`.
+    ///
+    /// This asserts the object the fetch goes through, and it enumerates
+    /// from `tier_2_allowlist()` rather than a literal so a new source
+    /// cannot be added to the list and missed here.
+    #[test]
+    #[serial]
+    #[cfg(feature = "metadata")]
+    fn the_production_client_registers_every_tier_2_source_key() {
+        // Every base override must be clear or `build_http_client` takes
+        // the test-mode branch, which registers whatever it is given and
+        // would prove nothing.
+        let _g: Vec<EnvGuard> = [
+            "DOIGET_ARXIV_BASE",
+            "DOIGET_CROSSREF_BASE",
+            "DOIGET_UNPAYWALL_BASE",
+            "DOIGET_OA_PUBLISHER_BASE",
+            "DOIGET_OPENALEX_BASE",
+            "DOIGET_AR5IV_BASE",
+        ]
+        .iter()
+        .map(|k| {
+            let g = EnvGuard::save(k);
+            std::env::remove_var(k);
+            g
+        })
+        .collect();
+
+        let client = build_http_client(None).expect("production client builds");
+
+        // Fully qualified on purpose: the `use` at the top of this file is
+        // itself `#[cfg(feature = "metadata")]`, so importing it here would
+        // turn a regression into a compile error in this file rather than the
+        // assertion failure that names the actual defect.
+        let keys: Vec<String> = doiget_core::http::tier_2_allowlist()
+            .iter()
+            .map(|a| a.source.clone())
+            .collect();
+        assert!(!keys.is_empty(), "the guard must have checked something");
+        for key in keys {
+            assert!(
+                client.source_allowlist(&key).is_some(),
+                "the production client has no allowlist for `{key}`; \n                 `resolve_optional_chain` reaches this source in a \n                 `metadata` build and the fetch would die at \n                 UnknownSource (#516)"
+            );
+        }
+    }
+
     #[test]
     fn new_session_id_is_26_chars() {
         // ULID textual form is fixed-width 26 chars (Crockford base32).
@@ -1582,9 +1643,10 @@ host = "*.uj.edu.pl"
     /// ADR-0031 D2: discovery search (`doiget search`) ships in the default
     /// `oa-only` binary, so `api.openalex.org` MUST be on the production
     /// allowlist under the `"openalex"` source key WITHOUT `--features
-    /// citation`. The Tier-2 `tier_2_allowlist()` extend is
-    /// `#[cfg(feature = "citation")]`; this test proves
-    /// `discovery_allowlist()` covers that gap in the shipped build.
+    /// metadata`. The Tier-2 `tier_2_allowlist()` extend is
+    /// `#[cfg(feature = "metadata")]` (#516 moved it off `citation`);
+    /// this test proves `discovery_allowlist()` covers that gap in the
+    /// shipped `oa-only` build, where neither feature is compiled.
     #[test]
     #[serial]
     fn build_http_client_registers_openalex_for_discovery() {

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1049,6 +1049,13 @@ pub(crate) fn cli_exit_code(code: ErrorCode) -> i32 {
         // A name filter that matched several entities is user-fixable by
         // narrowing the query → `docs/ERRORS.md` §4 exit 2 ("misuse").
         ErrorCode::Ambiguous => 2,
+        // An unparsable ref is a bad argument, and §4's exit 1 is "at
+        // least one fetch failed" — which does not describe a run where
+        // nothing was fetched. `graph` had followed the table with a
+        // hard-coded 2 while `fetch` and the eight #477 commands fell to
+        // the `_ => 1` arm below, so the same input produced different
+        // exit codes from the same binary (#492, ADR-0049).
+        ErrorCode::InvalidRef => 2,
         _ => 1,
     }
 }
@@ -1661,6 +1668,16 @@ host = "*.uj.edu.pl"
         // ADR-0031 D5: a name-filter ambiguity is user-fixable → exit 2,
         // distinct from the generic exit 1.
         assert_eq!(cli_exit_code(ErrorCode::Ambiguous), 2);
+    }
+
+    #[test]
+    fn invalid_ref_maps_to_exit_code_2() {
+        // ADR-0049: an unparsable ref is misuse. `docs/ERRORS.md` §4
+        // reserves 1 for "at least one fetch was attempted and failed",
+        // and nothing is fetched here. `Ambiguous` — a value that fails
+        // to select one entity — was already 2; `InvalidRef` is a value
+        // that fails to parse, and sat at the catch-all 1 next to it.
+        assert_eq!(cli_exit_code(ErrorCode::InvalidRef), 2);
     }
 
     /// Minimal `DenialContext` carrying only `reason`; every other field

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -399,10 +399,14 @@ impl OrchestratorConfig {
     fn from_env() -> Result<Self> {
         let store_root = super::resolve_store_root()?;
         let log_path = resolve_log_path()?;
-        let contact_email =
-            std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".into());
-        let unpaywall_email =
-            std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| contact_email.clone());
+        // Through the core resolver even though this struct is not read
+        // yet: a dormant third copy of the ladder is still a copy, and it
+        // is the one nobody would think to update.
+        let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
+        let unpaywall_email = std::env::var("DOIGET_UNPAYWALL_EMAIL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| contact_email.clone());
         Ok(Self {
             store_root,
             log_path,
@@ -723,17 +727,11 @@ pub async fn run_with_options(
     // mode.
     // Step 1: parse + safekey. Issue #119: render the cargo-style
     // `error[INVALID_REF]:` line + carry the exit code, rather than
-    // letting the granular `RefParseError` fall out as an opaque
-    // anyhow `{:?}` dump.
-    let ref_ = match Ref::parse(&input) {
-        Ok(r) => r,
-        Err(e) => {
-            super::render_ref_parse_error(&e);
-            return Err(anyhow::Error::new(CliExit(cli_exit_code(
-                ErrorCode::InvalidRef,
-            ))));
-        }
-    };
+    // letting the granular `RefParseError` fall out as an opaque anyhow
+    // `{:?}` dump. Through the shared helper (#492) so a change to the
+    // wording or the code reaches every command at once — this and `graph`
+    // were the last two hand-inlined copies of its body.
+    let ref_ = super::parse_ref_or_exit(&input)?;
 
     // Dry-run branch: build the plan and emit it. NO harness, NO network,
     // NO store write, NO provenance row. Posture-lint ADR-0022 §5 will

--- a/crates/doiget-cli/src/commands/frontier.rs
+++ b/crates/doiget-cli/src/commands/frontier.rs
@@ -63,7 +63,10 @@ pub async fn run(
         url::Url::parse(&raw)
             .with_context(|| format!("DOIGET_OPENALEX_BASE is not a URL: {raw}"))?
     };
-    let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+    // `unwrap_or_default`, not the placeholder: an unset address means
+    // `mailto` is omitted rather than sent as `doiget@localhost`. Routed
+    // through the core resolver so config.toml's rung counts (#504).
+    let contact_email = doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
     let harness = FetchHarness::from_env().context("building fetch harness")?;
     harness

--- a/crates/doiget-cli/src/commands/frontier.rs
+++ b/crates/doiget-cli/src/commands/frontier.rs
@@ -38,8 +38,24 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let seed_doi = doiget_core::Doi::parse(&doi_str)
-        .map_err(|e| anyhow::anyhow!("invalid seed DOI {doi_str:?}: {e}"))?;
+    // #492 / ADR-0049: previously a bare `anyhow!`, which exited 1 with no
+    // `error[INVALID_REF]:` line. Routed through the shared parser so the
+    // message and the exit code match every other ref-taking command.
+    let seed_doi = match super::parse_ref_or_exit(&doi_str)? {
+        doiget_core::Ref::Doi(d) => d,
+        doiget_core::Ref::Arxiv(_) => {
+            // Same shape as `graph`: OpenAlex keys the citation graph by
+            // DOI, so an arXiv id is argument misuse rather than a parse
+            // failure — `docs/ERRORS.md` §4 exit 2.
+            super::output::print_err(format_args!(
+                "error: doiget frontier requires a DOI seed; arXiv ids are not in \
+                 OpenAlex's referenced_works keyspace"
+            ));
+            return Err(anyhow::Error::new(CliExit(cli_exit_code(
+                doiget_core::ErrorCode::InvalidRef,
+            ))));
+        }
+    };
 
     let base = {
         let raw = std::env::var("DOIGET_OPENALEX_BASE")

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -59,12 +59,15 @@ pub async fn run(
         Ok(r) => r,
         Err(e) => {
             // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2
-            // (issue #149). NOTE: `fetch` exits 1 for the same input; §4
-            // says misuse is 2, so they disagree and this is the one
-            // following the table. Not reconciled in #477 -- see
-            // `commands::render_ref_parse_error`.
+            // (issue #149). Routed through `cli_exit_code` since #492:
+            // this used to hard-code the 2 while `fetch` fell to the
+            // generic 1, so the same input got two answers out of one
+            // binary and the comment here asserted a consistency that
+            // did not hold.
             super::render_ref_parse_error(&e);
-            return Err(anyhow::Error::new(CliExit(2)));
+            return Err(anyhow::Error::new(CliExit(
+                crate::commands::fetch::cli_exit_code(doiget_core::ErrorCode::InvalidRef),
+            )));
         }
     };
     let doi = match &ref_ {

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -55,21 +55,12 @@ pub async fn run(
     // `_mode` is threaded per ADR-0017 / #144. Graph's JSON output is
     // product output (the requested artifact), not informational; Quiet
     // does NOT suppress it.
-    let ref_ = match Ref::parse(&input) {
-        Ok(r) => r,
-        Err(e) => {
-            // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2
-            // (issue #149). Routed through `cli_exit_code` since #492:
-            // this used to hard-code the 2 while `fetch` fell to the
-            // generic 1, so the same input got two answers out of one
-            // binary and the comment here asserted a consistency that
-            // did not hold.
-            super::render_ref_parse_error(&e);
-            return Err(anyhow::Error::new(CliExit(
-                crate::commands::fetch::cli_exit_code(doiget_core::ErrorCode::InvalidRef),
-            )));
-        }
-    };
+    // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2 (issue
+    // #149). Through the shared helper (#492): this used to hard-code the 2
+    // while `fetch` fell to the generic 1, so the same input got two
+    // answers out of one binary and the comment here asserted a consistency
+    // that did not hold. Sharing the helper is what makes it hold.
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let doi = match &ref_ {
         Ref::Doi(d) => d.clone(),
         Ref::Arxiv(_) => {
@@ -101,8 +92,10 @@ pub async fn run(
         ))));
     }
 
-    let contact_email =
-        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    // Through the core resolver, not `std::env::var`: `[network]
+    // contact_email` in config.toml is a documented rung (#504), and a
+    // command that reads only the environment silently ignores it.
+    let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
     let source = if let Ok(base) = std::env::var("DOIGET_OPENALEX_BASE") {
         if let Ok(url) = url::Url::parse(&base) {
             OpenalexSource::with_base(url, contact_email)

--- a/crates/doiget-cli/src/commands/link.rs
+++ b/crates/doiget-cli/src/commands/link.rs
@@ -46,8 +46,9 @@ pub async fn run(ref_: String, mode: OutputMode, quiet_was_explicit: bool) -> Re
 
     let base = resolve_openalex_base()?;
     // Omit `mailto` when no contact email is configured (never a
-    // placeholder); the empty string is skipped downstream.
-    let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+    // placeholder); the empty string is skipped downstream. Resolved
+    // through the core ladder so config.toml's rung counts (#504).
+    let contact_email = doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
     let ctx = build_resolve_context().context("building fetch context")?;
 
     let links = match resolve_links_for_doi(&base, &contact_email, doi.as_str(), &ctx).await {

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -19,7 +19,9 @@
 //! - [`list_recent`] — prints up to N most-recently-fetched entries.
 //! - [`search`] — case-insensitive substring search over stored metadata.
 //!
-//! Other subcommands (`serve`) land in separate PRs.
+//! `serve` has no module here: it delegates straight to `doiget-mcp`. It
+//! is wired in `main.rs` and is what every `docs/INTEGRATION/` guide tells
+//! users to run.
 
 /// Parse a ref, or render the failure in the `docs/ERRORS.md` §3
 /// "Researcher (CLI human)" form and return the CLI exit error.

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -54,17 +54,17 @@ pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
     }
 }
 
-/// The renderer on its own, for the two call sites that already choose
-/// their own exit code.
+/// The renderer on its own, for the two call sites that build their own
+/// `CliExit` rather than going through [`parse_ref_or_exit`].
 ///
-/// `fetch` exits 1 (`cli_exit_code(InvalidRef)`) and `graph` exits 2,
-/// citing `docs/ERRORS.md` §4 "misuse" -- and §4 does say an unparsable
-/// argument is misuse, so they disagree and `graph` is the one following
-/// the table. Filed separately rather than changed here: #477 is about the
-/// message, `fetch`'s exit 1 is pinned by a named test, and quietly moving
-/// an exit code is how a script breaks without anyone noticing.
+/// Both now take the exit code from `fetch::cli_exit_code(InvalidRef)`,
+/// which is **2** since #492 / ADR-0049. Before that `fetch` fell to the
+/// generic `_ => 1` arm while `graph` hard-coded the 2 that
+/// `docs/ERRORS.md` §4 prescribes, so one binary gave two answers for the
+/// same input and each site's comment claimed agreement with the other.
 ///
-/// One renderer either way, which is the part that was missing.
+/// One renderer and one exit code. `every_ref_taking_command_exits_2_for_
+/// an_invalid_ref` is what keeps it that way.
 pub fn render_ref_parse_error(e: &doiget_core::RefParseError) {
     output::print_err(format_args!(
         "error[{}]: invalid ref: {e}",

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -56,8 +56,9 @@ pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
     }
 }
 
-/// The renderer on its own, for the two call sites that build their own
-/// `CliExit` rather than going through [`parse_ref_or_exit`].
+/// The renderer on its own, for call sites holding a
+/// [`doiget_core::RefParseError`] that did not come from
+/// [`parse_ref_or_exit`].
 ///
 /// Both now take the exit code from `fetch::cli_exit_code(InvalidRef)`,
 /// which is **2** since #492 / ADR-0049. Before that `fetch` fell to the

--- a/crates/doiget-cli/src/commands/resolve_citation.rs
+++ b/crates/doiget-cli/src/commands/resolve_citation.rs
@@ -34,8 +34,10 @@ fn build_context() -> Result<FetchContext> {
 }
 
 fn build_crossref_source() -> Result<CrossrefSource> {
-    let contact_email =
-        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    // Through the core resolver, not `std::env::var`: `[network]
+    // contact_email` in config.toml is a documented rung (#504), and a
+    // command that reads only the environment silently ignores it.
+    let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
     match std::env::var("DOIGET_CROSSREF_BASE").ok() {
         Some(base_str) => {
             let base = url::Url::parse(&base_str).context("invalid DOIGET_CROSSREF_BASE")?;

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -218,7 +218,8 @@ async fn run_external(
     // Leave `mailto` unset when no contact email is configured: send a real
     // address (polite pool) or none, never a non-routable placeholder. The
     // empty string is skipped by `build_search_url` / `resolve_entity_id`.
-    let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+    // Resolved through the core ladder so config.toml's rung counts (#504).
+    let contact_email = doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
     let harness = FetchHarness::from_env().context("building fetch harness")?;
     harness

--- a/crates/doiget-cli/src/commands/tag.rs
+++ b/crates/doiget-cli/src/commands/tag.rs
@@ -132,7 +132,11 @@ pub fn run(
 /// stored entry. Exactly one of `text` (Some) or `clear = true` must be given.
 pub fn run_annotate(ref_str: String, text: Option<String>, clear: bool) -> Result<()> {
     if !clear && text.is_none() {
-        bail!("provide annotation <text> or --clear");
+        // `docs/ERRORS.md` §4: a missing required argument is misuse, which
+        // is exit 2. A bare `bail!` gave the generic 1 — the same gap #492
+        // closed for an unparsable ref, one argument over.
+        super::output::print_err(format_args!("error: provide annotation <text> or --clear"));
+        return Err(anyhow::Error::new(super::fetch::CliExit(2)));
     }
 
     let ref_ = super::parse_ref_or_exit(&ref_str)?;

--- a/crates/doiget-cli/src/commands/tex_source.rs
+++ b/crates/doiget-cli/src/commands/tex_source.rs
@@ -33,7 +33,12 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    // #492 / ADR-0049: one renderer, one exit code. This used to be
+    // `Ref::parse(..).with_context(..)?`, which exited 1 and leaked the
+    // `Caused by:` chain that #477's contract exists to replace — the ADR
+    // claimed the rule held for "every ref-taking command" and this was one
+    // of two that were never in the set.
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let id: ArxivId = match parsed {
         Ref::Arxiv(a) => a,
         Ref::Doi(_) => {

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -50,29 +50,95 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_2() {
 ///
 /// Table-driven on purpose: a new ref-taking subcommand is added to this
 /// list or it is not covered, and the failure names which one regressed.
+/// Every subcommand that takes a ref, read back from clap rather than
+/// hand-listed.
+///
+/// This was a literal, and it silently omitted `tex-source`, `frontier`
+/// and `annotate` — two of which then violated BOTH halves of the contract
+/// these tests exist to enforce, throughout the very release that claimed
+/// to have unified them. A second hand-maintained copy of the subcommand
+/// set is the #454 / #504 shape; this reads the one clap actually built.
+///
+/// Excluded by name, each for a stated reason:
+/// - `verify` takes a FILE PATH, so an unparsable value is a missing file.
+/// - `batch` takes a file of refs and reports per row, not per process.
+/// - `resolve-citation` takes free text, not a ref.
+/// - the rest simply take no ref.
+fn ref_taking_commands() -> Vec<Vec<String>> {
+    const NOT_A_REF: &[&str] = &[
+        "verify",
+        "batch",
+        "resolve-citation",
+        // Reads pending citations from the store; takes no argument.
+        "batch-resolve-citations",
+        "version",
+        "config",
+        "serve",
+        "search",
+        "list-recent",
+        "provenance",
+        "audit-log",
+        "lint",
+        "capabilities",
+        "help",
+    ];
+
+    let out = Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .arg("--help")
+        .output()
+        .expect("run doiget --help");
+    let help = String::from_utf8_lossy(&out.stdout);
+
+    // clap lists subcommands indented, name first. Anything that is not a
+    // flag and not on the exclusion list is expected to take a ref — so a
+    // NEW ref-taking subcommand is covered by default, and a new non-ref
+    // one fails here until it is named, which is the safe direction.
+    let mut found: Vec<String> = help
+        .lines()
+        .filter(|l| l.starts_with("  "))
+        // `split_whitespace` already skips the leading indent; trimming
+        // first is what clippy's `trim_split_whitespace` flags.
+        .filter_map(|l| l.split_whitespace().next())
+        // Options share the two-space indent, so exclude anything that
+        // starts with a dash before the lowercase check (which `--color`
+        // would otherwise pass).
+        .filter(|n| !n.is_empty() && !n.starts_with('-'))
+        .filter(|n| n.chars().all(|c| c.is_ascii_lowercase() || c == '-'))
+        .filter(|n| !NOT_A_REF.contains(n))
+        .map(str::to_string)
+        .collect();
+    found.sort();
+    found.dedup();
+    assert!(
+        found.len() >= 9,
+        "parsed only {found:?} from --help — the parser has drifted from clap's output"
+    );
+
+    // Complete argv, bad ref included, because the ref is NOT the last
+    // positional everywhere: `annotate` is `<ref> <text>`.
+    found
+        .into_iter()
+        .map(|c| match c.as_str() {
+            "source" => vec!["source", "--out", ".", BAD_REF]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            "annotate" => vec!["annotate", BAD_REF, "a note"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            _ => vec![c, BAD_REF.to_string()],
+        })
+        .collect()
+}
+
+/// The value every command in the table is handed.
+const BAD_REF: &str = "not a doi";
+
 #[test]
 fn every_ref_taking_command_emits_the_error_code_contract() {
-    // `verify` is excluded: it takes a FILE PATH, not a ref, so an
-    // unparsable value is a missing file rather than a bad ref. It gets
-    // the `error:` misuse form instead -- see the test below.
-    let mut commands: Vec<Vec<&str>> = vec![
-        vec!["fetch"],
-        vec!["info"],
-        vec!["link"],
-        vec!["cite"],
-        vec!["text"],
-        vec!["bib"],
-        vec!["csl"],
-        // `source` needs `--out`; the ref is still the last positional.
-        vec!["source", "--out", "."],
-        vec!["tag"],
-    ];
-    // `graph` only exists in a `citation` build, and CI's default job runs
-    // plain `oa-only` -- where the subcommand is absent and clap answers
-    // "unrecognized subcommand", which is not this contract's business.
-    if cfg!(feature = "citation") {
-        commands.push(vec!["graph"]);
-    }
+    let commands = ref_taking_commands();
 
     let td = TempDir::new().expect("tempdir");
     let root = td.path().to_str().expect("utf-8");
@@ -83,12 +149,19 @@ fn every_ref_taking_command_emits_the_error_code_contract() {
         cmd.env("DOIGET_STORE_ROOT", root)
             .env("DOIGET_LOG_PATH", "")
             .env("DOIGET_CONTACT_EMAIL", "test@example.com")
-            .args(argv)
-            .arg("not a doi");
+            .args(argv);
         let out = cmd.output().expect("run doiget");
         let stderr = String::from_utf8_lossy(&out.stderr);
         let first = stderr.lines().next().unwrap_or("");
 
+        // A feature-gated subcommand (`graph` needs `citation`) is absent
+        // from a narrower build, and clap answers for it. That is clap's
+        // business, not this contract's — and `--help` is parsed from a
+        // binary that may have been built with a different feature set
+        // than the one under test when they share a target directory.
+        if first.starts_with("error: unrecognized subcommand") {
+            continue;
+        }
         if !first.starts_with("error[") {
             broken.push(format!("{}: {first}", argv.join(" ")));
         }
@@ -118,20 +191,7 @@ fn every_ref_taking_command_emits_the_error_code_contract() {
 /// subcommand is covered by both or by neither.
 #[test]
 fn every_ref_taking_command_exits_2_for_an_invalid_ref() {
-    let mut commands: Vec<Vec<&str>> = vec![
-        vec!["fetch"],
-        vec!["info"],
-        vec!["link"],
-        vec!["cite"],
-        vec!["text"],
-        vec!["bib"],
-        vec!["csl"],
-        vec!["source", "--out", "."],
-        vec!["tag"],
-    ];
-    if cfg!(feature = "citation") {
-        commands.push(vec!["graph"]);
-    }
+    let commands = ref_taking_commands();
 
     let td = TempDir::new().expect("tempdir");
     let root = td.path().to_str().expect("utf-8");
@@ -142,9 +202,14 @@ fn every_ref_taking_command_exits_2_for_an_invalid_ref() {
         cmd.env("DOIGET_STORE_ROOT", root)
             .env("DOIGET_LOG_PATH", "")
             .env("DOIGET_CONTACT_EMAIL", "test@example.com")
-            .args(argv)
-            .arg("not a doi");
+            .args(argv);
         let out = cmd.output().expect("run doiget");
+        // As above: a subcommand this build does not have is clap's answer,
+        // not this contract's.
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stderr.starts_with("error: unrecognized subcommand") {
+            continue;
+        }
         if out.status.code() != Some(2) {
             wrong.push(format!("{}: exit {:?}", argv.join(" "), out.status.code()));
         }

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -13,8 +13,15 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
+/// #119 gave `fetch` the `error[CODE]:` line and asserted exit **1**,
+/// which is what `cli_exit_code`'s catch-all produced rather than a
+/// decision anyone made. `docs/ERRORS.md` §4 reserves 1 for "at least one
+/// fetch failed", and an unparsable ref fetches nothing.
+///
+/// #492 / ADR-0049 moved it to 2 for every ref-taking command at once.
+/// The name is part of the assertion, so it moved too.
 #[test]
-fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
+fn fetch_invalid_ref_emits_cargo_style_error_and_exit_2() {
     let td = TempDir::new().expect("tempdir");
     Command::cargo_bin("doiget")
         .expect("doiget binary built")
@@ -24,7 +31,7 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() {
         .env("DOIGET_LOG_PATH", "")
         .args(["fetch", "not a doi"])
         .assert()
-        .code(1)
+        .code(2)
         .stderr(predicate::str::contains("error[INVALID_REF]: invalid ref"))
         // stdout MUST stay clean (ADR-0001 stdio rule).
         .stdout(predicate::str::is_empty());
@@ -95,6 +102,59 @@ fn every_ref_taking_command_emits_the_error_code_contract() {
         broken.is_empty(),
         "these commands do not honour the error[CODE] contract for an invalid ref:\n  {}",
         broken.join("\n  ")
+    );
+}
+
+/// #492: the exit code is half the contract, and it was the half that
+/// disagreed with itself.
+///
+/// `fetch` exited 1, `graph` exited 2, and `docs/ERRORS.md` §4 says 2 —
+/// so one binary answered the same input two ways, and the comment at
+/// each site asserted consistency with the other. A message contract that
+/// every command honours and an exit code that half of them get wrong is
+/// worse than neither, because a script keys off the exit code.
+///
+/// Same table as the message test above, deliberately: a new ref-taking
+/// subcommand is covered by both or by neither.
+#[test]
+fn every_ref_taking_command_exits_2_for_an_invalid_ref() {
+    let mut commands: Vec<Vec<&str>> = vec![
+        vec!["fetch"],
+        vec!["info"],
+        vec!["link"],
+        vec!["cite"],
+        vec!["text"],
+        vec!["bib"],
+        vec!["csl"],
+        vec!["source", "--out", "."],
+        vec!["tag"],
+    ];
+    if cfg!(feature = "citation") {
+        commands.push(vec!["graph"]);
+    }
+
+    let td = TempDir::new().expect("tempdir");
+    let root = td.path().to_str().expect("utf-8");
+
+    let mut wrong: Vec<String> = Vec::new();
+    for argv in &commands {
+        let mut cmd = Command::cargo_bin("doiget").expect("doiget binary built");
+        cmd.env("DOIGET_STORE_ROOT", root)
+            .env("DOIGET_LOG_PATH", "")
+            .env("DOIGET_CONTACT_EMAIL", "test@example.com")
+            .args(argv)
+            .arg("not a doi");
+        let out = cmd.output().expect("run doiget");
+        if out.status.code() != Some(2) {
+            wrong.push(format!("{}: exit {:?}", argv.join(" "), out.status.code()));
+        }
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "docs/ERRORS.md §4: an unparsable ref is misuse (exit 2), not a failed fetch \
+         (exit 1). These disagree:\n  {}",
+        wrong.join("\n  ")
     );
 }
 

--- a/crates/doiget-core/src/credentials.rs
+++ b/crates/doiget-core/src/credentials.rs
@@ -43,10 +43,31 @@ pub const PUBLISHERS: [&str; 4] = ["elsevier", "aps", "springer", "ieee"];
 /// file is optional, and one bad line must not take a fetch down. Every
 /// such case emits `tracing::warn!` — silence about this file is precisely
 /// what cost a user their configuration.
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 #[non_exhaustive]
 pub struct Credentials {
     keys: Vec<(String, String)>,
+}
+
+/// Hand-written so a stray `{:?}` cannot print a publisher API key.
+///
+/// `TdmGrant` wraps the same value in `secrecy::SecretString` precisely so
+/// `Debug` never renders it; between this file and that wrapper the key is
+/// a plain `String`, and a `#[derive(Debug)]` here would have re-opened the
+/// hole one hop earlier. Publisher names are not secret and are shown.
+impl std::fmt::Debug for Credentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credentials")
+            .field(
+                "keys",
+                &self
+                    .keys
+                    .iter()
+                    .map(|(p, _)| format!("{p}: <redacted>"))
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
 }
 
 impl Credentials {
@@ -63,6 +84,15 @@ impl Credentials {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
+    }
+
+    /// How many publishers supplied a usable key.
+    ///
+    /// For `config doctor`, which reports that a credentials file was read
+    /// without printing anything from it.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.keys.len()
     }
 }
 
@@ -97,9 +127,65 @@ pub fn path() -> Result<Utf8PathBuf, crate::user_extension::ConfigDirError> {
         .join("credentials.toml"))
 }
 
+/// Why `credentials.toml` could not be read.
+///
+/// Exists so `doiget config doctor` can *report* the failure. Without it
+/// the only surface was `tracing::warn!`, which the CLI's
+/// `EnvFilter::from_default_env()` suppresses at the default level — so a
+/// malformed or unreadable credentials file produced no warning, no doctor
+/// line, and only the downstream "source unavailable" this module exists to
+/// prevent.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CredentialsError {
+    /// The file exists but could not be read.
+    #[error("{path}: {source}")]
+    Io {
+        /// The file that could not be read.
+        path: String,
+        /// The underlying filesystem error.
+        source: std::io::Error,
+    },
+    /// The file is not valid TOML.
+    #[error("{path}: {source}")]
+    Parse {
+        /// The file that failed to parse.
+        path: String,
+        /// The underlying TOML error.
+        source: toml::de::Error,
+    },
+}
+
+/// Load `credentials.toml` from an explicit path, surfacing failures.
+///
+/// A missing file is `Ok(empty)` — TDM is opt-in and most installs have no
+/// such file. Mirrors [`crate::user_extension::load`], which `config
+/// doctor` already reports on the same way.
+///
+/// # Errors
+///
+/// [`CredentialsError::Io`] for a read failure other than not-found;
+/// [`CredentialsError::Parse`] for malformed TOML.
+pub fn load(path: &camino::Utf8Path) -> Result<Credentials, CredentialsError> {
+    let text = match std::fs::read_to_string(path.as_std_path()) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Credentials::default()),
+        Err(source) => {
+            return Err(CredentialsError::Io {
+                path: path.to_string(),
+                source,
+            })
+        }
+    };
+    warn_if_group_or_world_accessible(path);
+    parse(&text, path)
+}
+
 /// Load the credentials file, or the empty set.
 ///
-/// Never fails; every failure mode is warned about. See [`Credentials`].
+/// Never fails; every failure mode is warned about. This is the fetch-path
+/// entry point — one bad line must not take a fetch down. Callers that want
+/// to *report* the failure use [`load`] instead. See [`Credentials`].
 #[must_use]
 pub fn load_or_default() -> Credentials {
     let path = match path() {
@@ -109,39 +195,31 @@ pub fn load_or_default() -> Credentials {
             return Credentials::default();
         }
     };
-    let text = match std::fs::read_to_string(path.as_std_path()) {
-        Ok(t) => t,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Credentials::default(),
+    match load(&path) {
+        Ok(c) => c,
         Err(e) => {
             tracing::warn!(
-                path = %path,
                 error = %e,
-                "credentials.toml exists but could not be read; keys from it are \
-                 unavailable and only DOIGET_KEY_* will be used"
+                "credentials.toml could not be read; keys from it are unavailable and \
+                 only DOIGET_KEY_* will be used"
             );
-            return Credentials::default();
+            Credentials::default()
         }
-    };
-    warn_if_group_or_world_accessible(&path);
-    parse(&text, &path)
+    }
 }
 
 /// Parse a `credentials.toml` body. Pure; the path is for messages only.
-fn parse(text: &str, path: &camino::Utf8Path) -> Credentials {
-    let raw: RawFile = match toml::from_str(text) {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(
-                path = %path,
-                error = %e,
-                "credentials.toml is malformed; keys from it are unavailable and only \
-                 DOIGET_KEY_* will be used"
-            );
-            return Credentials::default();
-        }
-    };
+fn parse(text: &str, path: &camino::Utf8Path) -> Result<Credentials, CredentialsError> {
+    // A malformed file is a FILE-level failure and is returned, so
+    // `config doctor` can name it. The per-entry problems below (unknown
+    // publisher, an `agreed` key, a blank value) are advisories: they do
+    // not invalidate the rest of the file, so they stay warnings.
+    let raw: RawFile = toml::from_str(text).map_err(|source| CredentialsError::Parse {
+        path: path.to_string(),
+        source,
+    })?;
     let Some(tdm) = raw.tdm else {
-        return Credentials::default();
+        return Ok(Credentials::default());
     };
 
     let mut keys = Vec::new();
@@ -174,15 +252,28 @@ fn parse(text: &str, path: &camino::Utf8Path) -> Credentials {
         // Blank means unset, as everywhere else: an empty key cannot
         // authenticate, and building a grant around one would mask the
         // misconfiguration `AgreedButNoKey` exists to surface.
-        let key = entry
-            .api_key
-            .map(|k| k.trim().to_string())
-            .filter(|k| !k.is_empty());
-        if let Some(k) = key {
-            keys.push((publisher, k));
+        //
+        // It still gets a line. A present-but-blank value is a thing the
+        // user typed and believes is configured, so dropping it in silence
+        // is the #442 / #476 shape this module was written to close — and
+        // it was the one case here that reached no log call at all.
+        let raw = entry.api_key.unwrap_or_default();
+        let key = raw.trim();
+        if key.is_empty() {
+            if !raw.is_empty() {
+                tracing::warn!(
+                    path = %path,
+                    publisher = %publisher,
+                    "credentials.toml sets [tdm.{}] api_key to a blank value, which cannot \
+                     authenticate and is treated as unset. Remove the line or give it a key.",
+                    publisher
+                );
+            }
+        } else {
+            keys.push((publisher, key.to_string()));
         }
     }
-    Credentials { keys }
+    Ok(Credentials { keys })
 }
 
 /// Warn when the file is group- or world-accessible on POSIX.
@@ -222,12 +313,14 @@ mod tests {
         camino::Utf8PathBuf::from("/tmp/credentials.toml")
     }
 
+    /// Parse and unwrap, for the cases where the file is well-formed.
+    fn ok(text: &str) -> Credentials {
+        parse(text, &p()).expect("well-formed credentials.toml")
+    }
+
     #[test]
     fn an_api_key_is_read_per_publisher() {
-        let c = parse(
-            "[tdm.elsevier]\napi_key = \"abc\"\n\n[tdm.aps]\napi_key = \"def\"\n",
-            &p(),
-        );
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\n\n[tdm.aps]\napi_key = \"def\"\n");
         assert_eq!(c.api_key("elsevier"), Some("abc"));
         assert_eq!(c.api_key("aps"), Some("def"));
         assert_eq!(c.api_key("springer"), None);
@@ -238,7 +331,7 @@ mod tests {
     /// at all, so no caller can be tempted to consult one.
     #[test]
     fn agreed_in_the_file_grants_nothing() {
-        let c = parse("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n", &p());
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n");
         assert_eq!(
             c.api_key("elsevier"),
             Some("abc"),
@@ -248,26 +341,45 @@ mod tests {
 
     #[test]
     fn a_blank_key_is_treated_as_unset() {
-        let c = parse("[tdm.aps]\napi_key = \"   \"\n", &p());
+        let c = ok("[tdm.aps]\napi_key = \"   \"\n");
         assert!(c.is_empty(), "a blank key cannot authenticate");
     }
 
+    /// A malformed file is a FILE-level failure, returned rather than
+    /// warned about, so `doiget config doctor` can name it. Before #509's
+    /// follow-up the only surface was `tracing::warn!`, which the CLI's
+    /// default `EnvFilter` suppresses — the user saw nothing at all.
     #[test]
-    fn a_malformed_file_yields_no_keys_rather_than_a_panic() {
-        assert!(parse("this is not toml = = =", &p()).is_empty());
+    fn a_malformed_file_is_a_reportable_error_not_a_silent_empty_set() {
+        match parse("this is not toml = = =", &p()) {
+            Err(CredentialsError::Parse { path, .. }) => {
+                assert!(path.contains("credentials.toml"), "path: {path}");
+            }
+            other => panic!("expected a Parse error naming the file; got {other:?}"),
+        }
+    }
+
+    /// A blank value is a thing the user typed. It is still treated as
+    /// unset, but it no longer disappears without a line — that was the one
+    /// failure mode in this module with no log call at all.
+    #[test]
+    fn a_present_but_blank_key_is_reported_not_silently_dropped() {
+        let c = ok("[tdm.aps]\napi_key = \"\"\n");
+        assert!(c.is_empty());
+        assert_eq!(c.len(), 0);
     }
 
     #[test]
     fn an_unknown_publisher_table_is_skipped() {
         assert!(
-            parse("[tdm.wiley]\napi_key = \"abc\"\n", &p()).is_empty(),
+            ok("[tdm.wiley]\napi_key = \"abc\"\n").is_empty(),
             "unknown publishers grant nothing"
         );
     }
 
     #[test]
     fn an_absent_tdm_table_is_not_an_error() {
-        assert!(parse("[something_else]\nx = 1\n", &p()).is_empty());
-        assert!(parse("", &p()).is_empty());
+        assert!(ok("[something_else]\nx = 1\n").is_empty());
+        assert!(ok("").is_empty());
     }
 }

--- a/crates/doiget-core/src/credentials.rs
+++ b/crates/doiget-core/src/credentials.rs
@@ -1,0 +1,273 @@
+//! `credentials.toml` — the per-publisher TDM **API keys** (#509).
+//!
+//! `docs/CONFIG.md` §6 specified this file in full — schema, precedence, and
+//! a `0600` permission warning — and nothing read it. A user who followed a
+//! NORMATIVE document wrote their Elsevier key into a file doiget ignored,
+//! and the source then reported itself unavailable for want of a key. That
+//! is the #442 / #454 / #476 shape, landed on credentials.
+//!
+//! ## What this file carries, and what it deliberately does not
+//!
+//! **`api_key`: yes.** A long-lived key is genuinely better off in a file
+//! than in the environment. It survives a shell restart, it is not visible
+//! in `ps`, and it does not leak into the environment of every subprocess.
+//! The `0600` check is then a real control rather than a sentence.
+//!
+//! **`agreed`: no.** `docs/LEGAL.md` §6a.2 makes the per-publisher
+//! agreement an *enforced control*, and part of why it is meaningful is
+//! that `DOIGET_AGREE_TDM_<PUBLISHER>=1` is a variable the user sets in the
+//! session that runs the fetch. A boolean written once into a file and
+//! forgotten is a weaker act of consent, and weakening it as a side effect
+//! of adding a convenience is the kind of accident ADR-0048 was written
+//! about. So the key may come from either place; **the agreement is
+//! environment-only**, and an `agreed` key here is reported rather than
+//! silently discarded — a documented field with no reader is the defect
+//! this module exists to close.
+//!
+//! ## Precedence
+//!
+//! `DOIGET_KEY_<PUBLISHER>` wins over `[tdm.<publisher>] api_key`, matching
+//! the `docs/CONFIG.md` §1 chain and the `store_root` / `contact_email`
+//! rungs (#441, #504).
+
+use camino::Utf8PathBuf;
+use serde::Deserialize;
+
+/// Publisher slugs this file may carry, matching the `[tdm.<slug>]` tables
+/// in `docs/CONFIG.md` §6 and the `tdm-<slug>` Cargo features.
+pub const PUBLISHERS: [&str; 4] = ["elsevier", "aps", "springer", "ieee"];
+
+/// Parsed `credentials.toml`.
+///
+/// Absent, unreadable and malformed all yield the default (no keys): the
+/// file is optional, and one bad line must not take a fetch down. Every
+/// such case emits `tracing::warn!` — silence about this file is precisely
+/// what cost a user their configuration.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct Credentials {
+    keys: Vec<(String, String)>,
+}
+
+impl Credentials {
+    /// The `api_key` for `publisher`, if the file supplied one.
+    #[must_use]
+    pub fn api_key(&self, publisher: &str) -> Option<&str> {
+        self.keys
+            .iter()
+            .find(|(p, _)| p == publisher)
+            .map(|(_, k)| k.as_str())
+    }
+
+    /// True when the file carried no usable key at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawFile {
+    #[serde(default)]
+    tdm: Option<std::collections::BTreeMap<String, RawEntry>>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawEntry {
+    #[serde(default)]
+    api_key: Option<String>,
+    /// Parsed only so its presence can be *reported*. The agreement is
+    /// environment-only (`docs/LEGAL.md` §6a.2); see the module docs.
+    #[serde(default)]
+    agreed: Option<bool>,
+    #[serde(flatten)]
+    _other: serde::de::IgnoredAny,
+}
+
+/// `<config_dir>/doiget/credentials.toml`.
+///
+/// # Errors
+///
+/// As [`crate::user_extension::config_dir`].
+pub fn path() -> Result<Utf8PathBuf, crate::user_extension::ConfigDirError> {
+    Ok(crate::user_extension::config_dir()?
+        .join("doiget")
+        .join("credentials.toml"))
+}
+
+/// Load the credentials file, or the empty set.
+///
+/// Never fails; every failure mode is warned about. See [`Credentials`].
+#[must_use]
+pub fn load_or_default() -> Credentials {
+    let path = match path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(error = %e, "no config directory; credentials.toml not read");
+            return Credentials::default();
+        }
+    };
+    let text = match std::fs::read_to_string(path.as_std_path()) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Credentials::default(),
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "credentials.toml exists but could not be read; keys from it are \
+                 unavailable and only DOIGET_KEY_* will be used"
+            );
+            return Credentials::default();
+        }
+    };
+    warn_if_group_or_world_accessible(&path);
+    parse(&text, &path)
+}
+
+/// Parse a `credentials.toml` body. Pure; the path is for messages only.
+fn parse(text: &str, path: &camino::Utf8Path) -> Credentials {
+    let raw: RawFile = match toml::from_str(text) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "credentials.toml is malformed; keys from it are unavailable and only \
+                 DOIGET_KEY_* will be used"
+            );
+            return Credentials::default();
+        }
+    };
+    let Some(tdm) = raw.tdm else {
+        return Credentials::default();
+    };
+
+    let mut keys = Vec::new();
+    for (publisher, entry) in tdm {
+        if !PUBLISHERS.contains(&publisher.as_str()) {
+            tracing::warn!(
+                path = %path,
+                publisher = %publisher,
+                "credentials.toml has [tdm.{}], which is not a publisher doiget knows; \
+                 expected one of {:?}",
+                publisher,
+                PUBLISHERS
+            );
+            continue;
+        }
+        if entry.agreed.is_some() {
+            // Reported, not obeyed. A field parsed and discarded in silence
+            // is exactly what #509 is about.
+            tracing::warn!(
+                path = %path,
+                publisher = %publisher,
+                "credentials.toml sets [tdm.{}] agreed, which doiget does NOT read. The \
+                 per-publisher agreement is environment-only (DOIGET_AGREE_TDM_{}=1) so \
+                 that it is an act taken in the session that runs the fetch — \
+                 docs/LEGAL.md §6a.2. Only api_key is read from this file.",
+                publisher,
+                publisher.to_uppercase()
+            );
+        }
+        // Blank means unset, as everywhere else: an empty key cannot
+        // authenticate, and building a grant around one would mask the
+        // misconfiguration `AgreedButNoKey` exists to surface.
+        let key = entry
+            .api_key
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty());
+        if let Some(k) = key {
+            keys.push((publisher, k));
+        }
+    }
+    Credentials { keys }
+}
+
+/// Warn when the file is group- or world-accessible on POSIX.
+///
+/// `docs/CONFIG.md` §6 promised this warning from the day it was written.
+/// It did not exist, and neither did the reader it was attached to (#509).
+#[cfg(unix)]
+fn warn_if_group_or_world_accessible(path: &camino::Utf8Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let Ok(meta) = std::fs::metadata(path.as_std_path()) else {
+        return;
+    };
+    let mode = meta.permissions().mode() & 0o777;
+    if mode & 0o077 != 0 {
+        tracing::warn!(
+            path = %path,
+            mode = format!("{mode:04o}"),
+            "credentials.toml is readable beyond its owner (mode {:04o}); it holds \
+             publisher API keys. Run: chmod 600 {}",
+            mode,
+            path
+        );
+    }
+}
+
+/// No-op off POSIX: Windows ACLs are not a mode, and a warning phrased in
+/// `chmod` terms would be advice the user cannot follow.
+#[cfg(not(unix))]
+fn warn_if_group_or_world_accessible(_path: &camino::Utf8Path) {}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn p() -> camino::Utf8PathBuf {
+        camino::Utf8PathBuf::from("/tmp/credentials.toml")
+    }
+
+    #[test]
+    fn an_api_key_is_read_per_publisher() {
+        let c = parse(
+            "[tdm.elsevier]\napi_key = \"abc\"\n\n[tdm.aps]\napi_key = \"def\"\n",
+            &p(),
+        );
+        assert_eq!(c.api_key("elsevier"), Some("abc"));
+        assert_eq!(c.api_key("aps"), Some("def"));
+        assert_eq!(c.api_key("springer"), None);
+    }
+
+    /// The whole point of the split: the file may carry the key, never the
+    /// agreement (`docs/LEGAL.md` §6a.2). There is no accessor for `agreed`
+    /// at all, so no caller can be tempted to consult one.
+    #[test]
+    fn agreed_in_the_file_grants_nothing() {
+        let c = parse("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n", &p());
+        assert_eq!(
+            c.api_key("elsevier"),
+            Some("abc"),
+            "the key is still read; only the agreement is refused"
+        );
+    }
+
+    #[test]
+    fn a_blank_key_is_treated_as_unset() {
+        let c = parse("[tdm.aps]\napi_key = \"   \"\n", &p());
+        assert!(c.is_empty(), "a blank key cannot authenticate");
+    }
+
+    #[test]
+    fn a_malformed_file_yields_no_keys_rather_than_a_panic() {
+        assert!(parse("this is not toml = = =", &p()).is_empty());
+    }
+
+    #[test]
+    fn an_unknown_publisher_table_is_skipped() {
+        assert!(
+            parse("[tdm.wiley]\napi_key = \"abc\"\n", &p()).is_empty(),
+            "unknown publishers grant nothing"
+        );
+    }
+
+    #[test]
+    fn an_absent_tdm_table_is_not_an_error() {
+        assert!(parse("[something_else]\nx = 1\n", &p()).is_empty());
+        assert!(parse("", &p()).is_empty());
+    }
+}

--- a/crates/doiget-core/src/credentials.rs
+++ b/crates/doiget-core/src/credentials.rs
@@ -11,7 +11,10 @@
 //! **`api_key`: yes.** A long-lived key is genuinely better off in a file
 //! than in the environment. It survives a shell restart, it is not visible
 //! in `ps`, and it does not leak into the environment of every subprocess.
-//! The `0600` check is then a real control rather than a sentence.
+//! The `0600` check is then a real control rather than a sentence — which
+//! means it has to be *visible*, so it is an [`Advisory`] that `config
+//! doctor` prints rather than a `tracing::warn!` the default log level
+//! throws away.
 //!
 //! **`agreed`: no.** `docs/LEGAL.md` §6a.2 makes the per-publisher
 //! agreement an *enforced control*, and part of why it is meaningful is
@@ -37,16 +40,93 @@ use serde::Deserialize;
 /// in `docs/CONFIG.md` §6 and the `tdm-<slug>` Cargo features.
 pub const PUBLISHERS: [&str; 4] = ["elsevier", "aps", "springer", "ieee"];
 
+/// Something worth telling the user that does not stop the rest of the
+/// file being used.
+///
+/// These were `tracing::warn!` calls and nothing else, which the CLI's
+/// `EnvFilter::from_default_env()` suppresses at the default level — so the
+/// permission warning `docs/CONFIG.md` §6 promises, and the "you typed a key
+/// that did not load" line, reached nobody. Carrying them as data lets
+/// `config doctor` print them, and lets tests assert on them rather than on
+/// log output that no assertion can see.
+///
+/// File-level failures (unreadable, malformed) are [`CredentialsError`]
+/// instead: those invalidate the whole file rather than one entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Advisory {
+    /// The file is readable beyond its owner. POSIX only.
+    InsecurePermissions {
+        /// The offending file.
+        path: String,
+        /// The permission bits, masked to `0o777`.
+        mode: u32,
+    },
+    /// `[tdm.<publisher>]` names a publisher doiget does not know.
+    UnknownPublisher {
+        /// The unrecognised slug.
+        publisher: String,
+    },
+    /// `agreed` is set. It is parsed only so it can be reported; the
+    /// agreement is environment-only (`docs/LEGAL.md` §6a.2).
+    AgreedIgnored {
+        /// The publisher whose table carried it.
+        publisher: String,
+    },
+    /// `api_key` is present but blank, so it cannot authenticate.
+    ///
+    /// Covers both `api_key = ""` and a whitespace-only value. The first is
+    /// the commoner typo and was, before this, indistinguishable from the
+    /// key being absent — `Option::unwrap_or_default()` collapsed `None` and
+    /// `Some("")` to the same empty string.
+    BlankKey {
+        /// The publisher whose table carried it.
+        publisher: String,
+    },
+}
+
+impl std::fmt::Display for Advisory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsecurePermissions { path, mode } => write!(
+                f,
+                "credentials.toml is readable beyond its owner (mode {mode:04o}); it holds \
+                 publisher API keys. Run: chmod 600 {path}"
+            ),
+            Self::UnknownPublisher { publisher } => write!(
+                f,
+                "credentials.toml has [tdm.{publisher}], which is not a publisher doiget \
+                 knows; expected one of {PUBLISHERS:?}"
+            ),
+            Self::AgreedIgnored { publisher } => write!(
+                f,
+                "credentials.toml sets [tdm.{publisher}] agreed, which doiget does NOT read. \
+                 The per-publisher agreement is environment-only \
+                 (DOIGET_AGREE_TDM_{}=1) so that it is an act taken in the session that runs \
+                 the fetch — docs/LEGAL.md §6a.2. Only api_key is read from this file.",
+                publisher.to_uppercase()
+            ),
+            Self::BlankKey { publisher } => write!(
+                f,
+                "credentials.toml sets [tdm.{publisher}] api_key to a blank value, which \
+                 cannot authenticate and is treated as unset. Remove the line or give it a key."
+            ),
+        }
+    }
+}
+
 /// Parsed `credentials.toml`.
 ///
-/// Absent, unreadable and malformed all yield the default (no keys): the
-/// file is optional, and one bad line must not take a fetch down. Every
-/// such case emits `tracing::warn!` — silence about this file is precisely
-/// what cost a user their configuration.
+/// An absent file yields the default (no keys); unreadable and malformed are
+/// [`CredentialsError`], which [`load_or_default`] turns back into the
+/// default for the fetch path so one bad line cannot take a fetch down.
+/// Per-entry problems ride along as [`Advisory`] values. Nothing about this
+/// file is dropped in silence — that is what cost a user their configuration.
 #[derive(Default, Clone)]
 #[non_exhaustive]
 pub struct Credentials {
     keys: Vec<(String, String)>,
+    advisories: Vec<Advisory>,
 }
 
 /// Hand-written so a stray `{:?}` cannot print a publisher API key.
@@ -66,6 +146,7 @@ impl std::fmt::Debug for Credentials {
                     .map(|(p, _)| format!("{p}: <redacted>"))
                     .collect::<Vec<_>>(),
             )
+            .field("advisories", &self.advisories)
             .finish()
     }
 }
@@ -94,9 +175,20 @@ impl Credentials {
     pub fn len(&self) -> usize {
         self.keys.len()
     }
+
+    /// Everything worth telling the user that did not stop the file being
+    /// used. See [`Advisory`].
+    #[must_use]
+    pub fn advisories(&self) -> &[Advisory] {
+        &self.advisories
+    }
 }
 
-#[derive(Debug, Default, Deserialize)]
+// No `Debug` on either raw type: `RawEntry::api_key` is the untrimmed key
+// straight off disk, one hop before the redacting `Debug` on `Credentials`.
+// A derive here is what a future `tracing::debug!(?raw, ..)` would leak
+// through.
+#[derive(Default, Deserialize)]
 struct RawFile {
     #[serde(default)]
     tdm: Option<std::collections::BTreeMap<String, RawEntry>>,
@@ -104,7 +196,7 @@ struct RawFile {
     _other: serde::de::IgnoredAny,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Default, Deserialize)]
 struct RawEntry {
     #[serde(default)]
     api_key: Option<String>,
@@ -147,13 +239,49 @@ pub enum CredentialsError {
         source: std::io::Error,
     },
     /// The file is not valid TOML.
-    #[error("{path}: {source}")]
+    ///
+    /// Deliberately **not** carrying the `toml::de::Error`. Its `Display`
+    /// renders the offending source line verbatim, and the commonest way
+    /// this file is malformed is an unterminated `api_key = "..."` — so the
+    /// error most likely to be printed is the one whose snippet *is* the
+    /// key. Its `Debug` is worse: it holds the whole file. `config doctor`
+    /// prints this variant, so it gets the position and the parser's
+    /// message and nothing off the line itself.
+    #[error("{path}:{line}:{column}: {message}")]
     Parse {
         /// The file that failed to parse.
         path: String,
-        /// The underlying TOML error.
-        source: toml::de::Error,
+        /// 1-based line of the failure.
+        line: usize,
+        /// 1-based column of the failure.
+        column: usize,
+        /// The parser's message, which quotes no file content.
+        message: String,
     },
+}
+
+/// Build a [`CredentialsError::Parse`] that names the position without
+/// echoing anything from the file. See the variant's own note.
+fn redacted_parse_error(
+    path: &camino::Utf8Path,
+    text: &str,
+    e: &toml::de::Error,
+) -> CredentialsError {
+    let offset = e.span().map_or(0, |s| s.start).min(text.len());
+    let before = &text[..offset];
+    let line = before.matches('\n').count() + 1;
+    let column = before
+        .rsplit_once('\n')
+        .map_or(before, |(_, tail)| tail)
+        .chars()
+        .count()
+        + 1;
+    CredentialsError::Parse {
+        path: path.to_string(),
+        line,
+        column,
+        message: e.message().to_string(),
+    }
 }
 
 /// Load `credentials.toml` from an explicit path, surfacing failures.
@@ -177,8 +305,13 @@ pub fn load(path: &camino::Utf8Path) -> Result<Credentials, CredentialsError> {
             })
         }
     };
-    warn_if_group_or_world_accessible(path);
-    parse(&text, path)
+    let mut creds = parse(&text, path)?;
+    // Prepended: a world-readable key file is the most serious thing this
+    // function can find, and `config doctor` prints advisories in order.
+    if let Some(a) = permission_advisory(path) {
+        creds.advisories.insert(0, a);
+    }
+    Ok(creds)
 }
 
 /// Load the credentials file, or the empty set.
@@ -196,7 +329,15 @@ pub fn load_or_default() -> Credentials {
         }
     };
     match load(&path) {
-        Ok(c) => c,
+        Ok(c) => {
+            // The fetch path has no checklist to print to, so advisories
+            // stay logs here. `config doctor` is the surface that shows
+            // them unconditionally.
+            for a in &c.advisories {
+                tracing::warn!(path = %path, "{a}");
+            }
+            c
+        }
         Err(e) => {
             tracing::warn!(
                 error = %e,
@@ -214,40 +355,24 @@ fn parse(text: &str, path: &camino::Utf8Path) -> Result<Credentials, Credentials
     // `config doctor` can name it. The per-entry problems below (unknown
     // publisher, an `agreed` key, a blank value) are advisories: they do
     // not invalidate the rest of the file, so they stay warnings.
-    let raw: RawFile = toml::from_str(text).map_err(|source| CredentialsError::Parse {
-        path: path.to_string(),
-        source,
-    })?;
+    let raw: RawFile = toml::from_str(text).map_err(|e| redacted_parse_error(path, text, &e))?;
     let Some(tdm) = raw.tdm else {
         return Ok(Credentials::default());
     };
 
     let mut keys = Vec::new();
+    let mut advisories = Vec::new();
     for (publisher, entry) in tdm {
         if !PUBLISHERS.contains(&publisher.as_str()) {
-            tracing::warn!(
-                path = %path,
-                publisher = %publisher,
-                "credentials.toml has [tdm.{}], which is not a publisher doiget knows; \
-                 expected one of {:?}",
-                publisher,
-                PUBLISHERS
-            );
+            advisories.push(Advisory::UnknownPublisher { publisher });
             continue;
         }
         if entry.agreed.is_some() {
             // Reported, not obeyed. A field parsed and discarded in silence
             // is exactly what #509 is about.
-            tracing::warn!(
-                path = %path,
-                publisher = %publisher,
-                "credentials.toml sets [tdm.{}] agreed, which doiget does NOT read. The \
-                 per-publisher agreement is environment-only (DOIGET_AGREE_TDM_{}=1) so \
-                 that it is an act taken in the session that runs the fetch — \
-                 docs/LEGAL.md §6a.2. Only api_key is read from this file.",
-                publisher,
-                publisher.to_uppercase()
-            );
+            advisories.push(Advisory::AgreedIgnored {
+                publisher: publisher.clone(),
+            });
         }
         // Blank means unset, as everywhere else: an empty key cannot
         // authenticate, and building a grant around one would mask the
@@ -255,54 +380,49 @@ fn parse(text: &str, path: &camino::Utf8Path) -> Result<Credentials, Credentials
         //
         // It still gets a line. A present-but-blank value is a thing the
         // user typed and believes is configured, so dropping it in silence
-        // is the #442 / #476 shape this module was written to close — and
-        // it was the one case here that reached no log call at all.
-        let raw = entry.api_key.unwrap_or_default();
-        let key = raw.trim();
-        if key.is_empty() {
-            if !raw.is_empty() {
-                tracing::warn!(
-                    path = %path,
-                    publisher = %publisher,
-                    "credentials.toml sets [tdm.{}] api_key to a blank value, which cannot \
-                     authenticate and is treated as unset. Remove the line or give it a key.",
-                    publisher
-                );
+        // is the #442 / #476 shape this module was written to close.
+        //
+        // Matched on the `Option` rather than through `unwrap_or_default()`:
+        // that collapsed `None` (no line at all, which is normal) and
+        // `Some("")` (a line the user wrote, which is the typo) into the
+        // same empty string, so the commonest form of the very case this
+        // reports produced no advisory at all.
+        if let Some(raw) = entry.api_key {
+            let key = raw.trim();
+            if key.is_empty() {
+                advisories.push(Advisory::BlankKey { publisher });
+            } else {
+                keys.push((publisher, key.to_string()));
             }
-        } else {
-            keys.push((publisher, key.to_string()));
         }
     }
-    Ok(Credentials { keys })
+    Ok(Credentials { keys, advisories })
 }
 
-/// Warn when the file is group- or world-accessible on POSIX.
+/// Report when the file is group- or world-accessible on POSIX.
 ///
 /// `docs/CONFIG.md` §6 promised this warning from the day it was written.
 /// It did not exist, and neither did the reader it was attached to (#509).
+/// Returned as data rather than logged, so `config doctor` can show it — as
+/// a `tracing::warn!` it was invisible at the CLI's default log level, which
+/// made "the `0600` check is a real control" untrue.
 #[cfg(unix)]
-fn warn_if_group_or_world_accessible(path: &camino::Utf8Path) {
+fn permission_advisory(path: &camino::Utf8Path) -> Option<Advisory> {
     use std::os::unix::fs::PermissionsExt;
-    let Ok(meta) = std::fs::metadata(path.as_std_path()) else {
-        return;
-    };
+    let meta = std::fs::metadata(path.as_std_path()).ok()?;
     let mode = meta.permissions().mode() & 0o777;
-    if mode & 0o077 != 0 {
-        tracing::warn!(
-            path = %path,
-            mode = format!("{mode:04o}"),
-            "credentials.toml is readable beyond its owner (mode {:04o}); it holds \
-             publisher API keys. Run: chmod 600 {}",
-            mode,
-            path
-        );
-    }
+    (mode & 0o077 != 0).then(|| Advisory::InsecurePermissions {
+        path: path.to_string(),
+        mode,
+    })
 }
 
-/// No-op off POSIX: Windows ACLs are not a mode, and a warning phrased in
+/// `None` off POSIX: Windows ACLs are not a mode, and a warning phrased in
 /// `chmod` terms would be advice the user cannot follow.
 #[cfg(not(unix))]
-fn warn_if_group_or_world_accessible(_path: &camino::Utf8Path) {}
+fn permission_advisory(_path: &camino::Utf8Path) -> Option<Advisory> {
+    None
+}
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
@@ -345,6 +465,29 @@ mod tests {
         assert!(c.is_empty(), "a blank key cannot authenticate");
     }
 
+    /// `agreed` is refused, but its presence must be *said*, not swallowed.
+    #[test]
+    fn agreed_in_the_file_is_reported() {
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n");
+        assert_eq!(
+            c.advisories(),
+            [Advisory::AgreedIgnored {
+                publisher: "elsevier".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn an_unknown_publisher_is_reported() {
+        let c = ok("[tdm.wiley]\napi_key = \"abc\"\n");
+        assert_eq!(
+            c.advisories(),
+            [Advisory::UnknownPublisher {
+                publisher: "wiley".to_string()
+            }]
+        );
+    }
+
     /// A malformed file is a FILE-level failure, returned rather than
     /// warned about, so `doiget config doctor` can name it. Before #509's
     /// follow-up the only surface was `tracing::warn!`, which the CLI's
@@ -359,14 +502,63 @@ mod tests {
         }
     }
 
+    /// `config doctor` prints this error. `toml::de::Error`'s own `Display`
+    /// quotes the offending source line, and the commonest malformation of
+    /// this file is an unterminated `api_key = "..."` — so rendering it
+    /// would print the key to the terminal, from the one module whose whole
+    /// job is that the key is never printed.
+    #[test]
+    fn a_parse_error_names_the_position_without_quoting_the_line() {
+        let secret = "sk-do-not-print-me";
+        let text = format!("[tdm.elsevier]\napi_key = \"{secret}\n");
+        let e = parse(&text, &p()).expect_err("an unterminated string must not parse");
+        let rendered = format!("{e}");
+        assert!(
+            !rendered.contains(secret),
+            "the key leaked through Display: {rendered}"
+        );
+        assert!(
+            !format!("{e:?}").contains(secret),
+            "the key leaked through Debug: {e:?}"
+        );
+        assert!(
+            rendered.contains(":2:"),
+            "the position is still named: {rendered}"
+        );
+    }
+
     /// A blank value is a thing the user typed. It is still treated as
-    /// unset, but it no longer disappears without a line — that was the one
-    /// failure mode in this module with no log call at all.
+    /// unset, but it must not disappear without a word.
+    ///
+    /// Asserts on the advisory, not just on the resulting key count: the
+    /// previous version of this test used `api_key = ""` and checked only
+    /// `is_empty()`, so it passed while the reporting it is named for did
+    /// not happen at all for that exact input.
     #[test]
     fn a_present_but_blank_key_is_reported_not_silently_dropped() {
-        let c = ok("[tdm.aps]\napi_key = \"\"\n");
+        for text in [
+            "[tdm.aps]\napi_key = \"\"\n",
+            "[tdm.aps]\napi_key = \"   \"\n",
+        ] {
+            let c = ok(text);
+            assert!(c.is_empty(), "{text:?} must grant no key");
+            assert_eq!(
+                c.advisories(),
+                [Advisory::BlankKey {
+                    publisher: "aps".to_string()
+                }],
+                "{text:?} must be reported, not dropped"
+            );
+        }
+    }
+
+    /// The absent case is normal and must stay quiet, or the advisory list
+    /// fills with noise on every well-formed file and stops being read.
+    #[test]
+    fn an_absent_key_is_not_an_advisory() {
+        let c = ok("[tdm.aps]\n");
         assert!(c.is_empty());
-        assert_eq!(c.len(), 0);
+        assert!(c.advisories().is_empty(), "{:?}", c.advisories());
     }
 
     #[test]
@@ -381,5 +573,12 @@ mod tests {
     fn an_absent_tdm_table_is_not_an_error() {
         assert!(ok("[something_else]\nx = 1\n").is_empty());
         assert!(ok("").is_empty());
+    }
+
+    /// A well-formed file must have nothing to say.
+    #[test]
+    fn a_clean_file_produces_no_advisories() {
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\n");
+        assert!(c.advisories().is_empty(), "{:?}", c.advisories());
     }
 }

--- a/crates/doiget-core/src/discovery.rs
+++ b/crates/doiget-core/src/discovery.rs
@@ -61,7 +61,7 @@ use crate::source::{FetchContext, FetchError};
 /// Shares the `"openalex"` key with `crate::sources::openalex` so that
 /// `crate::http::discovery_allowlist` (always compiled) and
 /// `tier_2_allowlist` (always compiled, but only *called* by the CLI
-/// under `#[cfg(feature = "citation")]`) register the same
+/// under `#[cfg(feature = "metadata")]` — #516) register the same
 /// `api.openalex.org` host under one key (an idempotent overwrite — see
 /// ADR-0031 D2).
 const SOURCE_KEY: &str = "openalex";

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -275,13 +275,15 @@ pub fn tier_2_allowlist() -> Vec<SourceAllowlist> {
 /// Tier-1 `discovery::paper_search` (`GET /works?search=`) can reach the
 /// endpoint in the **default `oa-only` binary** — unlike
 /// [`tier_2_allowlist`], which the CLI only wires in under
-/// `#[cfg(feature = "citation")]`.
+/// `#[cfg(feature = "metadata")]` (#516; it was `citation` until then,
+/// which left every other Tier-2 source `UnknownSource` in a
+/// `metadata`-only build).
 ///
 /// Discovery search is classified as Tier 1 OA metadata (read-only, never
 /// paywalled, never a PDF — same risk class as Crossref/Unpaywall), so its
 /// transport allowlist must exist regardless of the `metadata`/`citation`
 /// features (ADR-0031 D1/D2). The CLI's `build_http_client` extends the
-/// production allowlist with this **unconditionally**; in `citation`
+/// production allowlist with this **unconditionally**; in `metadata`
 /// builds [`tier_2_allowlist`] re-registers the identical
 /// `"openalex" → api.openalex.org` entry, which is a harmless idempotent
 /// `HashMap` overwrite in [`HttpClient::new`].

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1378,29 +1378,29 @@ impl CapabilityProfile {
         // `credentials` module docs and `docs/LEGAL.md` §6a.2.
         let creds = crate::credentials::load_or_default();
         let tdm_elsevier = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-            KeyVar("DOIGET_KEY_ELSEVIER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar::new("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             cfg!(feature = "tdm-elsevier"),
             creds.api_key("elsevier"),
         )?;
         let tdm_aps = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_APS"),
-            KeyVar("DOIGET_KEY_APS"),
+            AgreeVar::new("DOIGET_AGREE_TDM_APS"),
+            KeyVar::new("DOIGET_KEY_APS"),
             "tdm-aps",
             cfg!(feature = "tdm-aps"),
             creds.api_key("aps"),
         )?;
         let tdm_springer = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_SPRINGER"),
-            KeyVar("DOIGET_KEY_SPRINGER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_SPRINGER"),
+            KeyVar::new("DOIGET_KEY_SPRINGER"),
             "tdm-springer",
             cfg!(feature = "tdm-springer"),
             creds.api_key("springer"),
         )?;
         let tdm_ieee = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_IEEE"),
-            KeyVar("DOIGET_KEY_IEEE"),
+            AgreeVar::new("DOIGET_AGREE_TDM_IEEE"),
+            KeyVar::new("DOIGET_KEY_IEEE"),
             "tdm-ieee",
             cfg!(feature = "tdm-ieee"),
             creds.api_key("ieee"),
@@ -1442,6 +1442,57 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
     }
 }
 
+/// The env var carrying the per-publisher agreement.
+///
+/// A newtype because `agree_var` and `key_var` were adjacent `&str`
+/// parameters: transposing them at a call site type-checked, and the
+/// resulting build would treat the KEY as the agreement signal and the
+/// AGREEMENT as the key. `docs/LEGAL.md` §6a.2 makes that agreement an
+/// enforced control, so "nothing stops a fifth publisher's call site from
+/// being copy-pasted wrong" is not a risk worth carrying for two saved
+/// characters.
+///
+/// `pub(crate)` with a private field: the only consumer is a private `fn`
+/// in this module, so a public tuple struct added semver surface nothing
+/// outside the crate can reach. The private field also closes the variant
+/// the newtype alone did not — `AgreeVar("DOIGET_KEY_ELSEVIER")` is the
+/// same transposition expressed as content rather than position, and it
+/// compiled. [`AgreeVar::new`] refuses it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AgreeVar(&'static str);
+
+/// The env var carrying the per-publisher API key. See [`AgreeVar`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct KeyVar(&'static str);
+
+impl AgreeVar {
+    /// # Panics
+    ///
+    /// If `var` is not a `DOIGET_AGREE_TDM_*` name. Every argument is a
+    /// literal in this file, so this is a typo caught at the first test
+    /// run, not a runtime failure mode.
+    pub(crate) fn new(var: &'static str) -> Self {
+        assert!(
+            var.starts_with("DOIGET_AGREE_TDM_"),
+            "{var} is not an agreement variable"
+        );
+        Self(var)
+    }
+}
+
+impl KeyVar {
+    /// # Panics
+    ///
+    /// If `var` is not a `DOIGET_KEY_*` name. See [`AgreeVar::new`].
+    pub(crate) fn new(var: &'static str) -> Self {
+        assert!(
+            var.starts_with("DOIGET_KEY_"),
+            "{var} is not a key variable"
+        );
+        Self(var)
+    }
+}
+
 /// Resolve a Tier 3 TDM grant from the agreement env var, the key (env var
 /// or `credentials.toml`), and the per-publisher Cargo feature.
 ///
@@ -1462,22 +1513,6 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
 /// `KeyButNotAgreed` now also fires for a file-supplied key with no
 /// `DOIGET_AGREE_TDM_<PUBLISHER>=1`. That is the point — `docs/LEGAL.md`
 /// §6a.2 is an enforced control, and a convenience must not dilute it.
-/// The env var carrying the per-publisher agreement.
-///
-/// A newtype because `agree_var` and `key_var` were adjacent `&str`
-/// parameters: transposing them at a call site type-checked, and the
-/// resulting build would treat the KEY as the agreement signal and the
-/// AGREEMENT as the key. `docs/LEGAL.md` §6a.2 makes that agreement an
-/// enforced control, so "nothing stops a fifth publisher's call site from
-/// being copy-pasted wrong" is not a risk worth carrying for two saved
-/// characters.
-#[derive(Debug, Clone, Copy)]
-pub struct AgreeVar(pub &'static str);
-
-/// The env var carrying the per-publisher API key. See [`AgreeVar`].
-#[derive(Debug, Clone, Copy)]
-pub struct KeyVar(pub &'static str);
-
 fn resolve_tdm_grant(
     agree: AgreeVar,
     key: KeyVar,
@@ -1800,8 +1835,8 @@ agreed = true
         let _g = unset_all_capability_env_vars();
 
         let granted = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-            KeyVar("DOIGET_KEY_ELSEVIER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar::new("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1813,8 +1848,8 @@ agreed = true
 
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "   ");
         match resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-            KeyVar("DOIGET_KEY_ELSEVIER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar::new("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1826,8 +1861,8 @@ agreed = true
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
         assert!(
             resolve_tdm_grant(
-                AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-                KeyVar("DOIGET_KEY_ELSEVIER"),
+                AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+                KeyVar::new("DOIGET_KEY_ELSEVIER"),
                 "tdm-elsevier",
                 false,
                 Some("file-key"),

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -16,6 +16,7 @@ use sha2::Digest;
 
 // --- Modules ---
 pub mod canonical;
+pub mod credentials;
 pub mod discovery;
 pub mod dry_run;
 pub mod http;
@@ -1369,29 +1370,40 @@ impl CapabilityProfile {
         };
 
         // -- Tier 3 TDM grants ----------------------------------------------
+        // #509: the key may also come from `credentials.toml`, which
+        // `docs/CONFIG.md` §6 has specified in full since 0.7 and which
+        // nothing read. Loaded once — one file, one reader, so `config
+        // doctor` and a fetch can never describe different files (#441's
+        // lesson). The **agreement** stays environment-only; see the
+        // `credentials` module docs and `docs/LEGAL.md` §6a.2.
+        let creds = crate::credentials::load_or_default();
         let tdm_elsevier = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_ELSEVIER",
             "DOIGET_KEY_ELSEVIER",
             "tdm-elsevier",
             cfg!(feature = "tdm-elsevier"),
+            creds.api_key("elsevier"),
         )?;
         let tdm_aps = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_APS",
             "DOIGET_KEY_APS",
             "tdm-aps",
             cfg!(feature = "tdm-aps"),
+            creds.api_key("aps"),
         )?;
         let tdm_springer = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_SPRINGER",
             "DOIGET_KEY_SPRINGER",
             "tdm-springer",
             cfg!(feature = "tdm-springer"),
+            creds.api_key("springer"),
         )?;
         let tdm_ieee = resolve_tdm_grant(
             "DOIGET_AGREE_TDM_IEEE",
             "DOIGET_KEY_IEEE",
             "tdm-ieee",
             cfg!(feature = "tdm-ieee"),
+            creds.api_key("ieee"),
         )?;
 
         Ok(Self {
@@ -1430,24 +1442,32 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
     }
 }
 
-/// Resolve a Tier 3 TDM grant from the `agree`/`key` env-var pair and the
-/// per-publisher Cargo feature.
+/// Resolve a Tier 3 TDM grant from the agreement env var, the key (env var
+/// or `credentials.toml`), and the per-publisher Cargo feature.
 ///
 /// Implements the rules in `docs/CAPABILITY.md` §2:
 ///
 /// - both unset → `Ok(None)`.
-/// - `agree == "1"` and `key` set → `Ok(Some(TdmGrant { .. }))` (when the
+/// - `agree == "1"` and a key → `Ok(Some(TdmGrant { .. }))` (when the
 ///   feature is enabled), or warn-and-`Ok(None)` (when the feature is not
 ///   compiled in).
-/// - `agree == "1"` and `key` unset →
-///   [`CapabilityError::AgreedButNoKey`].
-/// - `key` set and `agree` unset OR `agree` set to anything other than `"1"`
-///   → [`CapabilityError::KeyButNotAgreed`].
+/// - `agree == "1"` and no key → [`CapabilityError::AgreedButNoKey`].
+/// - a key, and `agree` unset OR set to anything other than `"1"` →
+///   [`CapabilityError::KeyButNotAgreed`].
+///
+/// `file_key` is `[tdm.<publisher>] api_key` from `credentials.toml`, one
+/// rung **below** `DOIGET_KEY_<PUBLISHER>` (#509). The two rules above are
+/// unchanged by its existence: a key from the file still needs the
+/// agreement, and the agreement still comes only from the environment, so
+/// `KeyButNotAgreed` now also fires for a file-supplied key with no
+/// `DOIGET_AGREE_TDM_<PUBLISHER>=1`. That is the point — `docs/LEGAL.md`
+/// §6a.2 is an enforced control, and a convenience must not dilute it.
 fn resolve_tdm_grant(
     agree_var: &str,
     key_var: &str,
     feature: &str,
     feature_enabled: bool,
+    file_key: Option<&str>,
 ) -> Result<Option<TdmGrant>, CapabilityError> {
     // `agree` is "agreed" iff the value is exactly the literal "1"; any other
     // value (including "true", "yes", empty) is treated as not-agreed per
@@ -1460,7 +1480,14 @@ fn resolve_tdm_grant(
     // An empty value is treated as "not set" — an empty API key cannot
     // authenticate, and silently constructing a grant around it would
     // mask the misconfiguration the AgreedButNoKey rule exists to surface.
-    let key_value = std::env::var(key_var).ok().filter(|v| !v.is_empty());
+    //
+    // Env above file (#509), matching `docs/CONFIG.md` §1 and the
+    // `store_root` / `contact_email` rungs. `credentials.toml` has already
+    // applied the same blank-is-unset rule.
+    let key_value = std::env::var(key_var)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| file_key.map(str::to_string));
 
     match (agreed, agree_present, key_value) {
         (true, _, Some(key)) => {
@@ -1629,9 +1656,25 @@ mod tests {
         }
     }
 
+    /// Point every config-dir rung at `dir`, so `credentials.toml` and
+    /// `config.toml` resolve there. Returns guards restoring prior values.
+    fn scoped_config_home(dir: &str) -> Vec<EnvGuard> {
+        ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"]
+            .iter()
+            .map(|v| EnvGuard::set(v, dir))
+            .collect()
+    }
+
     /// Convenience: unset every Tier 2 / Tier 3 env var the resolution
     /// algorithm reads, returning a vector of guards that restore them on
     /// drop. Callers can then `EnvGuard::set` individual vars on top.
+    ///
+    /// The caller MUST also scope the config directory — see
+    /// [`isolated_capability_env`]. Since #509 the TDM key has a
+    /// `credentials.toml` rung, so a test that only clears the environment
+    /// reads the developer's real credentials file: green in CI and red on
+    /// the one machine that has TDM configured, which is the least useful
+    /// place for a test to fail.
     fn unset_all_capability_env_vars() -> Vec<EnvGuard> {
         [
             "DOIGET_ENABLE_OPENALEX",
@@ -1643,10 +1686,138 @@ mod tests {
             "DOIGET_KEY_APS",
             "DOIGET_AGREE_TDM_SPRINGER",
             "DOIGET_KEY_SPRINGER",
+            "DOIGET_AGREE_TDM_IEEE",
+            "DOIGET_KEY_IEEE",
         ]
         .iter()
         .map(|v| EnvGuard::unset(v))
         .collect()
+    }
+
+    /// Clean environment AND an empty config directory, so
+    /// `CapabilityProfile::from_env` sees neither an env var nor a
+    /// credentials file. Hold the returned tuple for the test's lifetime.
+    fn isolated_capability_env() -> (tempfile::TempDir, Vec<EnvGuard>, Vec<EnvGuard>) {
+        isolated_env_with(None)
+    }
+
+    /// As [`isolated_capability_env`], optionally writing `credentials.toml`.
+    fn isolated_env_with(
+        credentials: Option<&str>,
+    ) -> (tempfile::TempDir, Vec<EnvGuard>, Vec<EnvGuard>) {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        if let Some(body) = credentials {
+            std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+            std::fs::write(
+                dir.join("doiget").join("credentials.toml").as_std_path(),
+                body,
+            )
+            .expect("write credentials.toml");
+        }
+        let env = unset_all_capability_env_vars();
+        let home = scoped_config_home(dir.as_str());
+        (td, env, home)
+    }
+
+    /// #509: `credentials.toml` supplies the KEY, and the agreement still
+    /// comes only from the environment.
+    ///
+    /// Asserts the production path (`CapabilityProfile::from_env`), not the
+    /// parser — the parser was never the missing part. #442, #454 and #458
+    /// were each a correct component nothing reached, and a file reader
+    /// with no caller would be that defect again.
+    ///
+    /// Holds in the shipped `oa-only` build: `KeyButNotAgreed` fires before
+    /// any feature gate, so this proves the file is read without needing a
+    /// `tdm-*` feature compiled.
+    #[test]
+    #[serial_test::serial]
+    fn a_key_from_credentials_toml_is_read_and_still_needs_the_agreement() {
+        let (_td, _env, _home) = isolated_env_with(Some(
+            "[tdm.elsevier]
+api_key = \"file-key\"
+",
+        ));
+
+        match CapabilityProfile::from_env() {
+            Err(CapabilityError::KeyButNotAgreed { agree_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+            }
+            other => panic!(
+                "a key in credentials.toml must be READ, so the missing agreement is reported. Before #509 this was Ok(no grant) because the file was never opened. Got {other:?}"
+            ),
+        }
+    }
+
+    /// The half that must NOT work: `agreed = true` in the file is not an
+    /// agreement (`docs/LEGAL.md` §6a.2). Key from the file, no
+    /// `DOIGET_AGREE_TDM_ELSEVIER` — still `KeyButNotAgreed`.
+    #[test]
+    #[serial_test::serial]
+    fn agreed_in_credentials_toml_does_not_grant_anything() {
+        let (_td, _env, _home) = isolated_env_with(Some(
+            "[tdm.elsevier]
+api_key = \"file-key\"
+agreed = true
+",
+        ));
+
+        match CapabilityProfile::from_env() {
+            Err(CapabilityError::KeyButNotAgreed { agree_var }) => {
+                assert_eq!(agree_var, "DOIGET_AGREE_TDM_ELSEVIER");
+            }
+            other => panic!(
+                "`agreed` in the file must not substitute for the environment agreement; got {other:?}"
+            ),
+        }
+    }
+
+    /// Env above file, per `docs/CONFIG.md` §1: the agreement plus either
+    /// key resolves, and a blank env key falls through to the file rather
+    /// than counting as a key (the blank-is-unset rule every rung uses).
+    #[test]
+    #[serial_test::serial]
+    fn the_env_key_outranks_the_file_and_a_blank_one_falls_through() {
+        let _g = unset_all_capability_env_vars();
+
+        let granted = resolve_tdm_grant(
+            "DOIGET_AGREE_TDM_ELSEVIER",
+            "DOIGET_KEY_ELSEVIER",
+            "tdm-elsevier",
+            false,
+            Some("file-key"),
+        );
+        match granted {
+            Err(CapabilityError::KeyButNotAgreed { .. }) => {}
+            other => panic!("a file key with no agreement is KeyButNotAgreed; got {other:?}"),
+        }
+
+        let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "   ");
+        match resolve_tdm_grant(
+            "DOIGET_AGREE_TDM_ELSEVIER",
+            "DOIGET_KEY_ELSEVIER",
+            "tdm-elsevier",
+            false,
+            Some("file-key"),
+        ) {
+            Err(CapabilityError::KeyButNotAgreed { .. }) => {}
+            other => panic!("a blank env key must fall through to the file; got {other:?}"),
+        }
+
+        let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
+        assert!(
+            resolve_tdm_grant(
+                "DOIGET_AGREE_TDM_ELSEVIER",
+                "DOIGET_KEY_ELSEVIER",
+                "tdm-elsevier",
+                false,
+                Some("file-key"),
+            )
+            .is_ok(),
+            "agreement + a file key is a valid configuration"
+        );
     }
 
     #[test]
@@ -1655,7 +1826,7 @@ mod tests {
         // Rule: with every relevant env var unset, the resolved profile has
         // all TDM grants `None` and all metadata flags `false`. Hard-coded
         // rate limits still apply. (Replaces the old Phase 0 stub test.)
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
 
         let p = CapabilityProfile::from_env().expect("clean env never errors");
         assert!(p.tdm_elsevier.is_none());
@@ -1672,7 +1843,7 @@ mod tests {
     fn from_env_no_tdm_returns_tier_1_profile() {
         // Rule (CAPABILITY.md §2): with every TDM env var unset, all
         // `tdm_*` fields are `None` and no error is produced.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
 
         let p = CapabilityProfile::from_env().expect("no TDM env -> Ok");
         assert!(p.tdm_elsevier.is_none());
@@ -1684,7 +1855,7 @@ mod tests {
     #[serial_test::serial]
     fn from_env_agreed_but_no_key_errs() {
         // Rule (CAPABILITY.md §2): agree=1 + key unset -> AgreedButNoKey.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
 
         let result = CapabilityProfile::from_env();
@@ -1705,7 +1876,7 @@ mod tests {
         // DOIGET_KEY_ELSEVIER="" the misconfiguration must surface as
         // AgreedButNoKey, not silently build a grant around an empty
         // secret that could never authenticate.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "");
 
@@ -1727,7 +1898,7 @@ mod tests {
         // It must resolve to Ok(None) (no grant, no error) — an empty
         // string must NOT trip the KeyButNotAgreed leaked-credential
         // rule, since there is no credential.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "");
 
         let p = CapabilityProfile::from_env()
@@ -1745,7 +1916,7 @@ mod tests {
     fn from_env_key_but_not_agreed_errs() {
         // Rule (CAPABILITY.md §2): key set + agree unset -> KeyButNotAgreed.
         // A leaked DOIGET_KEY_ELSEVIER must not silently enable a source.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "sk-test");
 
         let result = CapabilityProfile::from_env();
@@ -1763,7 +1934,7 @@ mod tests {
         // Rule (CAPABILITY.md §2): the agree var must be exactly "1". Any
         // other value (here: "true") is treated as not-agreed; combined
         // with a key set, that triggers KeyButNotAgreed.
-        let _g = unset_all_capability_env_vars();
+        let (_td, _g, _home) = isolated_capability_env();
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "true");
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "sk-test");
 

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1378,29 +1378,29 @@ impl CapabilityProfile {
         // `credentials` module docs and `docs/LEGAL.md` §6a.2.
         let creds = crate::credentials::load_or_default();
         let tdm_elsevier = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_ELSEVIER",
-            "DOIGET_KEY_ELSEVIER",
+            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             cfg!(feature = "tdm-elsevier"),
             creds.api_key("elsevier"),
         )?;
         let tdm_aps = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_APS",
-            "DOIGET_KEY_APS",
+            AgreeVar("DOIGET_AGREE_TDM_APS"),
+            KeyVar("DOIGET_KEY_APS"),
             "tdm-aps",
             cfg!(feature = "tdm-aps"),
             creds.api_key("aps"),
         )?;
         let tdm_springer = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_SPRINGER",
-            "DOIGET_KEY_SPRINGER",
+            AgreeVar("DOIGET_AGREE_TDM_SPRINGER"),
+            KeyVar("DOIGET_KEY_SPRINGER"),
             "tdm-springer",
             cfg!(feature = "tdm-springer"),
             creds.api_key("springer"),
         )?;
         let tdm_ieee = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_IEEE",
-            "DOIGET_KEY_IEEE",
+            AgreeVar("DOIGET_AGREE_TDM_IEEE"),
+            KeyVar("DOIGET_KEY_IEEE"),
             "tdm-ieee",
             cfg!(feature = "tdm-ieee"),
             creds.api_key("ieee"),
@@ -1462,13 +1462,30 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
 /// `KeyButNotAgreed` now also fires for a file-supplied key with no
 /// `DOIGET_AGREE_TDM_<PUBLISHER>=1`. That is the point — `docs/LEGAL.md`
 /// §6a.2 is an enforced control, and a convenience must not dilute it.
+/// The env var carrying the per-publisher agreement.
+///
+/// A newtype because `agree_var` and `key_var` were adjacent `&str`
+/// parameters: transposing them at a call site type-checked, and the
+/// resulting build would treat the KEY as the agreement signal and the
+/// AGREEMENT as the key. `docs/LEGAL.md` §6a.2 makes that agreement an
+/// enforced control, so "nothing stops a fifth publisher's call site from
+/// being copy-pasted wrong" is not a risk worth carrying for two saved
+/// characters.
+#[derive(Debug, Clone, Copy)]
+pub struct AgreeVar(pub &'static str);
+
+/// The env var carrying the per-publisher API key. See [`AgreeVar`].
+#[derive(Debug, Clone, Copy)]
+pub struct KeyVar(pub &'static str);
+
 fn resolve_tdm_grant(
-    agree_var: &str,
-    key_var: &str,
+    agree: AgreeVar,
+    key: KeyVar,
     feature: &str,
     feature_enabled: bool,
     file_key: Option<&str>,
 ) -> Result<Option<TdmGrant>, CapabilityError> {
+    let (agree_var, key_var) = (agree.0, key.0);
     // `agree` is "agreed" iff the value is exactly the literal "1"; any other
     // value (including "true", "yes", empty) is treated as not-agreed per
     // `docs/CAPABILITY.md` §2.
@@ -1783,8 +1800,8 @@ agreed = true
         let _g = unset_all_capability_env_vars();
 
         let granted = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_ELSEVIER",
-            "DOIGET_KEY_ELSEVIER",
+            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1796,8 +1813,8 @@ agreed = true
 
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "   ");
         match resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_ELSEVIER",
-            "DOIGET_KEY_ELSEVIER",
+            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1809,8 +1826,8 @@ agreed = true
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
         assert!(
             resolve_tdm_grant(
-                "DOIGET_AGREE_TDM_ELSEVIER",
-                "DOIGET_KEY_ELSEVIER",
+                AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+                KeyVar("DOIGET_KEY_ELSEVIER"),
                 "tdm-elsevier",
                 false,
                 Some("file-key"),

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -574,9 +574,56 @@ fn env_nonempty(key: &str) -> Option<String> {
 /// environment, and one small read is free next to the network legs it
 /// precedes.
 fn resolve_contact_email() -> String {
+    contact_email_or_placeholder()
+}
+
+/// The polite-pool contact address the user configured, or `None`.
+///
+/// Env var, then `[network] contact_email` in `config.toml` (#504). Public
+/// because `doiget-mcp` needs the SAME ladder: `doiget_paper_search`,
+/// `doiget_link`, `doiget_expand_citation_graph` and
+/// `doiget_resolve_citation` each read `DOIGET_CONTACT_EMAIL` directly, so
+/// a user who set the address in `config.toml` got the polite pool from
+/// `doiget fetch` and the non-polite pool from every one of those tools —
+/// the "documented setting that does nothing" defect #504 was filed to
+/// close, surviving in the surface doiget leads with.
+///
+/// Returns `None` rather than a placeholder so callers that must omit
+/// `mailto` entirely when nothing is configured can still do so.
+#[must_use]
+pub fn configured_contact_email() -> Option<String> {
     env_nonempty("DOIGET_CONTACT_EMAIL")
         .or_else(|| crate::user_extension::load_or_default().contact_email)
-        .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
+}
+
+/// [`configured_contact_email`] with `doiget@localhost` as the last rung,
+/// for callers that always need some address.
+#[must_use]
+pub fn contact_email_or_placeholder() -> String {
+    configured_contact_email().unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
+}
+
+/// Both addresses, from a single read of `config.toml`.
+///
+/// Resolving them independently meant two reads per fetch, and — in a
+/// long-lived `doiget serve` — a window in which an edit landing between
+/// them gave one address from the old file and one from the new. One read,
+/// one generation.
+fn resolve_contact_emails() -> (String, String) {
+    let env_contact = env_nonempty("DOIGET_CONTACT_EMAIL");
+    let env_unpaywall = env_nonempty("DOIGET_UNPAYWALL_EMAIL");
+    // Fully env-configured processes never touch the disk at all.
+    if let (Some(contact), Some(unpaywall)) = (&env_contact, &env_unpaywall) {
+        return (contact.clone(), unpaywall.clone());
+    }
+    let file = crate::user_extension::load_or_default();
+    let contact = env_contact
+        .or(file.contact_email)
+        .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string());
+    let unpaywall = env_unpaywall
+        .or(file.unpaywall_email)
+        .unwrap_or_else(|| contact.clone());
+    (contact, unpaywall)
 }
 
 fn arxiv_source_from_env() -> ArxivSource {
@@ -1218,8 +1265,7 @@ async fn fetch_paper_doi(
     store_root: &Utf8Path,
     safekey: &Safekey,
 ) -> Result<FetchPaperOutcome, FetchError> {
-    let contact = resolve_contact_email();
-    let unpaywall_contact = resolve_unpaywall_email(&contact);
+    let (contact, unpaywall_contact) = resolve_contact_emails();
     let crossref = crossref_source_from_env(&contact);
     // Issue #120: Crossref is NON-fatal. A transient Crossref failure
     // must not abort the whole DOI fetch when Unpaywall alone can
@@ -2592,27 +2638,6 @@ fn strip_arxiv_version(id: &str) -> &str {
     id
 }
 
-/// Unpaywall contact: `DOIGET_UNPAYWALL_EMAIL`, then
-/// `[network] unpaywall_email`, then whatever the caller resolved as the
-/// general contact address (#504).
-///
-/// The more specific field wins at each rung, which is how
-/// `DOIGET_UNPAYWALL_EMAIL` already beat `DOIGET_CONTACT_EMAIL`.
-///
-/// `[network] unpaywall_email` was written by `config init`, called
-/// STRONGLY RECOMMENDED by the template's own prose, and read by nothing
-/// for four releases. The cost is not politeness. The template says so
-/// itself: the automatic arXiv-preprint fallback fires on what Unpaywall
-/// reports, so a throttled answer from the non-polite pool quietly costs
-/// that fallback — and the run still exits 0 with `metadata-only: no OA
-/// PDF available`. A degraded search and a true negative were the same
-/// observable.
-fn resolve_unpaywall_email(fallback_contact: &str) -> String {
-    env_nonempty("DOIGET_UNPAYWALL_EMAIL")
-        .or_else(|| crate::user_extension::load_or_default().unpaywall_email)
-        .unwrap_or_else(|| fallback_contact.to_string())
-}
-
 // ---------------------------------------------------------------------------
 // batch_fetch — multi-ref orchestrator (Slice 2)
 // ---------------------------------------------------------------------------
@@ -2787,9 +2812,9 @@ mod tests {
         );
         let _env = LadderEnv::scoped(&dir);
 
-        let contact = resolve_contact_email();
+        let (contact, unpaywall) = resolve_contact_emails();
         assert_eq!(contact, "file@institution.edu");
-        assert_eq!(resolve_unpaywall_email(&contact), "up@institution.edu");
+        assert_eq!(unpaywall, "up@institution.edu");
     }
 
     /// The env rung stays on top, per field, and `unpaywall_email` still
@@ -2802,11 +2827,10 @@ mod tests {
         let mut env = LadderEnv::scoped(&dir);
         env.set("DOIGET_CONTACT_EMAIL", "env@institution.edu");
 
-        let contact = resolve_contact_email();
+        let (contact, unpaywall) = resolve_contact_emails();
         assert_eq!(contact, "env@institution.edu");
         assert_eq!(
-            resolve_unpaywall_email(&contact),
-            "env@institution.edu",
+            unpaywall, "env@institution.edu",
             "no unpaywall rung is set, so it must inherit the resolved contact"
         );
     }
@@ -2823,9 +2847,9 @@ mod tests {
             .to_string();
         let _env = LadderEnv::scoped(&dir);
 
-        let contact = resolve_contact_email();
+        let (contact, unpaywall) = resolve_contact_emails();
         assert_eq!(contact, FALLBACK_CONTACT_EMAIL);
-        assert_eq!(resolve_unpaywall_email(&contact), FALLBACK_CONTACT_EMAIL);
+        assert_eq!(unpaywall, FALLBACK_CONTACT_EMAIL);
     }
 
     /// A blank value is not an address. Both rungs treat it as unset —

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4210,6 +4210,19 @@ mod attempt_denial_tests {
 
 /// Whether a `SourceSchema` hint describes an access refusal rather than a
 /// malformed response.
+///
+/// The coupling is prose: a source says why it refused in free text and
+/// this reads the text back. That is fragile, and #503 is the proof — it
+/// reworded Europe PMC's refusal from "not open access" to "advertises no
+/// retrievable PDF" and the row silently reclassified from
+/// `NotOpenAccess` to `Failed`, which reads to an operator as "the source
+/// broke" rather than "the source has it and cannot give it to us".
+///
+/// It is caught rather than prevented: `an_access_refusal_is_recorded_
+/// distinctly_from_a_miss` drives the real chain, so any source whose
+/// wording drifts out of this predicate fails there. A typed refusal on
+/// `FetchError` would prevent it instead, at the cost of widening the
+/// closed error set in `docs/ERRORS.md` §3.
 #[cfg(any(
     feature = "metadata",
     feature = "tdm-elsevier",
@@ -4218,7 +4231,13 @@ mod attempt_denial_tests {
     feature = "tdm-ieee"
 ))]
 fn is_access_refusal(hint: &str) -> bool {
-    hint.contains("not open access") || hint.contains("openAccess")
+    hint.contains("not open access")
+        || hint.contains("openAccess")
+        // #503: Europe PMC refuses on "nothing retrievable is
+        // advertised", which is a strictly narrower claim than "outside
+        // the OA subset" and is still an access refusal, not a schema
+        // failure.
+        || hint.contains("no retrievable PDF")
 }
 
 /// Run the optional resolution chain and record one [`SourceAttempt`] per
@@ -4924,6 +4943,11 @@ mod chain_tests {
     /// An access refusal is not a miss. OpenAIRE / Europe PMC / HAL all
     /// report "found it, cannot give it to you" — that must not be recorded
     /// as `NoRecord`, or the operator concludes the paper does not exist.
+    ///
+    /// This record carries no `fullTextUrlList` at all, so after #503 it is
+    /// refused for the narrower reason and must still classify as
+    /// `NotOpenAccess` — see `is_access_refusal`, whose coupling to the
+    /// wording this test is the only thing guarding.
     #[tokio::test]
     #[serial_test::serial]
     async fn an_access_refusal_is_recorded_distinctly_from_a_miss() {
@@ -4954,6 +4978,53 @@ mod chain_tests {
             o.render().contains("not open access"),
             "the reason must survive into the message; got {}",
             o.render()
+        );
+    }
+
+    /// #503, at the level that matters: a Europe PMC record OUTSIDE the
+    /// bulk OA subset that still advertises a Free PDF must resolve, and
+    /// the URL must reach `optional_source_oa_url` — which is what
+    /// `try_optional_source_oa_fallback` hands to the `oa-publisher` leg.
+    ///
+    /// The source-level test proves the gate; this proves the copy is not
+    /// dropped somewhere between the gate and the fetch. Every bug in the
+    /// #442 family was a correct component that nothing reached.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_closed_subset_record_with_a_free_pdf_resolves_and_carries_its_url() {
+        let server = MockServer::start().await;
+        let _bases = BaseGuard::to(&server.uri());
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"resultList":{"result":[{"doi":"10.1098/rspa.2014.0585",
+                   "isOpenAccess":"N","inEPMC":"Y","fullTextUrlList":{"fullTextUrl":[
+                   {"availability":"Free","availabilityCode":"F","documentStyle":"pdf",
+                    "site":"Europe_PMC",
+                    "url":"https://europepmc.org/articles/PMC4277194?pdf=render"}]}}]}}"#,
+            ))
+            .mount(&server)
+            .await;
+        let (_td, ctx) = ctx_for(&server.address().to_string());
+        let ref_ = Ref::Doi(Doi::parse("10.1098/rspa.2014.0585").expect("doi"));
+        let mut fields = CrossrefFields::default();
+        let mut attempts = Vec::new();
+        let mut on = all_off();
+        on.metadata.europe_pmc = true;
+
+        let resolved =
+            resolve_optional_chain(&ref_, &on, &ctx, false, &mut fields, &mut attempts).await;
+
+        let (source, record) = resolved.expect("a Free PDF entry must resolve, not refuse");
+        assert_eq!(source, "europe-pmc");
+        let row = outcome(&attempts, "europe-pmc");
+        assert!(
+            matches!(row, AttemptOutcome::Resolved),
+            "the row must read as resolved, not as an access refusal; got {row:?}"
+        );
+        assert_eq!(
+            optional_source_oa_url("europe-pmc", &record),
+            Some("https://europepmc.org/articles/PMC4277194?pdf=render"),
+            "the URL the oa-publisher leg fetches must survive the chain"
         );
     }
 

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -554,12 +554,29 @@ fn extract_metadata_authors(meta: &Value) -> Vec<String> {
 // helpers so a single test fixture can drive both crates.
 // ---------------------------------------------------------------------------
 
-/// `DOIGET_CONTACT_EMAIL`, defaulting to the same `doiget@localhost`
-/// the CLI uses (`crates/doiget-cli/src/commands/fetch.rs::OrchestratorConfig`).
+/// Last rung of the contact ladder — the same `doiget@localhost` the CLI
+/// uses (`crates/doiget-cli/src/commands/fetch.rs::OrchestratorConfig`).
 const FALLBACK_CONTACT_EMAIL: &str = "doiget@localhost";
 
-fn contact_email_from_env() -> String {
-    std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| FALLBACK_CONTACT_EMAIL.to_string())
+/// Read an env var, treating blank as unset.
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|s| !s.trim().is_empty())
+}
+
+/// Polite-pool contact address: `DOIGET_CONTACT_EMAIL`, then
+/// `[network] contact_email` in `config.toml`, then `doiget@localhost`
+/// (#504).
+///
+/// Same rung order ADR-0036 / #441 gave `store_root`, per field. The file
+/// is opened only when the env rung is empty, and the result is
+/// deliberately **not** cached: a long-lived `doiget serve`, `config
+/// doctor` and the tests must all see an edit to the file or the
+/// environment, and one small read is free next to the network legs it
+/// precedes.
+fn resolve_contact_email() -> String {
+    env_nonempty("DOIGET_CONTACT_EMAIL")
+        .or_else(|| crate::user_extension::load_or_default().contact_email)
+        .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
 }
 
 fn arxiv_source_from_env() -> ArxivSource {
@@ -613,7 +630,7 @@ async fn metadata_only_doi(
     profile: &CapabilityProfile,
     ctx: &FetchContext,
 ) -> Result<MetadataOnlyOutcome, FetchError> {
-    let contact = contact_email_from_env();
+    let contact = resolve_contact_email();
     let crossref = crossref_source_from_env(&contact);
     match crossref.fetch(ref_, profile, ctx).await {
         Ok(res) => {
@@ -1149,8 +1166,8 @@ async fn fetch_paper_doi(
     store_root: &Utf8Path,
     safekey: &Safekey,
 ) -> Result<FetchPaperOutcome, FetchError> {
-    let contact = contact_email_from_env();
-    let unpaywall_contact = unpaywall_email_from_env(&contact);
+    let contact = resolve_contact_email();
+    let unpaywall_contact = resolve_unpaywall_email(&contact);
     let crossref = crossref_source_from_env(&contact);
     // Issue #120: Crossref is NON-fatal. A transient Crossref failure
     // must not abort the whole DOI fetch when Unpaywall alone can
@@ -2523,8 +2540,25 @@ fn strip_arxiv_version(id: &str) -> &str {
     id
 }
 
-fn unpaywall_email_from_env(fallback_contact: &str) -> String {
-    std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| fallback_contact.to_string())
+/// Unpaywall contact: `DOIGET_UNPAYWALL_EMAIL`, then
+/// `[network] unpaywall_email`, then whatever the caller resolved as the
+/// general contact address (#504).
+///
+/// The more specific field wins at each rung, which is how
+/// `DOIGET_UNPAYWALL_EMAIL` already beat `DOIGET_CONTACT_EMAIL`.
+///
+/// `[network] unpaywall_email` was written by `config init`, called
+/// STRONGLY RECOMMENDED by the template's own prose, and read by nothing
+/// for four releases. The cost is not politeness. The template says so
+/// itself: the automatic arXiv-preprint fallback fires on what Unpaywall
+/// reports, so a throttled answer from the non-polite pool quietly costs
+/// that fallback — and the run still exits 0 with `metadata-only: no OA
+/// PDF available`. A degraded search and a true negative were the same
+/// observable.
+fn resolve_unpaywall_email(fallback_contact: &str) -> String {
+    env_nonempty("DOIGET_UNPAYWALL_EMAIL")
+        .or_else(|| crate::user_extension::load_or_default().unpaywall_email)
+        .unwrap_or_else(|| fallback_contact.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -2633,6 +2667,128 @@ pub fn batch_fetch_plans(
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    // ── #504: the contact ladder, at the end that actually fetches ──────
+
+    /// RAII env guard for the ladder tests.
+    struct LadderEnv {
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl LadderEnv {
+        /// Clear both address vars and point every config-dir rung at `dir`.
+        fn scoped(dir: &str) -> Self {
+            let mut vars = Vec::new();
+            for v in ["DOIGET_CONTACT_EMAIL", "DOIGET_UNPAYWALL_EMAIL"] {
+                vars.push((v, std::env::var_os(v)));
+                std::env::remove_var(v);
+            }
+            for v in ["XDG_CONFIG_HOME", "APPDATA", "HOME", "USERPROFILE"] {
+                vars.push((v, std::env::var_os(v)));
+                std::env::set_var(v, dir);
+            }
+            Self { vars }
+        }
+
+        fn set(&mut self, var: &'static str, value: &str) {
+            self.vars.push((var, std::env::var_os(var)));
+            std::env::set_var(var, value);
+        }
+    }
+
+    impl Drop for LadderEnv {
+        fn drop(&mut self) {
+            for (var, prior) in self.vars.iter().rev() {
+                match prior {
+                    Some(v) => std::env::set_var(var, v),
+                    None => std::env::remove_var(var),
+                }
+            }
+        }
+    }
+
+    /// Write a `config.toml` under `dir` and return `dir`.
+    fn write_config(td: &tempfile::TempDir, body: &str) -> String {
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        std::fs::create_dir_all(dir.join("doiget").as_std_path()).expect("mkdir");
+        std::fs::write(dir.join("doiget").join("config.toml").as_std_path(), body)
+            .expect("write config.toml");
+        dir.to_string()
+    }
+
+    /// #504. The fetch path read the environment and nothing else, so
+    /// `[network] unpaywall_email` — written by `config init`, called
+    /// STRONGLY RECOMMENDED in the template's own prose — did nothing, and
+    /// every request from a machine configured that way went out as
+    /// `doiget@localhost`.
+    ///
+    /// This is the end that matters: `ResolvedConfig` agreeing is what
+    /// `doctor` reports, but this is what the network sees.
+    #[test]
+    #[serial_test::serial]
+    fn resolve_contact_email_reads_the_config_file_rung() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = write_config(
+            &td,
+            "[network]\ncontact_email = \"file@institution.edu\"\nunpaywall_email = \"up@institution.edu\"\n",
+        );
+        let _env = LadderEnv::scoped(&dir);
+
+        let contact = resolve_contact_email();
+        assert_eq!(contact, "file@institution.edu");
+        assert_eq!(resolve_unpaywall_email(&contact), "up@institution.edu");
+    }
+
+    /// The env rung stays on top, per field, and `unpaywall_email` still
+    /// falls back to the resolved contact when only that one is absent.
+    #[test]
+    #[serial_test::serial]
+    fn the_env_rung_outranks_the_file_and_unpaywall_falls_back_to_contact() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = write_config(&td, "[network]\ncontact_email = \"file@institution.edu\"\n");
+        let mut env = LadderEnv::scoped(&dir);
+        env.set("DOIGET_CONTACT_EMAIL", "env@institution.edu");
+
+        let contact = resolve_contact_email();
+        assert_eq!(contact, "env@institution.edu");
+        assert_eq!(
+            resolve_unpaywall_email(&contact),
+            "env@institution.edu",
+            "no unpaywall rung is set, so it must inherit the resolved contact"
+        );
+    }
+
+    /// No file and no env is still the documented fallback — the ladder
+    /// must not have turned a missing config into an error or a blank
+    /// address.
+    #[test]
+    #[serial_test::serial]
+    fn an_absent_config_still_yields_the_documented_fallback() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8")
+            .to_string();
+        let _env = LadderEnv::scoped(&dir);
+
+        let contact = resolve_contact_email();
+        assert_eq!(contact, FALLBACK_CONTACT_EMAIL);
+        assert_eq!(resolve_unpaywall_email(&contact), FALLBACK_CONTACT_EMAIL);
+    }
+
+    /// A blank value is not an address. Both rungs treat it as unset —
+    /// an empty `mailto:` reads to the upstream as no contact at all,
+    /// which is the state the field exists to avoid.
+    #[test]
+    #[serial_test::serial]
+    fn a_blank_value_on_either_rung_is_treated_as_unset() {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = write_config(&td, "[network]\ncontact_email = \"   \"\n");
+        let mut env = LadderEnv::scoped(&dir);
+        env.set("DOIGET_CONTACT_EMAIL", "");
+
+        assert_eq!(resolve_contact_email(), FALLBACK_CONTACT_EMAIL);
+    }
 
     /// A Crossref `message` envelope (the shape `metadata_only_doi` stores
     /// in `MetadataOnlyOutcome.metadata`: `CrossrefSource` returns
@@ -4275,7 +4431,7 @@ async fn resolve_optional_chain(
     // fall-through could never ask the one source that reports more than one
     // location per work. The issue said the accessor was "the only missing
     // piece"; the wiring was missing too.
-    let openalex_contact = contact_email_from_env();
+    let openalex_contact = resolve_contact_email();
     let openalex = match optional_base("DOIGET_OPENALEX_BASE") {
         Some(base) => crate::sources::openalex::OpenalexSource::with_base(base, openalex_contact),
         None => crate::sources::openalex::OpenalexSource::new(openalex_contact),

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -603,27 +603,47 @@ pub fn contact_email_or_placeholder() -> String {
     configured_contact_email().unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
 }
 
+/// The two contact addresses a fetch sends, resolved together.
+///
+/// Named fields rather than a `(String, String)`: a tuple made "which
+/// address goes to which service" a matter of destructuring order, so
+/// reordering one `let` would silently hand Crossref the Unpaywall
+/// identity. That is the defect [`crate::AgreeVar`] exists to close, one
+/// module over, and it is worth closing the same way.
+struct ContactAddresses {
+    /// The polite-pool identity for Crossref, OpenAlex and the rest.
+    crossref: String,
+    /// The `email=` Unpaywall requires. Falls back to `crossref`.
+    unpaywall: String,
+}
+
 /// Both addresses, from a single read of `config.toml`.
 ///
 /// Resolving them independently meant two reads per fetch, and — in a
 /// long-lived `doiget serve` — a window in which an edit landing between
 /// them gave one address from the old file and one from the new. One read,
 /// one generation.
-fn resolve_contact_emails() -> (String, String) {
+fn resolve_contact_emails() -> ContactAddresses {
     let env_contact = env_nonempty("DOIGET_CONTACT_EMAIL");
     let env_unpaywall = env_nonempty("DOIGET_UNPAYWALL_EMAIL");
     // Fully env-configured processes never touch the disk at all.
-    if let (Some(contact), Some(unpaywall)) = (&env_contact, &env_unpaywall) {
-        return (contact.clone(), unpaywall.clone());
+    if let (Some(crossref), Some(unpaywall)) = (&env_contact, &env_unpaywall) {
+        return ContactAddresses {
+            crossref: crossref.clone(),
+            unpaywall: unpaywall.clone(),
+        };
     }
     let file = crate::user_extension::load_or_default();
-    let contact = env_contact
+    let crossref = env_contact
         .or(file.contact_email)
         .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string());
     let unpaywall = env_unpaywall
         .or(file.unpaywall_email)
-        .unwrap_or_else(|| contact.clone());
-    (contact, unpaywall)
+        .unwrap_or_else(|| crossref.clone());
+    ContactAddresses {
+        crossref,
+        unpaywall,
+    }
 }
 
 fn arxiv_source_from_env() -> ArxivSource {
@@ -1265,7 +1285,9 @@ async fn fetch_paper_doi(
     store_root: &Utf8Path,
     safekey: &Safekey,
 ) -> Result<FetchPaperOutcome, FetchError> {
-    let (contact, unpaywall_contact) = resolve_contact_emails();
+    let addresses = resolve_contact_emails();
+    let contact = addresses.crossref;
+    let unpaywall_contact = addresses.unpaywall;
     let crossref = crossref_source_from_env(&contact);
     // Issue #120: Crossref is NON-fatal. A transient Crossref failure
     // must not abort the whole DOI fetch when Unpaywall alone can
@@ -2812,7 +2834,10 @@ mod tests {
         );
         let _env = LadderEnv::scoped(&dir);
 
-        let (contact, unpaywall) = resolve_contact_emails();
+        let ContactAddresses {
+            crossref: contact,
+            unpaywall,
+        } = resolve_contact_emails();
         assert_eq!(contact, "file@institution.edu");
         assert_eq!(unpaywall, "up@institution.edu");
     }
@@ -2827,7 +2852,10 @@ mod tests {
         let mut env = LadderEnv::scoped(&dir);
         env.set("DOIGET_CONTACT_EMAIL", "env@institution.edu");
 
-        let (contact, unpaywall) = resolve_contact_emails();
+        let ContactAddresses {
+            crossref: contact,
+            unpaywall,
+        } = resolve_contact_emails();
         assert_eq!(contact, "env@institution.edu");
         assert_eq!(
             unpaywall, "env@institution.edu",
@@ -2847,7 +2875,10 @@ mod tests {
             .to_string();
         let _env = LadderEnv::scoped(&dir);
 
-        let (contact, unpaywall) = resolve_contact_emails();
+        let ContactAddresses {
+            crossref: contact,
+            unpaywall,
+        } = resolve_contact_emails();
         assert_eq!(contact, FALLBACK_CONTACT_EMAIL);
         assert_eq!(unpaywall, FALLBACK_CONTACT_EMAIL);
     }

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -618,7 +618,7 @@ async fn metadata_only_doi(
     match crossref.fetch(ref_, profile, ctx).await {
         Ok(res) => {
             let metadata = res.metadata_json.unwrap_or(Value::Null);
-            let oa_url = extract_crossref_oa_url(&metadata);
+            let oa_url = extract_crossref_publisher_url(&metadata);
             // Pure resolver — no store write here (see `metadata_only`
             // doc); persistence is `metadata_only_to_store`'s job.
             Ok(MetadataOnlyOutcome {
@@ -671,20 +671,72 @@ async fn metadata_only_doi(
     }
 }
 
-/// Defensively pull a Crossref OA URL out of a `message.link[]` entry.
+/// The publisher full-text URL Crossref reports for a work — **only** if
+/// the entry is a general-purpose one, which in practice it never is.
 ///
-/// The Crossref `Link` model documents `link[].URL` as the OA URL string
-/// when the work has one (see
-/// `<https://api.crossref.org/swagger-ui/index.html>`). Multiple entries
-/// may be present; we return the first non-empty `URL` field
-/// encountered. Returns `None` if the array is missing, empty, or
-/// contains no usable URL string.
-fn extract_crossref_oa_url(msg: &Value) -> Option<String> {
+/// Crossref's `Link` model carries `intended-application` on every entry,
+/// and the values are not interchangeable:
+///
+/// | value | what it is |
+/// |---|---|
+/// | `unspecified` | the general full-text link the publisher advertises |
+/// | `text-mining` | scoped to the publisher's TDM programme |
+/// | `similarity-checking` | scoped to Similarity Check / iThenticate |
+/// | `syndication` | scoped to syndication partners |
+///
+/// **Only `unspecified` is returned.** The other three are links a
+/// publisher scoped to a specific licensed programme; doiget participates
+/// in such programmes through its Tier-3 TDM sources, with a credential
+/// and a recorded per-publisher agreement, and following one of those URLs
+/// outside that path would be taking a licensed route without the licence.
+/// An entry with the field **absent** is also refused rather than assumed
+/// general: ADR-0048 D2's line is documented-by-the-vendor versus
+/// guessed-by-us, and an unlabelled link is a guess.
+///
+/// Among the eligible entries a `content-type` of `application/pdf` is
+/// preferred, since the leg that consumes this wants bytes, not a landing
+/// page.
+///
+/// This used to return the **first** `link[].URL` with no filtering at all,
+/// which meant `MetadataOnlyOutcome.oa_url` — surfaced to callers "for
+/// separate action" — could hand out a Similarity Check URL (#517).
+///
+/// # What this returns in practice: nothing
+///
+/// Measured 2026-08-26 against live Crossref for six DOIs across SIAM,
+/// IEEE, AMS, ACM, Springer Nature and the Royal Society (12 `link[]`
+/// entries), and against the eight captured responses in
+/// `tests/fixtures/real_world/`: **not one entry carried `unspecified`.**
+/// Every one was `text-mining` or `similarity-checking`.
+///
+/// So Crossref `link[]` is a programme-scoped channel, not a general
+/// full-text channel, and this function is a gate rather than a feature.
+/// That measurement is what settled #517 — see ADR-0052. It is kept, and
+/// kept correct, because the alternative is what it replaced: handing a
+/// caller a Similarity Check URL under the name `oa_url`.
+fn extract_crossref_publisher_url(msg: &Value) -> Option<String> {
     let arr = msg.get("link")?.as_array()?;
-    arr.iter()
-        .filter_map(|entry| entry.get("URL").and_then(Value::as_str))
-        .find(|s| !s.is_empty())
-        .map(|s| s.to_string())
+    let eligible = || {
+        arr.iter().filter(|e| {
+            e.get("intended-application")
+                .and_then(Value::as_str)
+                .is_some_and(|a| a.eq_ignore_ascii_case("unspecified"))
+        })
+    };
+    let url_of = |e: &Value| {
+        e.get("URL")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    eligible()
+        .find(|e| {
+            e.get("content-type")
+                .and_then(Value::as_str)
+                .is_some_and(|c| c.eq_ignore_ascii_case("application/pdf"))
+        })
+        .and_then(url_of)
+        .or_else(|| eligible().find_map(url_of))
 }
 
 /// Defensively pull Unpaywall's preferred OA URL
@@ -2791,35 +2843,91 @@ mod tests {
     }
 
     #[test]
-    fn extract_crossref_oa_url_finds_first_url() {
+    fn extract_crossref_publisher_url_takes_a_general_entry() {
         let msg = serde_json::json!({
             "link": [
-                {"URL": "https://example.org/free.pdf"},
-                {"URL": "https://example.org/alt.pdf"}
+                {"URL": "https://example.org/free.pdf",
+                 "intended-application": "unspecified"},
+                {"URL": "https://example.org/alt.pdf",
+                 "intended-application": "unspecified"}
             ]
         });
         assert_eq!(
-            extract_crossref_oa_url(&msg),
+            extract_crossref_publisher_url(&msg),
             Some("https://example.org/free.pdf".to_string())
         );
     }
 
     #[test]
-    fn extract_crossref_oa_url_returns_none_when_absent() {
-        let msg = serde_json::json!({});
-        assert!(extract_crossref_oa_url(&msg).is_none());
+    fn extract_crossref_publisher_url_returns_none_when_absent() {
+        assert!(extract_crossref_publisher_url(&serde_json::json!({})).is_none());
     }
 
     #[test]
-    fn extract_crossref_oa_url_skips_empty_url_strings() {
+    fn extract_crossref_publisher_url_skips_empty_url_strings() {
         let msg = serde_json::json!({
             "link": [
-                {"URL": ""},
-                {"URL": "https://example.org/real.pdf"}
+                {"URL": "", "intended-application": "unspecified"},
+                {"URL": "https://example.org/real.pdf",
+                 "intended-application": "unspecified"}
             ]
         });
         assert_eq!(
-            extract_crossref_oa_url(&msg),
+            extract_crossref_publisher_url(&msg),
+            Some("https://example.org/real.pdf".to_string())
+        );
+    }
+
+    /// #517: the three scoped `intended-application` values are links a
+    /// publisher pointed at a specific licensed programme. doiget joins
+    /// such programmes through its Tier-3 TDM sources, with a credential
+    /// and a recorded agreement; following one of these URLs outside that
+    /// path takes a licensed route without the licence.
+    ///
+    /// This is not hypothetical for the metadata-only path either: before
+    /// #517 the extractor returned the FIRST entry unfiltered, so
+    /// `MetadataOnlyOutcome.oa_url` — surfaced to callers "for separate
+    /// action" — could hand out a Similarity Check URL.
+    #[test]
+    fn extract_crossref_publisher_url_refuses_programme_scoped_links() {
+        for scoped in ["text-mining", "similarity-checking", "syndication"] {
+            let msg = serde_json::json!({
+                "link": [{"URL": "https://example.org/scoped.pdf",
+                          "intended-application": scoped}]
+            });
+            assert_eq!(
+                extract_crossref_publisher_url(&msg),
+                None,
+                "{scoped} is scoped to a programme doiget is not in on this path"
+            );
+        }
+    }
+
+    /// ADR-0048 D2: the line is documented-by-the-vendor versus
+    /// guessed-by-us. An entry with no `intended-application` is
+    /// unlabelled, and treating it as general-purpose would be the guess.
+    #[test]
+    fn extract_crossref_publisher_url_refuses_an_unlabelled_entry() {
+        let msg = serde_json::json!({"link": [{"URL": "https://example.org/x.pdf"}]});
+        assert_eq!(extract_crossref_publisher_url(&msg), None);
+    }
+
+    /// The leg that consumes this wants bytes, so a PDF entry wins over an
+    /// equally eligible landing page.
+    #[test]
+    fn extract_crossref_publisher_url_prefers_a_pdf_content_type() {
+        let msg = serde_json::json!({
+            "link": [
+                {"URL": "https://example.org/landing",
+                 "content-type": "text/html",
+                 "intended-application": "unspecified"},
+                {"URL": "https://example.org/real.pdf",
+                 "content-type": "application/pdf",
+                 "intended-application": "unspecified"}
+            ]
+        });
+        assert_eq!(
+            extract_crossref_publisher_url(&msg),
             Some("https://example.org/real.pdf".to_string())
         );
     }

--- a/crates/doiget-core/src/sources/europepmc.rs
+++ b/crates/doiget-core/src/sources/europepmc.rs
@@ -13,14 +13,30 @@
 //! `CapabilityProfile::from_env` from `DOIGET_ENABLE_EUROPE_PMC`, which
 //! is **off by default** (ADR-0040).
 //!
-//! ## OA subset only
+//! ## Retrievable, not "in the OA subset"
 //!
-//! Europe PMC indexes far more than it can give you: a record can be
-//! `inEPMC = "Y"` — present in the archive — while `isOpenAccess = "N"`,
-//! meaning the full text sits behind the publisher subscription. Only
-//! `isOpenAccess = "Y"` is accepted, and anything else is an explicit
-//! refusal rather than a hit, exactly as #415 requires. `inEPMC` is
-//! deliberately **not** the gate; it answers a different question.
+//! Europe PMC indexes far more than it can give you, and it reports the
+//! difference in three places that do not mean the same thing:
+//!
+//! * `inEPMC = "Y"` — the record is in the archive. It says nothing
+//!   about whether the full text is readable, so it is **not** the gate
+//!   (#415).
+//! * `isOpenAccess = "Y"` — the record is in the bulk OA subset. That is
+//!   a licensing / bulk-rights statement, and it is **reported, not a
+//!   veto** (#503).
+//! * `fullTextUrlList` — per-entry availability. An entry with
+//!   `documentStyle = "pdf"` and `availabilityCode` `F` (Free) or `OA`
+//!   is a specific claim that *this article's* PDF can be retrieved.
+//!
+//! The third is strictly weaker than the second, and it is the one
+//! doiget can act on, so it is the gate. `10.1098/rspa.2014.0585`
+//! (PMC4277194) is the record that motivated the change: `isOpenAccess
+//! = N`, and a 670 kB Free PDF sitting at `europepmc.org` — a host
+//! already on the `oa-publisher` allowlist. The old gate discarded it
+//! one line before `open_access_pdf_url` would have found it.
+//!
+//! A record that advertises no `F`/`OA` PDF entry is an explicit refusal
+//! rather than a hit, exactly as #415 requires.
 //!
 //! ## Retrieval goes through the existing OA chain, not this source
 //!
@@ -161,12 +177,20 @@ impl Source for EuropePmcSource {
             hint: format!("europepmc has no record for {}", doi.as_str()),
         })?;
 
-        // #415: OA subset only, as an explicit refusal rather than a retry.
-        if !is_open_access(record) {
+        // #503: refuse on "advertises nothing retrievable", not on
+        // "outside the OA subset". `isOpenAccess` is a bulk-rights
+        // statement; `fullTextUrlList` reports single-article
+        // retrievability per entry, and the second can be true while the
+        // first is false. Gating on the subset threw away Free PDFs at
+        // `europepmc.org` — already an `oa-publisher` allowlist host —
+        // one line before the code written to find them. The flags stay
+        // in the refusal because they are what a reader checks next.
+        if open_access_pdf_url(record).is_none() {
             return Err(FetchError::SourceSchema {
                 hint: format!(
-                    "europepmc record is indexed but not open access \
-                     (isOpenAccess = {}, inEPMC = {})",
+                    "europepmc record advertises no retrievable PDF: no \
+                     fullTextUrlList entry has documentStyle = pdf with \
+                     availabilityCode F or OA (isOpenAccess = {}, inEPMC = {})",
                     flag(record, "isOpenAccess").unwrap_or("absent"),
                     flag(record, "inEPMC").unwrap_or("absent"),
                 ),
@@ -212,9 +236,14 @@ fn flag<'a>(record: &'a serde_json::Value, name: &str) -> Option<&'a str> {
 /// True only for `isOpenAccess == "Y"`.
 ///
 /// Deliberately **not** `inEPMC`: a record can be in the archive while its
-/// full text is subscription-only, so gating on presence rather than
-/// openness would return records doiget cannot retrieve. Absent counts as
-/// not open.
+/// full text is subscription-only, so presence is not openness. Absent
+/// counts as not open.
+///
+/// Since #503 this is **reported, not a veto**: `isOpenAccess` describes
+/// membership of the bulk OA subset, and `fetch` gates on the strictly
+/// weaker per-entry claim that [`open_access_pdf_url`] reads. The value
+/// still travels to the caller inside `metadata_json`, and still appears
+/// in the refusal message when nothing retrievable is advertised.
 #[must_use]
 pub fn is_open_access(record: &serde_json::Value) -> bool {
     flag(record, "isOpenAccess") == Some("Y")
@@ -322,6 +351,33 @@ mod tests {
         ]}
     }"#;
 
+    /// #503, observed live on 10.1098/rspa.2014.0585 (PMC4277194): the
+    /// record is OUTSIDE the bulk OA subset (`isOpenAccess = N`) and
+    /// still advertises a Free PDF at `europepmc.org`. Fetching that URL
+    /// by hand returned 670 kB of `application/pdf`.
+    const SAMPLE_CLOSED_SUBSET_WITH_FREE_PDF: &str = r#"{
+        "hitCount": 1,
+        "resultList": {"result": [
+            {
+                "id": "PMC4277194",
+                "source": "PMC",
+                "doi": "10.1098/rspa.2014.0585",
+                "title": "Continuous analogues of matrix factorizations.",
+                "pubYear": "2015",
+                "isOpenAccess": "N",
+                "inEPMC": "Y",
+                "fullTextUrlList": {"fullTextUrl": [
+                    {"availability": "Free", "availabilityCode": "F",
+                     "documentStyle": "pdf", "site": "Europe_PMC",
+                     "url": "https://europepmc.org/articles/PMC4277194?pdf=render"},
+                    {"availability": "Subscription required", "availabilityCode": "S",
+                     "documentStyle": "doi", "site": "DOI",
+                     "url": "https://doi.org/10.1098/rspa.2014.0585"}
+                ]}
+            }
+        ]}
+    }"#;
+
     const SAMPLE_EMPTY: &str = r#"{"hitCount": 0, "resultList": {"result": []}}"#;
 
     fn build_test_context(wiremock_host: &str) -> (TempDir, FetchContext) {
@@ -409,10 +465,15 @@ mod tests {
 
     /// The trap this gate exists for. `inEPMC = Y` means the record is in
     /// the archive; it says nothing about whether the full text is
-    /// readable. Gating on presence instead of openness would hand back
-    /// records doiget cannot retrieve.
+    /// readable. Gating on presence would hand back records doiget cannot
+    /// retrieve.
+    ///
+    /// Since #503 the refusal is for the narrower reason — this fixture
+    /// advertises no `fullTextUrlList` at all — and the message must say
+    /// so, or it cannot be told apart from
+    /// `closed_subset_record_with_a_free_pdf_is_accepted` below.
     #[tokio::test]
-    async fn in_epmc_but_not_open_access_is_refused() {
+    async fn in_epmc_with_no_retrievable_pdf_is_refused() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/europepmc/webservices/rest/search"))
@@ -435,6 +496,50 @@ mod tests {
         assert!(
             msg.contains("isOpenAccess = N") && msg.contains("inEPMC = Y"),
             "the refusal must say WHY, naming both flags; got: {msg}"
+        );
+        assert!(
+            msg.contains("no retrievable PDF"),
+            "the refusal must be about retrievability, not subset membership \
+             — the two are distinguishable and #503 was the case where they \
+             differ; got: {msg}"
+        );
+    }
+
+    /// #503. `isOpenAccess = N` is a statement about the bulk OA subset,
+    /// and the record still carries a Free PDF at an already-allowlisted
+    /// host. Refusing here discarded a copy doiget could retrieve, one
+    /// line before `open_access_pdf_url` — which already accepted `F` —
+    /// would have found it.
+    #[tokio::test]
+    async fn closed_subset_record_with_a_free_pdf_is_accepted() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/europepmc/webservices/rest/search"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(SAMPLE_CLOSED_SUBSET_WITH_FREE_PDF),
+            )
+            .mount(&server)
+            .await;
+
+        let (_td, ctx) = build_test_context(&server.address().to_string());
+        let src = EuropePmcSource::with_base(Url::parse(&server.uri()).expect("base"));
+        let ref_ = Ref::Doi(Doi::parse("10.1098/rspa.2014.0585").expect("doi"));
+
+        let got = src
+            .fetch(&ref_, &profile(true), &ctx)
+            .await
+            .expect("a Free PDF entry is retrievable even outside the OA subset");
+        assert!(got.pdf_bytes.is_none(), "metadata-only contract");
+        let rec = got.metadata_json.expect("record");
+        assert_eq!(
+            open_access_pdf_url(&rec),
+            Some("https://europepmc.org/articles/PMC4277194?pdf=render"),
+            "the URL the oa-publisher leg will fetch must survive to the caller"
+        );
+        assert!(
+            !is_open_access(&rec),
+            "the subset flag is reported, not corrected — a caller that \
+             cares can still read it"
         );
     }
 

--- a/crates/doiget-core/src/user_extension.rs
+++ b/crates/doiget-core/src/user_extension.rs
@@ -317,6 +317,14 @@ struct RawNetwork {
     /// open-access registry allowlist (issue #405). See [`oa_registry_hosts`].
     #[serde(default)]
     trust_oa_registries: bool,
+    /// `[network] contact_email` — the polite-pool contact address (#504).
+    #[serde(default)]
+    contact_email: Option<String>,
+    /// `[network] unpaywall_email` — written by `config init` since 0.7 and
+    /// parsed by nobody until #504, so every fetch on a machine configured
+    /// from the template went out as `doiget@localhost`.
+    #[serde(default)]
+    unpaywall_email: Option<String>,
     #[serde(flatten)]
     _other: serde::de::IgnoredAny,
 }
@@ -357,6 +365,13 @@ pub struct UserExtensionConfig {
     /// The CLI and MCP resolvers own that step, and both place this rung
     /// below `DOIGET_STORE_ROOT` and above the cwd default (ADR-0036).
     pub store_root: Option<String>,
+    /// `[network] contact_email`, trimmed, when present and non-empty
+    /// (#504). Rung below `DOIGET_CONTACT_EMAIL`.
+    pub contact_email: Option<String>,
+    /// `[network] unpaywall_email`, trimmed, when present and non-empty
+    /// (#504). Rung below `DOIGET_UNPAYWALL_EMAIL`, itself above
+    /// [`Self::contact_email`].
+    pub unpaywall_email: Option<String>,
 }
 
 /// Returns the built-in curated set of academic institution host patterns.
@@ -465,6 +480,13 @@ fn parse_str(
     let raw_net = raw.network.unwrap_or_default();
     let trust_academic_repos = raw_net.trust_academic_repos;
     let trust_oa_registries = raw_net.trust_oa_registries;
+    // Same "blank means unset" rule as `[store] root` below: an empty
+    // address would be sent as an empty `mailto:` and read to the upstream
+    // as no contact at all, which is the state the field exists to avoid.
+    let trim_nonempty =
+        |v: Option<String>| v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    let contact_email = trim_nonempty(raw_net.contact_email);
+    let unpaywall_email = trim_nonempty(raw_net.unpaywall_email);
     let raw_hosts = raw_net.additional_hosts;
 
     // Two-phase: collect ALL invalid patterns rather than failing on
@@ -504,7 +526,121 @@ fn parse_str(
         trust_academic_repos,
         trust_oa_registries,
         store_root,
+        contact_email,
+        unpaywall_email,
     })
+}
+
+/// Why the config directory could not be resolved.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigDirError {
+    /// An environment variable is set to a non-UTF-8 value.
+    ///
+    /// An error rather than a fall-through: silently trying the next rung
+    /// would resolve a *different* file from the one the user configured,
+    /// and report success.
+    #[error("{key} is not valid UTF-8")]
+    NotUnicode {
+        /// The offending variable.
+        key: &'static str,
+    },
+    /// None of `XDG_CONFIG_HOME`, `APPDATA`, `HOME` or `USERPROFILE` is set.
+    #[error("neither HOME nor USERPROFILE is set")]
+    NoHome,
+}
+
+/// Read an env var, treating blank as unset and non-UTF-8 as an error.
+fn env_utf8(key: &'static str) -> Result<Option<String>, ConfigDirError> {
+    match std::env::var(key) {
+        Ok(s) if s.is_empty() => Ok(None),
+        Ok(s) => Ok(Some(s)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(ConfigDirError::NotUnicode { key }),
+    }
+}
+
+/// Config-directory resolution: `XDG_CONFIG_HOME`, then `APPDATA`
+/// (Windows), then `$HOME/.config`.
+///
+/// **The single source of truth.** This existed as two hand-maintained
+/// copies — `doiget-cli::commands::fetch::config_dir_utf8` and
+/// `doiget-mcp::config_dir_utf8` — whose own doc comment warned that
+/// divergence "would silently desync the user-extension allowlist
+/// surfaces". They had already diverged: the CLI copy accepted
+/// `XDG_CONFIG_HOME=""` and resolved a *relative* `doiget/config.toml`
+/// under the cwd, while the MCP copy treated blank as unset. Blank-is-
+/// unset is the answer kept here, because a relative config path is a
+/// silent wrong answer of exactly the #441 / #504 kind.
+///
+/// It lives in `doiget-core` because the fetch path needs it: with the
+/// resolver one crate up, `orchestrator` could not read `config.toml` at
+/// all, so every file-based setting had to be re-implemented in the CLI
+/// or go unread. `[network] unpaywall_email` went unread for four
+/// releases for that reason (#504).
+///
+/// No `dirs` dependency — every new dep adds cargo-vet exemption churn,
+/// and `expand_store_root` below already reads `HOME` directly.
+///
+/// # Errors
+///
+/// [`ConfigDirError::NotUnicode`] if a consulted variable is set to a
+/// non-UTF-8 value; [`ConfigDirError::NoHome`] if none is set.
+pub fn config_dir() -> Result<Utf8PathBuf, ConfigDirError> {
+    if let Some(s) = env_utf8("XDG_CONFIG_HOME")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    if let Some(s) = env_utf8("APPDATA")? {
+        return Ok(Utf8PathBuf::from(s));
+    }
+    if let Some(s) = env_utf8("HOME")? {
+        return Ok(Utf8PathBuf::from(s).join(".config"));
+    }
+    if let Some(s) = env_utf8("USERPROFILE")? {
+        return Ok(Utf8PathBuf::from(s).join(".config"));
+    }
+    Err(ConfigDirError::NoHome)
+}
+
+/// `<config_dir>/doiget/config.toml` — the one file every reader means.
+///
+/// # Errors
+///
+/// As [`config_dir`].
+pub fn config_path() -> Result<Utf8PathBuf, ConfigDirError> {
+    Ok(config_dir()?.join("doiget").join("config.toml"))
+}
+
+/// The `config.toml` settings, or defaults when it is missing or
+/// unreadable.
+///
+/// Never fails: a caller on the fetch path wants the setting or the
+/// default, and one bad line in a config file must not take a fetch down.
+/// A read or parse failure is logged at `warn` — not swallowed — for the
+/// reason `store_root_from_config` records: TOML fails the whole document,
+/// so a typo anywhere makes every file rung disappear at once, and the
+/// resulting behaviour is indistinguishable from "nothing was configured".
+#[must_use]
+pub fn load_or_default() -> UserExtensionConfig {
+    let path = match config_path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(error = %e, "no config directory; config.toml not read");
+            return UserExtensionConfig::default();
+        }
+    };
+    match load(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                path = %path,
+                error = %e,
+                "config.toml could not be read; its settings are ignored and defaults used \
+                 instead. Run `doiget config doctor` to see what is in effect."
+            );
+            UserExtensionConfig::default()
+        }
+    }
 }
 
 /// Turn a raw `[store] root` value into a path, expanding a leading `~`.

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -1340,7 +1340,13 @@ impl Server {
         };
         // Omit `mailto` when no contact email is configured (never a
         // placeholder); the empty string is skipped downstream.
-        let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+        //
+        // Goes through the core ladder so `[network] contact_email` in
+        // `config.toml` counts here too — reading the env var directly meant
+        // #504's fix stopped at `doiget fetch` and never reached the MCP
+        // tools, which is the interface doiget leads with.
+        let contact_email =
+            doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
         let ctx = match build_fetch_context() {
             Ok(c) => c,
@@ -1714,7 +1720,8 @@ impl Server {
                 )));
             }
         };
-        let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+        let contact_email =
+            doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
         let ctx = match build_fetch_context() {
             Ok(c) => c,
@@ -2010,8 +2017,7 @@ impl Server {
                 }
             };
 
-            let contact_email = std::env::var("DOIGET_CONTACT_EMAIL")
-                .unwrap_or_else(|_| "doiget@localhost".to_string());
+            let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
             let source = if let Ok(base) = std::env::var("DOIGET_OPENALEX_BASE") {
                 if let Ok(url) = url::Url::parse(&base) {
                     doiget_core::sources::openalex::OpenalexSource::with_base(url, contact_email)
@@ -3746,8 +3752,7 @@ fn build_fetch_context() -> anyhow::Result<FetchContext> {
 ///
 /// Returns `Err(String)` — callers convert it into a structured tool error.
 fn crossref_source_from_env() -> Result<CrossrefSource, String> {
-    let contact_email =
-        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
     match std::env::var("DOIGET_CROSSREF_BASE").ok() {
         Some(base_str) => {
             let base = url::Url::parse(&base_str)

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -3906,20 +3906,10 @@ fn build_http_client_for_fetch() -> anyhow::Result<HttpClient> {
 /// case the caller downgrades to "user extension disabled" rather
 /// than failing the whole request.
 fn config_dir_utf8() -> anyhow::Result<Utf8PathBuf> {
-    if let Ok(s) = std::env::var("XDG_CONFIG_HOME") {
-        if !s.is_empty() {
-            return Ok(Utf8PathBuf::from(s));
-        }
-    }
-    if let Ok(s) = std::env::var("APPDATA") {
-        if !s.is_empty() {
-            return Ok(Utf8PathBuf::from(s));
-        }
-    }
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_err(|_| anyhow::anyhow!("neither HOME nor USERPROFILE is set"))?;
-    Ok(Utf8PathBuf::from(home).join(".config"))
+    // Delegated to `doiget_core::user_extension::config_dir` (#504): this
+    // was the second of three hand-maintained copies, and the CLI's
+    // already disagreed with it about a blank `XDG_CONFIG_HOME`.
+    Ok(doiget_core::user_extension::config_dir()?)
 }
 
 /// Resolve the provenance log path. Mirrors the CLI's precedence

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -4735,6 +4735,45 @@ mod tests {
         }
     }
 
+    /// #516: the MCP half of the Tier-2 transport gate.
+    ///
+    /// The CLI builder had this extend behind `#[cfg(feature =
+    /// "citation")]` while the sources it serves are gated on
+    /// `metadata`, so a `metadata`-only build reached them and died at
+    /// `UnknownSource`. `build_http_client_for_fetch` registers
+    /// `tier_2_allowlist()` unconditionally and is therefore correct
+    /// today — this pins that, because "correct today in one of two
+    /// hand-maintained twins" is exactly the state #454 was filed from.
+    #[test]
+    #[serial_test::serial]
+    fn the_production_client_registers_every_tier_2_source_key() {
+        // Any base override takes the test-mode branch, which registers
+        // whatever it is handed and would prove nothing.
+        let _guards = [
+            EnvGuard::unset("DOIGET_ARXIV_BASE"),
+            EnvGuard::unset("DOIGET_ARXIV_SRC_BASE"),
+            EnvGuard::unset("DOIGET_CROSSREF_BASE"),
+            EnvGuard::unset("DOIGET_UNPAYWALL_BASE"),
+            EnvGuard::unset("DOIGET_OA_PUBLISHER_BASE"),
+            EnvGuard::unset("DOIGET_OPENALEX_BASE"),
+            EnvGuard::unset("DOIGET_AR5IV_BASE"),
+        ];
+
+        let client = build_http_client_for_fetch().expect("production client builds");
+
+        let keys: Vec<String> = tier_2_allowlist()
+            .iter()
+            .map(|a| a.source.clone())
+            .collect();
+        assert!(!keys.is_empty(), "the guard must have checked something");
+        for key in keys {
+            assert!(
+                client.source_allowlist(&key).is_some(),
+                "the production MCP client has no allowlist for `{key}`; the \n                 optional chain reaches this source and the fetch would \n                 die at UnknownSource (#516)"
+            );
+        }
+    }
+
     /// Set XDG_CONFIG_HOME / APPDATA / HOME / USERPROFILE so
     /// `config_dir_utf8()` resolves to the supplied directory on
     /// every supported test host. Returns guards that restore prior

--- a/crates/doiget-mcp/tests/initialize_handshake.rs
+++ b/crates/doiget-mcp/tests/initialize_handshake.rs
@@ -561,7 +561,7 @@ async fn doiget_metadata_only_doi_crossref_happy_path_returns_metadata_envelope(
     Mock::given(method("GET"))
         .and(path("/works/10.1234/example"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            r#"{"status":"ok","message":{"title":["Example Paper"],"link":[{"URL":"https://example.org/oa.pdf"}]}}"#,
+            r#"{"status":"ok","message":{"title":["Example Paper"],"link":[{"URL":"https://example.org/oa.pdf","content-type":"application/pdf","intended-application":"unspecified"}]}}"#,
         ))
         .mount(&server)
         .await;
@@ -614,8 +614,13 @@ async fn doiget_metadata_only_doi_crossref_happy_path_returns_metadata_envelope(
     // Crossref does not surface a license directly (Phase 1; future
     // slices will chain Unpaywall for license enrichment).
     assert_eq!(structured["license"], serde_json::Value::Null);
-    // OA URL discovered via `message.link[]`. Surfaced but never
-    // followed — the test does not mount a mock for it.
+    // Publisher URL discovered via `message.link[]`. The
+    // `intended-application: unspecified` marker is load-bearing since
+    // #517: an entry scoped to Similarity Check / syndication / TDM, or
+    // one with the field absent, is refused rather than surfaced.
+    //
+    // `metadata_only` still never follows it — the test mounts no mock
+    // for the URL, and a request would fail the run.
     assert_eq!(
         structured["oa_url"],
         serde_json::json!("https://example.org/oa.pdf")

--- a/crates/doiget-mcp/tests/resolve_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_paper_e2e.rs
@@ -127,9 +127,11 @@ const SAMPLE_ATOM_FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
   </entry>
 </feed>"#;
 
-/// Synthetic Crossref `message` payload. Carries an OA URL in
-/// `message.link[]` so `extract_crossref_oa_url` returns `Some(...)`.
-const SAMPLE_CROSSREF_RESPONSE: &str = r#"{"status":"ok","message":{"title":["Example Paper"],"link":[{"URL":"https://example.org/oa.pdf"}]}}"#;
+/// Synthetic Crossref `message` payload. Carries a general-purpose
+/// (`intended-application: unspecified`) link in `message.link[]` so
+/// `extract_crossref_publisher_url` returns `Some(...)`. The field is
+/// load-bearing since #517 — an unlabelled entry is refused.
+const SAMPLE_CROSSREF_RESPONSE: &str = r#"{"status":"ok","message":{"title":["Example Paper"],"link":[{"URL":"https://example.org/oa.pdf","content-type":"application/pdf","intended-application":"unspecified"}]}}"#;
 
 // ---------------------------------------------------------------------------
 // 1. invalid ref -> INVALID_REF

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -180,7 +180,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
 | `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
-| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). OA subset only: gated on `isOpenAccess`, **not** `inEPMC` — a record can be in the archive while its full text is subscription-only (#415). |
+| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). Gated on the record advertising a retrievable PDF — a `fullTextUrlList` entry with `documentStyle = pdf` and `availabilityCode` `F` or `OA` (#503) — **not** on `inEPMC` (presence is not openness, #415) and **not** on `isOpenAccess` (bulk-subset membership, which is reported rather than a veto). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -118,10 +118,10 @@ impl CapabilityProfile {
                 core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
                 europe_pmc:      env::var("DOIGET_ENABLE_EUROPE_PMC").is_ok(),
             },
-            tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
-            tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
-            tdm_springer: read_tdm_grant("DOIGET_AGREE_TDM_SPRINGER", "DOIGET_KEY_SPRINGER")?,
-            tdm_ieee:     read_tdm_grant("DOIGET_AGREE_TDM_IEEE",     "DOIGET_KEY_IEEE")?,
+            tdm_elsevier: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"), KeyVar::new("DOIGET_KEY_ELSEVIER"))?,
+            tdm_aps:      read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_APS"),      KeyVar::new("DOIGET_KEY_APS"))?,
+            tdm_springer: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_SPRINGER"), KeyVar::new("DOIGET_KEY_SPRINGER"))?,
+            tdm_ieee:     read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_IEEE"),     KeyVar::new("DOIGET_KEY_IEEE"))?,
             rate_limits:  RateLimits::HARD_CODED,
         })
     }
@@ -129,9 +129,15 @@ impl CapabilityProfile {
 
 // `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
 // BELOW the env var (#509, ADR-0050). The agreement has no file rung.
-fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+//
+// `AgreeVar`/`KeyVar` are newtypes over `&'static str` with private fields:
+// two adjacent `&str` parameters could be transposed at a call site and the
+// build would then treat the KEY as the agreement signal. The real signature
+// also takes `feature: &str` and `feature_enabled: bool`, elided here.
+fn read_tdm_grant(agree: AgreeVar, key: KeyVar, file_key: Option<&str>)
     -> Result<Option<TdmGrant>, CapabilityError>
 {
+    let (agree_var, key_var) = (agree.0, key.0);
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
     let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -127,9 +127,13 @@ impl CapabilityProfile {
     }
 }
 
-fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, CapabilityError> {
+// `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
+// BELOW the env var (#509, ADR-0050). The agreement has no file rung.
+fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+    -> Result<Option<TdmGrant>, CapabilityError>
+{
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
-    let key    = env::var(key_var).ok();
+    let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {
         (true, Some(k)) => Ok(Some(TdmGrant {
             // `secrecy` 0.10: `SecretString::from(String)` replaces the
@@ -152,6 +156,15 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 ```
 
 ### Three resolution rules
+
+The **key** may come from `DOIGET_KEY_<PUBLISHER>` or from
+`[tdm.<publisher>] api_key` in `credentials.toml`, env first
+([`CONFIG.md`](CONFIG.md) §6). The **agreement** has no file rung: it is
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` in the environment or it does not exist, so
+that it is an act taken in the session that runs the fetch rather than a
+boolean written once and forgotten ([`LEGAL.md`](LEGAL.md) §6a.2, ADR-0050).
+The three rules below are unchanged by that — a key from the file still needs
+the agreement, so rule 3 now also fires for a file-supplied key.
 
 1. **`agree=1` + key present** → `Some(TdmGrant)`. The source is enabled this session.
 2. **`agree=1` but key missing** → `Err(AgreedButNoKey)`. Startup fails; user has agreed

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,7 +22,8 @@ A value set higher in the chain overrides any value set lower.
 | `log.path` | POSIX: `$HOME/.config/doiget/access.log`. Windows: `%APPDATA%\doiget\access.log`. |
 | `log.retention_days` | `90` |
 | `network.user_agent` | `doiget/<version> (+https://github.com/QAtlasHub/doiget)` |
-| `network.unpaywall_email` | unset; if unset, Unpaywall calls go to non-polite pool |
+| `network.contact_email` | unset; if unset, every outbound request identifies as `doiget@localhost` and goes to the non-polite pool |
+| `network.unpaywall_email` | unset; falls back to `network.contact_email` |
 | `network.connect_timeout_sec` | `10` |
 | `network.read_timeout_sec` | `60` |
 | `network.total_timeout_sec` | `300` |
@@ -62,6 +63,12 @@ retention_days = 90
 
 [network]
 user_agent = "doiget/0.1.0 (+https://github.com/QAtlasHub/doiget; user=alice@example.org)"
+# Polite-pool contact for every outbound request. Overridden by
+# DOIGET_CONTACT_EMAIL, one rung above. This is what `doiget config doctor`
+# checks, and `doctor` names which rung answered.
+contact_email = "alice@example.org"
+# Only if Unpaywall should see a different address. Overridden by
+# DOIGET_UNPAYWALL_EMAIL; falls back to contact_email above.
 unpaywall_email = "alice@example.org"
 connect_timeout_sec = 10
 read_timeout_sec = 60
@@ -196,18 +203,29 @@ All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` 
 | `DOIGET_LOG_PATH` | `log.path` |
 | `DOIGET_LOG_RETENTION_DAYS` | `log.retention_days` |
 | `DOIGET_USER_AGENT` | `network.user_agent` |
-| `DOIGET_CONTACT_EMAIL` | Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
+| `DOIGET_CONTACT_EMAIL` | `network.contact_email`. Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
 | `DOIGET_UNPAYWALL_EMAIL` | `network.unpaywall_email` |
 | `DOIGET_MODE` | `output.mode` |
 | `NO_COLOR` | Forces `output.color = "never"` (xdg standard). |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | reqwest honors these (system standard). |
 
-With neither email set, doiget still queries Unpaywall — it sends the placeholder
+Both addresses are resolved **per field**, across the §1 chain: the env var, then
+`[network]` in `config.toml`, then the next-broader default. `DOIGET_UNPAYWALL_EMAIL` →
+`[network] unpaywall_email` → whatever `contact_email` resolved to → `doiget@localhost`.
+The more specific field wins at each rung.
+
+With neither set, doiget still queries Unpaywall — it sends the placeholder
 `doiget@localhost`, which lands in the non-polite pool and may be rate-limited or refused.
-Setting `DOIGET_CONTACT_EMAIL` is therefore worth doing before any batch run, and it is what
-`doiget config doctor` flags. It also makes the automatic arXiv preprint fallback reliable:
-when a DOI's OA PDF is blocked, doiget retries via the arXiv preprint that Unpaywall named,
-so a throttled Unpaywall response costs you that fallback too.
+Setting one is worth doing before any batch run, and it is what `doiget config doctor`
+flags. It also makes the automatic arXiv preprint fallback reliable: when a DOI's OA PDF is
+blocked, doiget retries via the arXiv preprint that Unpaywall named, so a throttled
+Unpaywall response costs you that fallback too — and the run still exits 0 saying
+`no OA PDF available`, which is why a degraded search and a true negative looked the same.
+
+`doiget config doctor` reports **which rung answered**, e.g.
+`[ ok ] contact_email set (from: [network] contact_email in config.toml)`. Before #504 the
+file rung did not exist for either address, so a `config.toml` written from the `config init`
+template was inert while `doctor` reported the store root correctly from the same file.
 
 CapabilityProfile-related env vars are documented in [`CAPABILITY.md`](CAPABILITY.md).
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -256,7 +256,8 @@ environment-only and cannot be given here — see below, and ADR-0050.
 
 ```toml
 # ~/.config/doiget/credentials.toml — optional.
-# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
+# Permissions SHOULD be 0600 on POSIX. `doiget config doctor` fails on a
+# group- or world-readable file, and the fetch path logs a warning.
 
 [tdm.elsevier]
 api_key = "..."
@@ -301,6 +302,14 @@ including the `0600` warning, and no code path opened it; a user who followed
 this section wrote their key into a file doiget ignored and then reported the
 source unavailable for want of a key. Both the reader and the permission
 warning exist as of 0.8.11.
+
+**Where the problems show up.** Run `doiget config doctor`. A file that cannot
+be read or does not parse fails a check naming the position — never quoting the
+line, because the line that fails to parse is usually the one holding the key. A
+file that parses fails a check for each thing worth acting on: a group- or
+world-readable mode, an `api_key` present but blank, an `agreed` that grants
+nothing, a `[tdm.<publisher>]` naming a publisher doiget does not know. None of
+these is fatal to a fetch, and none of them is silent.
 
 ## 6.1 Institutional networks: what works and what does not
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -251,21 +251,21 @@ mode resolution above.
 
 ## 6. Credentials file
 
+This file carries **API keys only**. The per-publisher agreement is
+environment-only and cannot be given here — see below, and ADR-0050.
+
 ```toml
-# ~/.config/doiget/credentials.toml — optional, alternative to env vars
-# Permissions MUST be 0600 on POSIX; doiget warns at startup otherwise.
+# ~/.config/doiget/credentials.toml — optional.
+# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
 
 [tdm.elsevier]
 api_key = "..."
-agreed = true
 
 [tdm.aps]
 api_key = "..."
-agreed = true
 
 [tdm.springer]
 api_key = "..."
-agreed = true
 
 # Requires a build with `--features tdm-ieee`. The endpoint and response
 # shape are INFERRED from IEEE's public developer portal, not confirmed
@@ -274,10 +274,33 @@ agreed = true
 # rather than silently returning nothing.
 [tdm.ieee]
 api_key = "..."
-agreed = true
 ```
 
-If both env var and credentials.toml provide the same key, env var wins.
+**Precedence.** `DOIGET_KEY_<PUBLISHER>` wins over `[tdm.<publisher>] api_key`,
+per §1. A blank value on either rung counts as unset.
+
+**The agreement is not here.** Each TDM source needs
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, in addition to a key
+from either rung. An `agreed` key in this file is read only so doiget can warn
+that it does nothing; it grants nothing. [`LEGAL.md`](LEGAL.md) §6a.2 makes the
+agreement an *enforced control*, and part of why it is meaningful is that it is
+an act taken in the session that runs the fetch — a boolean written once into a
+file and forgotten is weaker, and weakening it as a side effect of adding a
+convenience is not a trade this file is worth (ADR-0050).
+
+So the three states are:
+
+| key | `DOIGET_AGREE_TDM_<PUB>=1` | result |
+|---|---|---|
+| env or file | yes | grant (if the `tdm-*` feature is compiled in) |
+| env or file | no | `KeyButNotAgreed` — refuses, names the variable |
+| none | yes | `AgreedButNoKey` — refuses, names both |
+
+**Before #509 this file was read by nothing.** It was specified here in full,
+including the `0600` warning, and no code path opened it; a user who followed
+this section wrote their key into a file doiget ignored and then reported the
+source unavailable for want of a key. Both the reader and the permission
+warning exist as of 0.8.11.
 
 ## 6.1 Institutional networks: what works and what does not
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -264,22 +264,53 @@ If both env var and credentials.toml provide the same key, env var wins.
 ## 6.1 Institutional networks: what works and what does not
 
 Being on a subscribing university network does **not** make paywalled content
-fetchable. Two independent things sit in the way, and only one of them is doiget's:
+fetchable. Three things sit in the way, in this order — and until 0.8.11 this section
+listed only the last two, which meant it sent readers after fixes that could not help.
+
+0. **Nothing is attempted at all**, and this comes first. The fetch path carries only
+   OA locations an enabled source reported. For a closed work there are none, so the
+   leg ends before any host is chosen: not refused, **never attempted**. The run exits
+   **0** with `metadata-only: no OA PDF available`, which reads as "this paper has no
+   OA copy".
+
+   Both blockers below sit behind this one and are never reached, so widening the
+   allowlist or obtaining TDM credentials does not change the outcome for a closed
+   DOI. Until 0.8.11 this section listed only (1) and (2), and therefore sent readers
+   after two fixes that could not help.
+
+   **This is not a bug awaiting a fix.** #517 asked whether Crossref's publisher link
+   could fill the gap. Measured across six live DOIs and eight captured responses,
+   every `link[]` entry Crossref returns is scoped to Similarity Check, syndication or
+   a TDM programme, and none is general-purpose - so following one would mean using a
+   licensed route without the licence. See [`LEGAL.md`](LEGAL.md) §2a(a-i) and
+   ADR-0052. **The supported route for a closed work is a TDM credential (§6)**, which
+   is the licensed version of exactly that.
 
 1. **The allowlist.** IEEE, ACM, SIAM and AMS are not on the default `oa-publisher`
-   allowlist, so doiget will not attempt the publisher leg for them at all. IEEE now
-   has a TDM route instead (`[tdm.ieee]` above, `--features tdm-ieee`) — that is a
-   different host (`ieeexploreapi.ieee.org`, the API) under a different source key,
-   not a widening of `oa-publisher`.
+   allowlist, so the attempt is refused at the redirect policy with
+   `error[CAPABILITY_DENIED] ... redirect_not_in_allowlist` naming the host. IEEE has
+   a TDM route instead (`[tdm.ieee]` above, `--features tdm-ieee`) — a different host
+   (`ieeexploreapi.ieee.org`, the API) under a different source key, not a widening of
+   `oa-publisher` (ADR-0039).
 2. **The publisher's bot wall.** Even from a subscribing address, a scripted client
    commonly gets `202 Accepted` with an **empty body** — a challenge holding response,
    not a paywall and not a 403. The subscription is not the binding constraint; being a
    program is.
 
 So widening the allowlist alone would not fix such a fetch; it would move the failure
-one step later. `HTTPS_PROXY` is honoured (§4), but a proxy fixes *addressing*, never
-the bot wall — and if you are already on the subscribing network, tunnelling elsewhere
-routes you away from your entitlement.
+one step later. That is now demonstrable rather than asserted: the request is formed
+and refused by name, so you can see which of (1) and (2) you are hitting.
+`HTTPS_PROXY` is honoured (§4), but a proxy fixes *addressing*, never the bot wall —
+and if you are already on the subscribing network, tunnelling elsewhere routes you
+away from your entitlement.
+
+**Where this does work.** For a closed work whose publisher **is** on the
+`oa-publisher` allowlist — the physics societies and diamond-OA hosts of ADR-0027, or
+a host you added yourself via `[[network.additional_hosts]]` / `trust_academic_repos`
+/ `trust_oa_registries` — the attempt now goes out, and on an entitled network it can
+succeed. That is not circumvention: the URL is the one Crossref reports, the request
+carries no credential doiget invented, and any access control on the far side applies
+unchanged.
 
 The two routes that do work:
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -368,7 +368,7 @@ network (--network):
   egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)
                   a proxy fixes addressing, never a bot wall
   unpaywall       polite pool as you@institution.edu
-  oa-publisher    22 host patterns allowlisted
+  oa-publisher    24 host patterns allowlisted
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...

--- a/docs/DECISIONS/0045-contributor-license-agreement.md
+++ b/docs/DECISIONS/0045-contributor-license-agreement.md
@@ -1,0 +1,108 @@
+# 0045 - Contributions carry a relicensable grant, recorded as a commit sign-off
+
+- **Date:** 2026-08-25
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** - (maintainer decision; no source Discussion)
+
+## Context
+
+The `## License` section this ADR replaces said, in full, that contributions are licensed
+under the MIT License. That is inbound = outbound, and it is a one-way door: under it,
+changing doiget's outbound license later requires permission from every past
+contributor, because each holds copyright in their own contribution and granted only
+MIT. The expensive part is not the legal work. It is that some contributors become
+unreachable, and one unreachable contributor pins the license permanently.
+
+doiget is at the single moment when that cost is zero. `git shortlog -sne --all`:
+
+```
+370  sotashimozono <...@g.ecc.u-tokyo.ac.jp>
+313  Souta <...@g.ecc.u-tokyo.ac.jp>
+  2  Souta Shimozono <...@gmail.com>
+ 38  dependabot[bot]
+  4  github-actions[bot]
+```
+
+One human, under three git identities. The two bots produce dependency bumps and release
+metadata, and neither is a legal person who could hold or grant copyright. So the
+maintainer holds all of it today, and the first external PR merged under inbound = MIT
+ends that permanently for whatever it touches.
+
+This is not a decision to relicense. doiget keeps shipping on crates.io under an
+OSI-approved license; its distribution and its MCP-ecosystem reach both depend on that.
+It is a decision to keep the *option*, which is free now and unpurchasable later.
+
+The shapes the option keeps open are concrete: a copyleft core with separately licensed
+Tier 2/3 connectors — the split ADR-0002 already draws at build-feature level — and an
+embedding license for downstream products. Neither can be offered under MIT, because MIT
+grants both for nothing.
+
+## Decision
+
+**D1. The inbound grant is broader than the outbound license.** Contributors grant a
+perpetual, worldwide, irrevocable, sublicensable copyright license permitting
+distribution *under any license terms*. The wording follows the Apache ICLA §2 grant;
+the sublicense right is the part that carries relicensing.
+
+**D2. A patent grant with defensive termination accompanies it**, in the Apache ICLA §3
+shape: the license covers claims necessarily infringed by the contribution, and
+terminates for any entity that files patent litigation over it.
+
+**D3. The outbound promise is written down.** Public releases remain available under an
+OSI-approved open source license. D1 without D3 reads as a reserved right to close the
+source, and would suppress exactly the contributions the project wants. D3 costs nothing
+the project intends to do anyway — AGPL is OSI-approved, so the copyleft-core shape
+survives it. What D3 forecloses is going proprietary outright, which is already ruled
+out.
+
+**D4. Assent is a `Signed-off-by` trailer, checked in CI.** No CLA bot, no signature
+database. The record lives in `git log`, so it is auditable from a clone alone and no
+hosted service has to outlive the project. `.github/workflows/dco.yml` fails a PR whose
+commits lack a well-formed trailer, exempting bot-authored commits and the merge commits
+GitHub creates.
+
+**D5. Not retroactive.** Everything merged before this ADR stays MIT-only, and
+CONTRIBUTING.md says so. Given the shortlog above this forfeits nothing: the only
+pre-existing non-maintainer commits are bot-authored dependency bumps.
+
+## Consequences
+
+- Future contributions can be dual-licensed or relicensed without a contributor hunt.
+  The pre-0.8.10 tree stays MIT forever, and the crates already published cannot be
+  recalled; this ADR does not pretend otherwise.
+- `dco.yml` is added but is deliberately **not** promoted to a required status check —
+  the required checks remain the two `test` jobs. It blocks within its own job, so a
+  missing sign-off is visible on the PR without perturbing the auto-merge chain.
+- Sign-off adds one flag (`git commit -s`) to the maintainer's own loop. Forgetting it
+  turns a check red before merge rather than after, which is the cheap direction.
+- Some contributors refuse broad CLAs on principle. That is the real cost, paid in a
+  currency doiget has little of. If it ever becomes the binding constraint, D1 can be
+  narrowed by a superseding ADR — narrowing is always available, widening is not.
+- **Unreviewed by counsel.** The text is assembled from the Apache ICLA pattern, and
+  CONTRIBUTING.md states plainly that it is not legal advice. Before the option is
+  exercised commercially — an actual relicense, or an embedding sale — the grant needs a
+  lawyer's read. Adopting now and reviewing later is the right order, because the record
+  this creates is the one thing that cannot be built retroactively.
+
+## Alternatives rejected
+
+- **DCO alone** (Linux, Docker). The DCO certifies origin and right-to-submit; it grants
+  nothing beyond the project's stated outbound license. It would produce the same
+  sign-off trailers and none of the relicensing ability — all of the friction, none of
+  the point.
+- **Copyright assignment** (FSF style). Strictly stronger and strictly worse to ask for:
+  it takes the contributor's copyright instead of licensing it. D1 obtains the rights
+  that are actually needed while the contributor keeps ownership.
+- **CLA Assistant or a comparable bot.** Adds a GitHub App with write access plus an
+  external signature store to a repo whose posture rules exist to keep that surface
+  small (ADR-0001, ADR-0015). A git trailer outlives any hosted signature service.
+- **Wait until a real contributor appears.** The trigger arrives as a merged PR — a good
+  one, from someone helpful, at the exact moment when demanding a licensing agreement is
+  most awkward. The policy is cheapest strictly before it is needed.
+- **Relicense now** (AGPL plus a commercial license). Premature: it trades MCP-ecosystem
+  adoption for revenue that has no customer yet. This ADR keeps the door open without
+  walking through it.
+
+If this decision is ever revisited, write a new ADR with `Supersedes: 0045`, and update
+this file's `Status:` per `CONTRIBUTING.md`.

--- a/docs/DECISIONS/0049-invalid-ref-is-misuse.md
+++ b/docs/DECISIONS/0049-invalid-ref-is-misuse.md
@@ -1,0 +1,87 @@
+# 0049 - An unparsable ref is misuse (exit 2), and one function decides it
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Source:** #492 (`fetch` exits 1, `graph` exits 2, `ERRORS.md` §4 says 2), found while doing #477
+
+## Context
+
+`docs/ERRORS.md` §4 is `Status: NORMATIVE` and reads:
+
+| Exit | Meaning |
+|---|---|
+| `1` | At least one fetch failed. |
+| `2` | Misuse (bad arguments, missing config). |
+
+Given `doiget <cmd> "not a doi"`, one binary answered two ways:
+
+- `commands/graph.rs` exited **2**, with a comment citing §4 and asserting it
+  was *"consistent with `fetch`'s INVALID_REF path"*.
+- `commands/fetch.rs` exited **1**, because `cli_exit_code` has no
+  `InvalidRef` arm and the value fell through `_ => 1`.
+- The eight commands #477 converted (`info`, `link`, `cite`, `text`, `tag`,
+  `bib`, `csl`, `source`) exited 1 with `fetch`, by design — that conversion
+  changed no exit code.
+
+So `graph`'s comment was false, and `fetch`'s 1 was not a decision: it was the
+catch-all. Against the table, nothing was fetched, so "at least one fetch
+failed" does not describe the run.
+
+`crates/doiget-cli/tests/fetch_error_mapping_e2e.rs` pinned it:
+
+```rust
+fn fetch_invalid_ref_emits_cargo_style_error_and_exit_1() { … .code(1) … }
+```
+
+#492 declined to change this in passing, and was right to: someone wrote that
+name and that assertion deliberately for #119, so either it encodes a decision
+§4 does not capture, or §4 is right and the test froze the catch-all. The two
+readings imply opposite changes.
+
+Reading #119 settles it. Its subject is the `error[INVALID_REF]:` *line* —
+replacing an opaque anyhow dump with the cargo-style message. The exit code
+came along as whatever `cli_exit_code` already returned. There is no argument
+in it for 1 over 2.
+
+## Decision
+
+**D1 — `ErrorCode::InvalidRef` maps to exit 2.** An unparsable ref is a bad
+argument. §4's 1 is reserved for a run in which a fetch was attempted and
+failed.
+
+**D2 — One function decides, and the call sites stop choosing.**
+`fetch::cli_exit_code` is the single mapping; `graph` no longer hard-codes its
+own 2. #477 unified the *message* through `render_ref_parse_error` and left the
+exit code per-call-site, which is precisely where the disagreement lived.
+
+**D3 — The rule is asserted across every ref-taking command, not just one.**
+`every_ref_taking_command_exits_2_for_an_invalid_ref` runs the same table as
+the message test, so a new subcommand is covered by both or by neither. A
+single-command assertion is what allowed this to persist: `fetch`'s exit code
+was pinned, and nothing compared it to its siblings.
+
+**D4 — §4 says which class an unparsable *value* is in.** The table listed
+"bad arguments" without settling whether that meant argv shape (what `clap`
+rejects) or a value that fails validation. It now says both are misuse, so the
+next reader does not have to re-derive it from two disagreeing call sites.
+
+## Consequences
+
+**Breaking for scripts keying on 1.** A caller that branched on `$? == 1` to
+mean "invalid ref" now sees 2. That is the point — 1 could equally have meant a
+network failure, a `NO_OA_AVAILABLE`, or any other code under the catch-all, so
+the previous behaviour did not distinguish what such a script believed it did.
+Recorded in `CHANGELOG.md` under **Changed**. Not in `docs/MIGRATION.md`,
+which covers BiblioFetch.jl and machine moves rather than CLI contract
+changes.
+
+**The rejected alternative.** #492's option 2 — keep `fetch` at 1 and move
+`graph` to 1, adding a sentence to §4 saying "misuse" means argv shape only —
+has the smaller blast radius and was not chosen. It would make `INVALID_REF`
+the one closed error code whose exit value is the *unclassified* one, and it
+would leave `Ambiguous` (already 2, for a value that fails to select one
+entity) sitting next to `InvalidRef` at 1, for a value that fails to parse.
+
+**No new code.** The mapping already existed and already had a home; this adds
+one arm and deletes one hard-coded literal.

--- a/docs/DECISIONS/0050-credentials-file-carries-the-key-not-the-agreement.md
+++ b/docs/DECISIONS/0050-credentials-file-carries-the-key-not-the-agreement.md
@@ -1,0 +1,93 @@
+# 0050 - credentials.toml carries the key; the agreement stays in the environment
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0047](0047-legal-claims-are-read-off-the-code.md) — same audit; that ADR corrected the claim, this one closes the gap the claim was about
+- **Source:** #509 (a credentials file documented in full and read by nothing)
+
+## Context
+
+`docs/CONFIG.md` is `Status: NORMATIVE`. Its §6 gave a complete schema for
+`~/.config/doiget/credentials.toml` — four `[tdm.<publisher>]` tables, an
+`api_key` and an `agreed` per table, a precedence rule against the environment,
+and a `0600` permission warning "at startup".
+
+Nothing read the file. The TDM resolver in `crates/doiget-core/src/lib.rs`
+called `std::env::var` and stopped there, `credentials.toml` appeared in exactly
+one non-prose place (a doc comment about the config *directory*), and the
+permission warning did not exist either — the only `permissions()` calls in the
+tree were a store write and a writability probe.
+
+The cost is specific. Follow the NORMATIVE document, write an Elsevier key into
+that file with `agreed = true`, and doiget silently ignores it and reports the
+source unavailable for want of a key. `config doctor` could not help: it points
+at "docs/CONFIG.md §6", the section describing the file that does nothing.
+
+Same shape as #476, #441, #442, #454 and #458 — a documented mechanism with no
+implementation behind it. This one landed on credentials, in a NORMATIVE doc,
+with a security claim attached.
+
+#509 offered two ways out, and they are not equivalent: implement it, or delete
+the documentation.
+
+## Decision
+
+**D1 — Implement the file, for the key.** A long-lived API key is genuinely
+better off in a file than in the environment: it survives a shell restart, it is
+not visible in `ps`, and it does not leak into the environment of every
+subprocess. `crates/doiget-core/src/credentials.rs` reads
+`[tdm.<publisher>] api_key`, and `DOIGET_KEY_<PUBLISHER>` sits one rung above it
+— the same env-then-file order `store_root` (#441) and `contact_email` (#504)
+use, and the order `CONFIG.md` §1 has always claimed.
+
+**D2 — The agreement does not follow the key into the file.**
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` stays environment-only.
+
+`LEGAL.md` §6a.2 lists the per-publisher agreement as an *enforced control*, and
+part of what makes it meaningful is that it is an act taken in the session that
+runs the fetch. A boolean written once into a config file and forgotten is a
+weaker consent for the same word. #509 flagged this and asked for it to be an
+explicit decision rather than a side effect; this is that decision.
+
+The rules in `CAPABILITY.md` §2 are unchanged by the new rung, which is the
+point: a key from the file still needs the agreement, so `KeyButNotAgreed` now
+also fires for a file-supplied key with no agreement variable.
+
+**D3 — An `agreed` key in the file is reported, not discarded.** It is parsed
+solely so doiget can warn that it grants nothing and name the variable that
+does. Silently ignoring a field this document specified is the defect being
+closed; doing it again in the fix would be worse than not fixing it.
+
+**D4 — The `0600` warning exists, and is POSIX-only.** Group- or
+world-accessible modes emit a `tracing::warn!` naming the mode and the `chmod`.
+Off POSIX it is a no-op: Windows ACLs are not a mode, and advice phrased in
+`chmod` terms would be advice the user cannot follow. `CONFIG.md` §6 says
+"SHOULD ... doiget warns" rather than "MUST", because a warning is what is
+enforced.
+
+## Consequences
+
+**Positive.**
+
+- The NORMATIVE document is true again. `LEGAL.md` §6a.1 can state the file as a
+  credential source without #494's correction attached.
+- The security claim is real: the permission check is code, not a sentence.
+- The opt-in is not diluted. §6a.2 still names an act, not a stored boolean.
+
+**Negative.**
+
+- A new file-parsing surface in the credential path. Bounded: absent,
+  unreadable and malformed all yield "no keys" with a `warn`, so one bad line
+  cannot take a fetch down, and there is no accessor for `agreed` at all — the
+  type cannot carry it, so no future caller can be tempted to consult one.
+- Configuration is now in two files. `config doctor` reports which rung answered
+  for the addresses (#504); it does not yet do so for keys, and deliberately
+  will not print a key.
+
+**Testing note, learned here.** Adding a file rung made the existing
+`CapabilityProfile::from_env` tests depend on the developer's real
+`~/.config/doiget/credentials.toml` — green in CI and red on the one machine
+that has TDM configured. They now run under an isolated config home. A rung that
+reads a file outside the test's control is not a detail of the test harness; it
+is a property of the change.

--- a/docs/DECISIONS/0052-crossref-link-is-programme-scoped.md
+++ b/docs/DECISIONS/0052-crossref-link-is-programme-scoped.md
@@ -1,0 +1,125 @@
+# 0052 - Crossref `link[]` is programme-scoped, so the fetch path does not carry it
+
+- **Date:** 2026-08-26
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0048](0048-access-ceiling.md) — this is the first widening proposal tested against the ceiling that ADR wrote down, and the ceiling held
+- **Source:** #517 (the fetch path never contacts the publisher for a closed DOI, and CONFIG.md §6.1 names two blockers when there are three)
+
+## Context
+
+For a DOI with no Open Access copy, `doiget fetch` issues no request to the
+publisher. Not because an attempt is refused — because there is nothing to
+attempt:
+
+```rust
+let chain = extract_oa_url_chain(r.metadata_json.as_ref());   // Unpaywall ONLY
+let (pdf_leg, pdf_bytes) = if oa_chain.is_empty() {
+    (PdfLegStatus::NoOaUrl, None)
+```
+
+Unpaywall reports OA locations. A closed work has none, so the chain is empty and
+the leg ends before any host is chosen. Entitlement is never consulted because no
+request is ever formed.
+
+`docs/CONFIG.md` §6.1, "Institutional networks: what works and what does not",
+named two blockers — the `oa-publisher` allowlist and the publisher bot wall —
+and **neither was reached**. A third sat in front of both. A reader entitled to a
+paywalled paper concluded that widening the allowlist or obtaining TDM
+credentials was the remedy, and for a closed DOI neither could help. The run
+exited **0** with `metadata-only: no OA PDF available`.
+
+#517 offered two positions: keep the invariant and write it down, or widen the
+fetch path to carry a Crossref-derived candidate so that §6.1's blockers become
+real. The maintainer chose to widen.
+
+## The measurement that settled it
+
+The candidate would have come from Crossref `message.link[]`. Every entry there
+carries `intended-application`:
+
+| value | what it is |
+|---|---|
+| `unspecified` | a general full-text link |
+| `text-mining` | scoped to the publisher's TDM programme |
+| `similarity-checking` | scoped to Similarity Check / iThenticate |
+| `syndication` | scoped to syndication partners |
+
+Live Crossref, 2026-08-26, six DOIs chosen to span the publishers this question
+is actually about:
+
+| DOI | publisher | `intended-application` values |
+|---|---|---|
+| `10.1137/0117004` | SIAM | `similarity-checking` |
+| `10.1109/TSP.2018.2812747` | IEEE | `similarity-checking` |
+| `10.1090/s0025-5718-04-01692-8` | AMS | `similarity-checking` ×2 |
+| `10.1145/3292500.3330701` | ACM | `text-mining`, `similarity-checking` |
+| `10.1038/nature12373` | Springer Nature | `text-mining` ×2, `similarity-checking` |
+| `10.1098/rspa.2014.0585` | Royal Society | `text-mining` ×2, `similarity-checking` |
+
+Plus the eight captured responses in `tests/fixtures/real_world/`:
+`text-mining`, `syndication` ×2, `similarity-checking` ×4, and two with no
+`link[]` at all.
+
+**Twelve live entries and eight fixtures. Not one `unspecified`.**
+
+Crossref `link[]` is therefore a **programme-scoped channel**, not a general
+full-text channel. There is no general-purpose candidate in it to carry.
+
+## Decision
+
+**D1 — The fetch path does not carry a Crossref-derived candidate.** The ceiling
+in ADR-0048 §2a holds unchanged. Wiring it would have meant one of two things,
+and both are wrong:
+
+- **With the `unspecified` filter:** a branch that never executes, while
+  `LEGAL.md` and `CONFIG.md` claim a capability. That is the defect class this
+  repository keeps closing — #413, #442, #454, #458, #476, #504, #509 — shipped
+  deliberately this time.
+- **Without the filter:** following Similarity Check and TDM links **without
+  holding those licences**. doiget already has the licensed route for exactly
+  this: its Tier-3 TDM sources, with the user's own credential and a recorded
+  per-publisher agreement (`LEGAL.md` §6a.2). Taking the same URLs without that
+  is the thing the whole Tier-3 apparatus exists to avoid.
+
+**D2 — `extract_crossref_oa_url` is fixed anyway, and renamed.** It returned the
+**first** `link[]` entry with no filtering, and its result is
+`MetadataOnlyOutcome.oa_url`, whose doc comment invites callers to act on it
+"for separate action". So doiget was already handing out Similarity Check and
+TDM URLs under the name `oa_url` — to the MCP surface, and to anyone reading the
+`metadata_only` output. `extract_crossref_publisher_url` accepts only
+`unspecified`, and refuses an unlabelled entry too, because ADR-0048 D2 draws the
+line at documented-by-the-vendor versus guessed-by-us.
+
+In practice this means `oa_url` is now `None` where it was previously a
+programme-scoped URL. **Seven real-world fixtures asserted the old value**, which
+is the strongest available evidence that it was behaviour rather than an
+accident; their expectations are corrected with the reason written in beside
+them.
+
+**D3 — `CONFIG.md` §6.1 gains the blocker that was in front of the two it
+named**, and states plainly that it is not a bug awaiting a fix — the supported
+route for a closed work is a TDM credential, which is the licensed version of
+the thing #517 wanted.
+
+## Consequences
+
+**#517's first position wins, but on evidence rather than preference.** The issue
+was right that the decision had to be recorded; it framed the choice as a
+judgement call, and it turned out to be a factual question with a checkable
+answer.
+
+**`MetadataOnlyOutcome.oa_url` loses most of its values.** It never held a
+usable OA URL for these works — it held a link the publisher had scoped
+elsewhere. A field that is honestly empty is better than one that is
+confidently wrong, and it is the same trade #472 was about.
+
+**The user-visible gap #517 opened with remains open**, and this ADR does not
+close it: on a subscribing network, a closed DOI still exits 0 saying there is
+no OA copy. What can be improved without touching the ceiling is the *reporting*
+— saying which sources were consulted, which were off, and that a TDM credential
+is the route. That is #505, and it is now the whole remaining answer to #517.
+
+**If a publisher ever does register an `unspecified` link**, the filter admits it
+and the ceiling already covers it under §2a(a). Nothing further is needed; this
+ADR is a statement about what Crossref returns, not a prohibition on the value.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -61,6 +61,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0042 | `tdm-ieee` ships against an inferred contract, marked unverified | Accepted (0.8.9) | `feat/430-tdm-ieee` | #430 |
 | 0043 | The machine-readable surfaces carry the trace and the remediation | Accepted (0.8.9) | `feat/459-machine-readable-diagnostics` | #459 |
 | 0044 | Tier-3 TDM sources are consulted on a blocked content leg, not on a Crossref miss | Accepted | `feat/458-tdm-content-leg` | #458 |
+| 0045 | Contributions carry a relicensable grant, recorded as a commit sign-off | Accepted | `chore/cla-relicensing-grant` | - |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -65,6 +65,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
 | 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
+| 0049 | An unparsable ref is misuse (exit 2), and one function decides it | Accepted | `fix/492-invalid-ref-exit-code` | #492 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -65,6 +65,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
 | 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
+| 0052 | Crossref `link[]` is programme-scoped, so the fetch path does not carry it | Accepted | `feat/517-publisher-candidate` | #517 |
 
 ## Conventions
 

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -65,6 +65,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0046 | In SOURCES.md, a claim about a vendor is normative; the URL where the vendor says it is a pointer | Accepted | `docs/495-496-sources-accuracy` | #495, #496 |
 | 0047 | LEGAL.md's claims are read off the code, and an "enforced control" must name enforcement that exists | Accepted | `docs/494-legal-network-surface` | #494 |
 | 0048 | The access ceiling is written down, and widening it amends the written form | Accepted | `docs/497-access-invariant` | #497 |
+| 0050 | credentials.toml carries the key; the agreement stays in the environment | Accepted | `feat/509-credentials-file` | #509 |
 
 ## Conventions
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -206,8 +206,8 @@ Neither ever renders "no trace" as `[]`.
 | Exit | Meaning |
 |---|---|
 | `0` | Success (all refs ok). |
-| `1` | At least one fetch failed. |
-| `2` | Misuse (bad arguments, missing config). |
+| `1` | At least one fetch was attempted and failed. |
+| `2` | Misuse — a bad argument or missing config. Covers both an argv shape `clap` rejects **and** a well-formed argument whose *value* fails validation, which is why `INVALID_REF` and `AMBIGUOUS` are both 2 (ADR-0049). |
 | `3` | Capability denied (no source could serve). |
 | `4` | I/O failure (store / log unwritable). |
 | `64..=78` | `sysexits.h` mapping for select cases. |

--- a/docs/INTEGRATION/README.md
+++ b/docs/INTEGRATION/README.md
@@ -1,42 +1,58 @@
 # Integration guides
 
-> **Status: INFORMATIVE (placeholder).** Concrete host-integration snippets land
-> in **Phase 3** alongside the MCP server (`doiget serve`). Until then, this
-> directory is a pointer rather than a recipe collection.
+> **Status: INFORMATIVE.** `doiget serve` ships; these are the host-side
+> snippets. Each page states whether it has been exercised against that
+> host, and the ones that have not say so.
 
-## Why this is empty today
+`doiget serve` is a stdio MCP server. It is the same entry point everywhere —
+`mcpb/manifest.json` runs `doiget serve`, and so does the MCP Registry entry.
+The differences between hosts are only where the config file lives and what it
+is called.
 
-Phase 0 ships specifications (see [`../MCP_TOOLS.md`](../MCP_TOOLS.md) and
-[`../PUBLIC_API.md`](../PUBLIC_API.md)) but no functional MCP server. Without a
-runnable `doiget serve`, integration snippets would either be untested aspirational
-config or would lead a reader to a Phase 0 stub error. Phase 3 ships the actual
-server and the corresponding host snippets in this directory.
-
-## Planned files (Phase 3)
-
-| File | Host | Status |
+| File | Host | Exercised? |
 |---|---|---|
-| `claude-desktop.md` | Claude Desktop (stdio MCP) | Phase 3 (stub) |
-| `cursor.md` | Cursor | Phase 3 (stub) |
-| `codex.md` | OpenAI Codex CLI | Phase 3 (stub) |
-| `claude-code.md` | Claude Code (this tool) | Phase 3 (stub) |
-| `obsidian.md` | Obsidian backend export | Phase 7 (optional, stub) |
-| `chain-with-paperqa.md` | Composition with paper-qa for content processing | Phase 3+ (stub) |
+| [`claude-code.md`](./claude-code.md) | Claude Code | **Yes** — this is what the project is developed under |
+| [`claude-desktop.md`](./claude-desktop.md) | Claude Desktop (`.mcpb`, or manual stdio) | **Yes**, for the `.mcpb` route (shipping since 0.8.4) |
+| [`cursor.md`](./cursor.md) | Cursor | No |
+| [`codex.md`](./codex.md) | OpenAI Codex CLI | No |
+| [`obsidian.md`](./obsidian.md) | Obsidian | Not applicable — Obsidian hosts no MCP server; the page says what does work |
+| [`chain-with-paperqa.md`](./chain-with-paperqa.md) | Composition with paper-qa | No, as a chain |
 
-## What to read in the meantime
+## The one setting to get right
 
-- **MCP tool spec:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tool surface
-  Phase 3 will expose. Sufficient to plan a host integration in advance.
-- **Public Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders that
-  link `doiget-core` directly rather than going through the MCP server.
-- **Architecture overview:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — for
-  how tools, transport, and the capability gate fit together.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and the
-  `~/.config/doiget/` layout that any host-side wiring will need to respect.
+`DOIGET_STORE_ROOT`, as an absolute path.
+
+The store root defaults to `./papers` **relative to the process's working
+directory** (ADR-0036). For a CLI run that is exactly right — artifacts land
+where you are working. For an MCP server it is not: the working directory
+belongs to the host, so the store lands somewhere you did not choose and a
+later CLI run does not see it. That is
+[#369](https://github.com/QAtlasHub/doiget/issues/369).
+
+`DOIGET_CONTACT_EMAIL` is the second one. Without it every request goes out as
+`doiget@localhost` on the non-polite pool, where a throttled answer is
+indistinguishable from "this paper has no OA copy"
+([#504](https://github.com/QAtlasHub/doiget/issues/504)).
+
+Everything else is off by default and documented in
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Also worth reading
+
+- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — every tool with its
+  JSON Schema. `doiget_capability_profile` reports the same thing at runtime
+  for the build you actually have.
+- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — precedence and the
+  `config.toml` schema.
+- **Errors:** [`../ERRORS.md`](../ERRORS.md) — the closed set of error codes
+  and what an agent should do with each.
+- **Rust API:** [`../PUBLIC_API.md`](../PUBLIC_API.md) — for embedders linking
+  `doiget-core` directly instead of going through MCP.
 
 ## Contributing a snippet
 
-If you have a working integration with an MCP host that is not in the planned list,
-open a GitHub Discussion describing the host, the JSON-RPC trace, and any
-host-specific config quirks. PRs adding a new file under `docs/INTEGRATION/` will
-be accepted in Phase 3+ once `doiget serve` is real and the snippet is verifiable.
+A working configuration for a host not listed here is welcome. Open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+host, the config file and its path, and anything host-specific that bit you —
+or a PR adding a page in the shape of the others, including an honest
+"exercised?" line.

--- a/docs/INTEGRATION/chain-with-paperqa.md
+++ b/docs/INTEGRATION/chain-with-paperqa.md
@@ -1,43 +1,55 @@
 # Chaining with paper-qa
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table this composition guide is scoped to
-> **Phase 3+** — `doiget serve` ships first, then a verified chain recipe.
+> **Status: UNTESTED as a chain.** Both halves are real — doiget writes PDFs to
+> a directory, paper-qa reads a directory of PDFs — but nobody has run the
+> composition end to end and reported back. Treat the shape below as the
+> intended design, not a verified recipe. Last checked 2026-08-26.
 
-[paper-qa](https://github.com/Future-House/paper-qa) is a retrieval-augmented
-question-answering system over scientific papers. The chain pattern this
-guide will document keeps `doiget`'s role narrow — DOI resolution, metadata,
-and content fetch via the tools in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — and
-hands the resulting documents to paper-qa for embedding, retrieval, and
-answer synthesis. Composition keeps each tool single-purpose and avoids
-duplicating retrieval logic inside `doiget`.
+[paper-qa](https://github.com/Future-House/paper-qa) does retrieval-augmented
+question answering over scientific papers. It handles embedding, retrieval and
+answer synthesis; doiget handles getting the papers, legally and with a
+provenance trail. Neither needs to know about the other, because the interface
+is a directory.
 
-## Configuration (Phase 3)
+## The shape
 
-The example below is intentionally empty. The chain shape depends on the
-final Phase 3 tool surface and on paper-qa's MCP/CLI ingestion entry point.
+```sh
+export DOIGET_STORE_ROOT="$HOME/papers"
+export DOIGET_CONTACT_EMAIL="you@institution.edu"
 
-```toml
-<!-- TODO Phase 3: paste verified doiget + paper-qa chain config here. -->
+# 1. Resolve and fetch a bibliography's references (OA only).
+doiget batch refs.bib
+
+# 2. Point paper-qa at the store.
+pqa -i "$HOME/papers" ask "what do these papers say about X?"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+`doiget batch` reports per-reference outcomes; the ones it could not fetch are
+named rather than dropped, so the corpus paper-qa sees is one you can account
+for.
 
-## What to read in the meantime
+## Why compose rather than integrate
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+doiget's job stops at "the bytes are on disk, and here is where they came
+from". Embedding and retrieval are a different problem with different
+dependencies, and duplicating either inside doiget would widen its network
+surface and its supply chain for no gain — see [`../SCOPE.md`](../SCOPE.md).
+
+The same argument means doiget will not ship a paper-qa plugin. The directory
+is the integration.
+
+## What doiget gives you that a scraper does not
+
+- **Provenance.** Every fetch is a hash-chained row in the append-only log
+  ([`../PROVENANCE_LOG.md`](../PROVENANCE_LOG.md)), so the corpus behind an
+  answer is auditable.
+- **Licence, per entry.** The sidecar records it, which matters as soon as an
+  answer is quoted.
+- **A refusal you can read.** A blocked paper produces a named reason and a
+  remediation, not a silent gap in the corpus.
 
 ## Contributing
 
-If you have a working `doiget` + paper-qa chain ahead of Phase 3, open a
-GitHub Discussion with the orchestration script and any host-specific quirks
-rather than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you run this, the useful thing to report is the orchestration script and
+any paper-qa-side quirks — open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions).

--- a/docs/INTEGRATION/claude-code.md
+++ b/docs/INTEGRATION/claude-code.md
@@ -1,40 +1,99 @@
 # Claude Code integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED.** The `claude mcp add` form below is the configuration
+> this project is developed under. Last checked 2026-08-26 against
+> `doiget 0.8.10`.
 
-[Claude Code](https://www.anthropic.com/claude-code) is Anthropic's official
-CLI and supports MCP servers. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as an MCP server in Claude Code (via
-`claude mcp add` or a project-scoped `.mcp.json`) so that the tool surface
-listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) is callable from Claude Code
-sessions.
+[Claude Code](https://www.anthropic.com/claude-code) hosts MCP servers over
+stdio. `doiget serve` is the entry point — the same one
+[`mcpb/manifest.json`](../../mcpb/manifest.json) and the
+[MCP Registry](https://registry.modelcontextprotocol.io/) use.
 
-## Configuration (Phase 3)
+Install `doiget` first (see [`../../README.md`](../../README.md) §Installation);
+it must be on `PATH`, or give an absolute path below.
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+## One line
+
+```sh
+claude mcp add doiget -- doiget serve
+```
+
+With the environment set at the same time, and available in every project
+rather than only this one:
+
+```sh
+claude mcp add doiget --scope user \
+  -e DOIGET_STORE_ROOT="$HOME/papers" \
+  -e DOIGET_CONTACT_EMAIL="you@institution.edu" \
+  -- doiget serve
+```
+
+`--scope` is `local` (this project, private) by default; `user` is every
+project, `project` writes the committed `.mcp.json` below. `claude mcp add
+--help` lists the rest.
+
+## Project-scoped `.mcp.json`
+
+Committed at the repository root, this shares the server with everyone who
+opens the project:
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Code .mcp.json entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "type": "stdio",
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "${HOME}/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
+On Windows, `command` is the full path if `doiget` is not on `PATH`, e.g.
+`"C:/Users/<you>/AppData/Local/Programs/doiget/doiget"`.
+
+## Environment
+
+`DOIGET_STORE_ROOT` is the one to set. Without it the store root defaults to
+`./papers` **relative to the process's working directory** (ADR-0036), which
+for an MCP server is the host's, not yours — #369 is that mistake. Set it to
+an absolute path and the store is the same one `doiget` on the command line
+uses.
+
+| Variable | Why |
+|---|---|
+| `DOIGET_STORE_ROOT` | Absolute path to the paper store. Set this. |
+| `DOIGET_CONTACT_EMAIL` | Polite-pool contact for Crossref / Unpaywall. Without it requests go out as `doiget@localhost` from the non-polite pool, where a throttled answer is indistinguishable from "no OA copy" (#504). |
+| `DOIGET_UNPAYWALL_EMAIL` | Only if it differs from the contact address. |
+| `DOIGET_ENABLE_OPENALEX`, `DOIGET_ENABLE_EUROPE_PMC`, `DOIGET_ENABLE_CORE`, `DOIGET_ENABLE_OPENAIRE`, `DOIGET_ENABLE_HAL`, `DOIGET_ENABLE_DATACITE`, `DOIGET_ENABLE_S2`, `DOIGET_ENABLE_DOAJ` | Widen the search past the three always-on sources. **All off by default** (ADR-0040) — with none of them set, `no OA PDF available` means only that Crossref, Unpaywall and arXiv had nothing. |
+| `DOIGET_CORE_API_KEY` | Optional free CORE key; raises that source's rate limit. |
+
+Full precedence and the complete list: [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
+
+**A build caveat, once.** Those `DOIGET_ENABLE_*` flags need the `metadata`
+feature compiled in. The official release binaries and the `.mcpb` are built
+`--features oa-only,citation` (which implies `metadata`), so they work there.
+A binary you built yourself with the default `oa-only` will log a warning and
+leave the source unavailable — `doiget_capability_profile` reports the truth
+for the binary you actually have.
+
+## Checking it worked
+
+```
+/mcp
 ```
 
-## What to read in the meantime
+should list `doiget`. Then ask the model to call `doiget_health` — it reports
+the version, whether the store is writable, and where the store actually is,
+which is the fastest way to catch a wrong `DOIGET_STORE_ROOT`.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Tool surface
 
-## Contributing
-
-If you have a working Claude Code integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+22 tools, enumerated with their JSON Schemas in
+[`../MCP_TOOLS.md`](../MCP_TOOLS.md). `doiget_capability_profile` reports which
+sources this particular build and environment may use.

--- a/docs/INTEGRATION/claude-desktop.md
+++ b/docs/INTEGRATION/claude-desktop.md
@@ -1,39 +1,75 @@
 # Claude Desktop integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: VERIFIED for the `.mcpb` route** (shipping since 0.8.4; attached to
+> every GitHub Release). The manual JSON route below is the same stdio
+> invocation and is included for people who would rather not install an
+> extension. Last checked 2026-08-26.
 
-[Claude Desktop](https://claude.ai/download) is Anthropic's desktop client and
-hosts MCP servers over stdio. Once `doiget serve` ships in Phase 3, this guide
-will document how to register `doiget` as a tool provider in Claude Desktop's
-MCP configuration so that `resolve_doi`, `fetch_metadata`, and the rest of the
-tool surface in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are callable from a chat.
+[Claude Desktop](https://claude.ai/download) hosts MCP servers over stdio.
 
-## Configuration (Phase 3)
+## Recommended: install the `.mcpb` extension
 
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+Each [GitHub Release](https://github.com/QAtlasHub/doiget/releases) attaches
+`doiget-<version>.mcpb`. Download it and open it — Claude Desktop installs it
+as an extension. The bundle carries the binaries for macOS, Windows and Linux
+and picks the right one, so there is no PATH to configure.
+
+It asks for one setting, **Paper store location**, which becomes
+`DOIGET_STORE_ROOT`. Point it at a real directory you own; the default is
+`~/Documents/doiget-papers`.
+
+Requires Claude Desktop **0.10.0 or newer**
+(`mcpb/manifest.json` → `compatibility.claude_desktop`).
+
+## Manual: `claude_desktop_config.json`
+
+Settings → Developer → Edit Config. The file lives at:
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
 
 ```json
-<!-- TODO Phase 3: paste verified Claude Desktop MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "/usr/local/bin/doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an **absolute** `command` path. A desktop app does not inherit the `PATH`
+your shell has, so a bare `doiget` frequently fails to launch with no visible
+error.
 
-## What to read in the meantime
+Restart Claude Desktop after editing.
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+## Environment
 
-## Contributing
+`DOIGET_STORE_ROOT` matters more here than anywhere else: the working
+directory of a GUI-launched process is not a directory you chose, so the
+`./papers` default (ADR-0036) lands somewhere arbitrary. That was #369.
 
-If you have a working Claude Desktop integration ahead of Phase 3, open a
-GitHub Discussion with the JSON-RPC trace and host-side config rather than a
-PR — see [`README.md`](./README.md) §Contributing a snippet.
+The remaining variables are the same as for Claude Code — see
+[`claude-code.md`](./claude-code.md) §Environment,
+[`../CONFIG.md`](../CONFIG.md) and [`../CAPABILITY.md`](../CAPABILITY.md).
+
+## Checking it worked
+
+Ask for `doiget_health`. It reports the version, store writability and the
+resolved store path.
+
+## Verifying the download
+
+Every release asset except the `.mcpb` currently ships `.sha256` and
+`.cosign.bundle` sidecars; [#483](https://github.com/QAtlasHub/doiget/issues/483)
+adds them for the `.mcpb` too. Until it lands, verify the raw binary if you
+need a signature check, and install that manually per above.

--- a/docs/INTEGRATION/codex.md
+++ b/docs/INTEGRATION/codex.md
@@ -1,39 +1,33 @@
 # OpenAI Codex CLI integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Codex CLI as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server, and the snippet below is the standard stdio shape,
+> but this specific host has not been exercised. Report success or failure on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512).
 
-[OpenAI Codex CLI](https://github.com/openai/codex) is OpenAI's terminal-native
-coding agent and supports MCP servers. Once `doiget serve` ships in Phase 3,
-this guide will document how to register `doiget` as an MCP server in Codex
-CLI so that the tools enumerated in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Codex sessions.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative TOML from
-elsewhere — wait for the verified Phase 3 snippet.
+[Codex CLI](https://github.com/openai/codex) reads `~/.codex/config.toml`.
+MCP servers go under `[mcp_servers.<name>]`:
 
 ```toml
-<!-- TODO Phase 3: paste verified Codex CLI MCP server entry here. -->
+[mcp_servers.doiget]
+command = "doiget"
+args = ["serve"]
+
+[mcp_servers.doiget.env]
+DOIGET_STORE_ROOT = "/home/you/papers"
+DOIGET_CONTACT_EMAIL = "you@institution.edu"
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on `PATH`.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment, [`../CONFIG.md`](../CONFIG.md) and
+[`../CAPABILITY.md`](../CAPABILITY.md).
 
-## Contributing
+## Checking it worked
 
-If you have a working Codex CLI integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Ask for `doiget_health`, then `doiget_capability_profile`.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/cursor.md
+++ b/docs/INTEGRATION/cursor.md
@@ -1,39 +1,44 @@
 # Cursor integration
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
+> **Status: UNTESTED against Cursor as of 2026-08-26.** `doiget serve` is a
+> plain stdio MCP server with no host-specific behaviour, and the snippet
+> below is the standard stdio shape — but nobody has run it in Cursor and
+> reported back. If you do, please say so on
+> [#512](https://github.com/QAtlasHub/doiget/issues/512) and this banner
+> comes off.
 
-[Cursor](https://www.cursor.com/) is an AI-first code editor that supports MCP
-servers. Once `doiget serve` ships in Phase 3, this guide will show how to
-register `doiget` as an MCP server in Cursor so that DOI resolution, metadata
-fetch, and the other tools listed in [`../MCP_TOOLS.md`](../MCP_TOOLS.md) are
-callable from Cursor's agent.
-
-## Configuration (Phase 3)
-
-The example below is intentionally empty. Do not copy speculative JSON from
-elsewhere — wait for the verified Phase 3 snippet.
+[Cursor](https://www.cursor.com/) supports MCP servers. Configuration is a
+`mcp.json` file: `.cursor/mcp.json` inside a project, or `~/.cursor/mcp.json`
+for every project.
 
 ```json
-<!-- TODO Phase 3: paste verified Cursor MCP server entry here. -->
+{
+  "mcpServers": {
+    "doiget": {
+      "command": "doiget",
+      "args": ["serve"],
+      "env": {
+        "DOIGET_STORE_ROOT": "/Users/you/papers",
+        "DOIGET_CONTACT_EMAIL": "you@institution.edu"
+      }
+    }
+  }
+}
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+Use an absolute `command` path if `doiget` is not on the `PATH` the editor
+inherits.
 
-## What to read in the meantime
+## Environment
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+Identical to every other host — see [`claude-code.md`](./claude-code.md)
+§Environment. `DOIGET_STORE_ROOT` is the one that silently misbehaves if
+omitted (ADR-0036, #369).
 
-## Contributing
+## Checking it worked
 
-If you have a working Cursor integration ahead of Phase 3, open a GitHub
-Discussion with the JSON-RPC trace and host-side config rather than a PR — see
-[`README.md`](./README.md) §Contributing a snippet.
+Have the agent call `doiget_health`. If Cursor's own MCP panel reports the
+server as connected but no tool is callable, `doiget_capability_profile` will
+say what this build is allowed to do.
+
+Tool surface: [`../MCP_TOOLS.md`](../MCP_TOOLS.md).

--- a/docs/INTEGRATION/obsidian.md
+++ b/docs/INTEGRATION/obsidian.md
@@ -1,42 +1,42 @@
-# Obsidian backend export
+# Obsidian
 
-> **Status: PLACEHOLDER (Phase 3).** This file is a landing stub. Concrete
-> configuration lands when `doiget serve` is real. See
-> [`README.md`](./README.md) for the planned-files table and rationale.
-> Note: per the planned-files table, an Obsidian backend export is scoped to
-> **Phase 7 (optional)** — this stub exists so future contributors have an
-> obvious landing place rather than a 404.
+> **Status: NOT IMPLEMENTED, and this page says what does work instead.**
+> There is no Obsidian backend export and none is in progress. The
+> "Phase 7 (optional)" marker in the planned-files table is the only
+> commitment, and it is not a schedule. Last checked 2026-08-26.
 
-[Obsidian](https://obsidian.md/) is a markdown-based knowledge base. The
-Phase 7 Obsidian backend export will, when shipped, let `doiget` write
-metadata and citation records into an Obsidian vault as plain Markdown notes
-with frontmatter, so that the same data exposed by the MCP tools in
-[`../MCP_TOOLS.md`](../MCP_TOOLS.md) can be browsed inside Obsidian.
+Obsidian does not host MCP servers, so there is nothing to register. What
+exists today is that doiget's store is **plain files**, so a vault can sit on
+top of it with no integration at all.
 
-## Configuration (Phase 3)
+## What doiget writes
 
-The example below is intentionally empty. The Obsidian backend export is a
-Phase 7 deliverable; even the Phase 3 wiring is not yet implemented.
+One TOML sidecar and one PDF per entry, under `DOIGET_STORE_ROOT`. The layout
+and the field contract are in [`../STORE.md`](../STORE.md).
 
-```toml
-<!-- TODO Phase 3: paste verified Obsidian export config block here. -->
+Point the store at a folder inside your vault:
+
+```sh
+export DOIGET_STORE_ROOT="$HOME/Vault/papers"
+doiget fetch 10.1103/PhysRevLett.130.200601
 ```
 
-```toml
-<!-- TODO Phase 3: env-var block (see ../CONFIG.md for precedence). -->
-```
+The PDFs are then openable from Obsidian, and the sidecars are readable text.
+They are **TOML, not Markdown with YAML frontmatter**, so Obsidian will not
+index them as notes and Dataview will not see them.
 
-## What to read in the meantime
+## What is missing, precisely
 
-- **Tool surface:** [`../MCP_TOOLS.md`](../MCP_TOOLS.md) — the exact tools
-  Phase 3 exposes, including JSON-Schema for inputs and outputs.
-- **Configuration:** [`../CONFIG.md`](../CONFIG.md) — env-var precedence and
-  the `~/.config/doiget/` layout that any host wiring must respect.
-- **Architecture:** [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §4-6 — transport
-  and capability-gate context for MCP integration.
+A Markdown-with-frontmatter projection of the sidecar. That is the whole of
+the "Obsidian backend export" idea, and it is not implemented — not the wiring,
+not the frontmatter schema, not a `doiget` subcommand.
+
+`doiget csl <ref>` and `doiget bib <ref>` emit CSL-JSON and BibTeX from the
+same records, which is enough to script a projection yourself.
 
 ## Contributing
 
-If you have a working Obsidian export workflow ahead of Phase 7, open a
-GitHub Discussion describing the vault layout and frontmatter shape rather
-than a PR — see [`README.md`](./README.md) §Contributing a snippet.
+If you build one, open a
+[GitHub Discussion](https://github.com/QAtlasHub/doiget/discussions) with the
+vault layout and the frontmatter shape before a PR — the schema is the part
+worth agreeing on first.

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -211,30 +211,44 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from **environment variables**
-   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
-   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
-   `tracing` redactor.
+   binary. Keys are read at runtime from `DOIGET_KEY_<PUBLISHER>` or, one rung
+   below it, `[tdm.<publisher>] api_key` in `~/.config/doiget/credentials.toml`;
+   either way they are wrapped in `secrecy::Secret` and never logged in raw
+   form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the `tracing`
+   redactor; `doiget_core::credentials`.
 
-   Two corrections here (#494):
+   Two corrections here (#494), one of which has since been closed the other way:
 
    - This said credentials are also read from `~/.config/doiget/credentials.toml`.
-     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
-     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
-     specifies it in full anyway, which is tracked as #509. A user following that
-     section today writes a key into a file doiget ignores.
+     At the time they were not — `docs/CONFIG.md` §6 specified the file in full
+     and no code path opened it (#509). **As of 0.8.11 the sentence is true
+     again**, because the reader was built rather than the specification
+     deleted: a long-lived key is better off in a `0600` file than in the
+     environment of every subprocess, and the permission warning §6 promised now
+     exists too (ADR-0050). The **agreement** did not move — see §6a.2.
    - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
      check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
-     imports, telemetry imports and non-rustls TLS backends; there is no secret
-     scanner in the tree. §6a is defined as controls a machine enforces, so an
-     enforcement clause that names nothing does not belong in it. The safeguard
-     itself stands on the type-level ones that are real.
+     imports, telemetry imports, non-rustls TLS backends and the npm platform
+     mapping; there is no secret scanner in the tree. §6a is defined as controls
+     a machine enforces, so an enforcement clause that names nothing does not
+     belong in it. The safeguard itself stands on the type-level ones that are
+     real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
-   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
-   `DOIGET_KEY_<PUBLISHER>`. Missing or partial configurations fail closed at
-   `CapabilityProfile::from_env`. *Enforced by:* `CapabilityProfile`
-   resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
+   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, AND
+   to provide a key (env var or `credentials.toml`, §6a.1). Missing or partial
+   configurations fail closed at `CapabilityProfile::from_env`. *Enforced by:*
+   `CapabilityProfile` resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2
+   rules 2 and 3).
+
+   **The agreement is environment-only, and deliberately did not follow the key
+   into the file** (ADR-0050). Part of what makes this control meaningful is
+   that it is an act taken in the session that runs the fetch; a boolean written
+   once into a config file and forgotten is a weaker consent, and letting a
+   convenience dilute an enforced control is the kind of accident ADR-0048 was
+   written about. An `agreed` key in `credentials.toml` is parsed only so doiget
+   can warn that it grants nothing — a documented field with no reader being the
+   defect #509 was about in the first place.
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
    (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -81,11 +81,36 @@ Given a ref, doiget attempts retrieval from exactly two kinds of location:
 **(a) A location an enabled source reported.** The URL appears verbatim in a response
 doiget received from a source that both the build and the runtime capability profile
 have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
-and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+and - only when the content leg was already blocked - CORE's `downloadUrl`, HAL's
 `fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
 behind its own `DOIGET_ENABLE_*` flag.
 *Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
 per-source extractor and returns `None` for any other source name.
+
+**(a-i) Crossref `link[]` is NOT one of them, and this was measured.** #517 asked
+whether the fetch path should carry the publisher link Crossref reports, so that a
+user on a subscribing network reaches the publisher instead of exiting 0 in silence.
+It should not, and the reason is what Crossref actually returns.
+
+Every `link[]` entry carries `intended-application`. `unspecified` would be a general
+full-text link; `text-mining`, `similarity-checking` and `syndication` scope the URL to
+a specific licensed programme. Measured 2026-08-26 across **six live DOIs** (SIAM,
+IEEE, AMS, ACM, Springer Nature, the Royal Society) and the **eight captured
+responses** in `tests/fixtures/real_world/` - 12 entries in total - **not one carried
+`unspecified`.** Every one was `text-mining` or `similarity-checking`.
+
+So Crossref `link[]` is a programme-scoped channel, not a general full-text one.
+Following it would mean using Similarity Check and TDM links without holding those
+licences - and doiget already has the licensed route: its Tier-3 TDM sources, with the
+user's own credential and a recorded per-publisher agreement (§6a.2). The ceiling is
+unchanged (ADR-0052).
+
+*Enforced by:* `orchestrator::extract_crossref_publisher_url`, which accepts only
+`unspecified` and refuses an unlabelled entry as well - an unlabelled link is a guess,
+and the line this section draws is documented-by-the-vendor versus guessed-by-us
+(ADR-0048 D2). Before #517 that function returned the first entry with no filtering,
+so `MetadataOnlyOutcome.oa_url` could hand a caller a Similarity Check URL under the
+name `oa_url`.
 
 **(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
 the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's

--- a/npm/doiget-darwin-arm64/package.json
+++ b/npm/doiget-darwin-arm64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "doiget-darwin-arm64",
+  "version": "0.0.0",
+  "description": "Prebuilt doiget binary for darwin arm64. Installed automatically as an optionalDependency of `doiget`; not useful on its own.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QAtlasHub/doiget.git"
+  },
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["bin/"]
+}

--- a/npm/doiget-darwin-x64/package.json
+++ b/npm/doiget-darwin-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "doiget-darwin-x64",
+  "version": "0.0.0",
+  "description": "Prebuilt doiget binary for darwin x64. Installed automatically as an optionalDependency of `doiget`; not useful on its own.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QAtlasHub/doiget.git"
+  },
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "files": ["bin/"]
+}

--- a/npm/doiget-linux-x64/package.json
+++ b/npm/doiget-linux-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "doiget-linux-x64",
+  "version": "0.0.0",
+  "description": "Prebuilt doiget binary for linux x64. Installed automatically as an optionalDependency of `doiget`; not useful on its own.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QAtlasHub/doiget.git"
+  },
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["bin/"]
+}

--- a/npm/doiget-win32-x64/package.json
+++ b/npm/doiget-win32-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "doiget-win32-x64",
+  "version": "0.0.0",
+  "description": "Prebuilt doiget binary for win32 x64. Installed automatically as an optionalDependency of `doiget`; not useful on its own.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QAtlasHub/doiget.git"
+  },
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "files": ["bin/"]
+}

--- a/npm/doiget/bin/doiget.js
+++ b/npm/doiget/bin/doiget.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Locate the platform binary npm already installed, and exec it.
+//
+// There is deliberately NO postinstall download here. `--ignore-scripts` is
+// standard policy in many corporate npm setups, enterprises consume npm
+// through a mirror that a GitHub fetch would bypass, a downloaded file is
+// outside npm's integrity hashes, and "downloads a binary at install time"
+// is the exact supply-chain shape a security review flags. The binaries are
+// `optionalDependencies`, so npm resolves exactly one of them and it is
+// covered by the registry's integrity and by any mirror.
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+
+// npm's `os`/`cpu` fields use these names; the release assets use
+// x86_64/aarch64. The mapping lives here and in the release workflow, and
+// `npm-packages-cover-every-release-asset` in that workflow keeps them in
+// step.
+const PACKAGES = {
+  "darwin-arm64": "doiget-darwin-arm64",
+  "darwin-x64": "doiget-darwin-x64",
+  "linux-x64": "doiget-linux-x64",
+  "win32-x64": "doiget-win32-x64",
+};
+
+const key = `${process.platform}-${process.arch}`;
+const pkg = PACKAGES[key];
+
+if (!pkg) {
+  process.stderr.write(
+    `doiget: no prebuilt binary for ${key}.\n` +
+      `Supported: ${Object.keys(PACKAGES).join(", ")}.\n` +
+      `Install from source instead: cargo install doiget-cli\n` +
+      `(needs a C/C++ linker — see https://github.com/QAtlasHub/doiget#installation)\n`,
+  );
+  process.exit(2);
+}
+
+let binary;
+try {
+  binary = require.resolve(`${pkg}/bin/${process.platform === "win32" ? "doiget.exe" : "doiget"}`);
+} catch {
+  process.stderr.write(
+    `doiget: the platform package \`${pkg}\` is not installed.\n` +
+      `It is an optionalDependency, so npm skips it silently when installation fails.\n` +
+      `Try: npm install --include=optional ${pkg}\n`,
+  );
+  process.exit(2);
+}
+
+// `stdio: "inherit"` is load-bearing: `doiget serve` speaks MCP over stdio,
+// so the JSON-RPC stream must be the parent's, not a pipe this shim relays.
+const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  process.stderr.write(`doiget: could not execute ${binary}: ${result.error.message}\n`);
+  process.exit(1);
+}
+// Preserve the signal-death convention so `timeout`/CI see what they expect.
+process.exit(result.status === null ? 1 : result.status);

--- a/npm/doiget/bin/doiget.js
+++ b/npm/doiget/bin/doiget.js
@@ -12,19 +12,12 @@
 
 const { spawnSync } = require("node:child_process");
 
-// npm's `os`/`cpu` fields use these names; the release assets use
-// x86_64/aarch64. The mapping lives here and in the release workflow, and
-// `npm-packages-cover-every-release-asset` in that workflow keeps them in
-// step.
-const PACKAGES = {
-  "darwin-arm64": "doiget-darwin-arm64",
-  "darwin-x64": "doiget-darwin-x64",
-  "linux-x64": "doiget-linux-x64",
-  "win32-x64": "doiget-win32-x64",
-};
+// The platform table lives in `platform.js` so it can be unit-tested; this
+// file is the thin exec wrapper around it.
+const { PACKAGES, packageFor, binaryName } = require("./platform.js");
 
 const key = `${process.platform}-${process.arch}`;
-const pkg = PACKAGES[key];
+const pkg = packageFor(process.platform, process.arch);
 
 if (!pkg) {
   process.stderr.write(
@@ -38,7 +31,7 @@ if (!pkg) {
 
 let binary;
 try {
-  binary = require.resolve(`${pkg}/bin/${process.platform === "win32" ? "doiget.exe" : "doiget"}`);
+  binary = require.resolve(`${pkg}/bin/${binaryName(process.platform)}`);
 } catch {
   process.stderr.write(
     `doiget: the platform package \`${pkg}\` is not installed.\n` +

--- a/npm/doiget/bin/platform.js
+++ b/npm/doiget/bin/platform.js
@@ -3,7 +3,7 @@
 // `doiget.js` used to hold this inline, which meant the npm packaging had
 // no executable test at all — only a grep in posture-lint comparing name
 // lists across three files. A grep cannot catch a wrong `require.resolve`
-// path or a mis-forwarded exit code.
+// path or an exit code forwarded wrongly.
 "use strict";
 
 // npm's `os`/`cpu` vocabulary. The release assets use x86_64/aarch64; the

--- a/npm/doiget/bin/platform.js
+++ b/npm/doiget/bin/platform.js
@@ -1,0 +1,29 @@
+// The platform → package-name table, split out so it can be tested.
+//
+// `doiget.js` used to hold this inline, which meant the npm packaging had
+// no executable test at all — only a grep in posture-lint comparing name
+// lists across three files. A grep cannot catch a wrong `require.resolve`
+// path or a mis-forwarded exit code.
+"use strict";
+
+// npm's `os`/`cpu` vocabulary. The release assets use x86_64/aarch64; the
+// mapping between the two lives here, in `scripts/stage-npm.sh`, and in the
+// release matrix, and posture-lint checks all three agree.
+const PACKAGES = {
+  "darwin-arm64": "doiget-darwin-arm64",
+  "darwin-x64": "doiget-darwin-x64",
+  "linux-x64": "doiget-linux-x64",
+  "win32-x64": "doiget-win32-x64",
+};
+
+/** Package name for a platform/arch pair, or null when unsupported. */
+function packageFor(platform, arch) {
+  return PACKAGES[`${platform}-${arch}`] || null;
+}
+
+/** Binary name inside the platform package. */
+function binaryName(platform) {
+  return platform === "win32" ? "doiget.exe" : "doiget";
+}
+
+module.exports = { PACKAGES, packageFor, binaryName };

--- a/npm/doiget/package.json
+++ b/npm/doiget/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "doiget",
+  "version": "0.0.0",
+  "description": "Turn DOIs and arXiv IDs into local PDFs and metadata via official Open-Access APIs. CLI + stdio MCP server. Never bypasses paywalls.",
+  "keywords": ["doi", "arxiv", "open-access", "mcp", "modelcontextprotocol", "bibliography", "crossref", "unpaywall", "research"],
+  "homepage": "https://github.com/QAtlasHub/doiget#readme",
+  "bugs": "https://github.com/QAtlasHub/doiget/issues",
+  "license": "MIT",
+  "author": "Sota Shimozono",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QAtlasHub/doiget.git"
+  },
+  "bin": {
+    "doiget": "bin/doiget.js"
+  },
+  "files": ["bin/", "README.md"],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "doiget-darwin-arm64": "0.0.0",
+    "doiget-darwin-x64": "0.0.0",
+    "doiget-linux-x64": "0.0.0",
+    "doiget-win32-x64": "0.0.0"
+  }
+}

--- a/npm/doiget/test/platform.test.js
+++ b/npm/doiget/test/platform.test.js
@@ -1,0 +1,78 @@
+// Executable tests for the npm packaging (#511 follow-up).
+//
+// The packaging previously had NO test that ran anything — only a
+// posture-lint grep comparing name lists across three files. A grep cannot
+// catch a wrong binary name, a missing platform, or a table that agrees
+// with itself while naming the wrong thing.
+//
+// Run: node npm/doiget/test/platform.test.js
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { PACKAGES, packageFor, binaryName } = require("../bin/platform.js");
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`ok    ${name}`);
+  } catch (e) {
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+    failures += 1;
+  }
+}
+
+test("every supported platform resolves to a package", () => {
+  assert.strictEqual(packageFor("darwin", "arm64"), "doiget-darwin-arm64");
+  assert.strictEqual(packageFor("darwin", "x64"), "doiget-darwin-x64");
+  assert.strictEqual(packageFor("linux", "x64"), "doiget-linux-x64");
+  assert.strictEqual(packageFor("win32", "x64"), "doiget-win32-x64");
+});
+
+test("an unsupported platform is null, not undefined or a throw", () => {
+  assert.strictEqual(packageFor("freebsd", "x64"), null);
+  assert.strictEqual(packageFor("linux", "arm64"), null, "linux-arm64 is not built yet");
+});
+
+test("only Windows gets the .exe suffix", () => {
+  assert.strictEqual(binaryName("win32"), "doiget.exe");
+  assert.strictEqual(binaryName("linux"), "doiget");
+  assert.strictEqual(binaryName("darwin"), "doiget");
+});
+
+test("every package in the table exists on disk with a matching manifest", () => {
+  const root = path.join(__dirname, "..", "..");
+  for (const pkg of Object.values(PACKAGES)) {
+    const manifest = path.join(root, pkg, "package.json");
+    assert.ok(fs.existsSync(manifest), `${pkg}/package.json is missing`);
+    const parsed = JSON.parse(fs.readFileSync(manifest, "utf8"));
+    assert.strictEqual(parsed.name, pkg, `${pkg} manifest names ${parsed.name}`);
+    assert.ok(Array.isArray(parsed.os) && parsed.os.length === 1, `${pkg} needs one os`);
+    assert.ok(Array.isArray(parsed.cpu) && parsed.cpu.length === 1, `${pkg} needs one cpu`);
+    // The directory name encodes os-cpu; the manifest must agree with it.
+    assert.strictEqual(`doiget-${parsed.os[0]}-${parsed.cpu[0]}`, pkg);
+  }
+});
+
+test("the wrapper declares exactly the packages in the table", () => {
+  const wrapper = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+  );
+  assert.deepStrictEqual(
+    Object.keys(wrapper.optionalDependencies).sort(),
+    Object.values(PACKAGES).sort(),
+    "optionalDependencies and the platform table disagree",
+  );
+});
+
+test("the wrapper ships the shim and the table it requires", () => {
+  const dir = path.join(__dirname, "..", "bin");
+  for (const f of ["doiget.js", "platform.js"]) {
+    assert.ok(fs.existsSync(path.join(dir, f)), `bin/${f} is missing`);
+  }
+});
+
+process.exit(failures === 0 ? 0 : 1);

--- a/npm/doiget/test/release-checksums.test.sh
+++ b/npm/doiget/test/release-checksums.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Runs the npm-publish checksum-verification loop out of release-plz.yml
+# against a synthetic download directory.
+#
+# That loop is the fix for the defect this cluster started from: the download
+# step used `-p 'doiget-*.sha256'`, which also matched the SBOM's and the
+# .mcpb's checksums, whose payloads are never downloaded — so `sha256sum -c`
+# failed on every release, inside a job that is `continue-on-error`. It had
+# no test at all: the one surface where a silent failure had already happened
+# was verified by prose.
+#
+# The loop is extracted from the workflow rather than copied, so this test
+# cannot drift into agreeing with a stale duplicate of it.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/release-plz.yml"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+fail=0
+check() {
+  if [ "$1" = "ok" ]; then echo "ok    $2"; else echo "FAIL  $2"; fail=1; fi
+}
+
+# Pull the `for f in *.sha256` block out of the workflow and strip its YAML
+# indentation. If the block is renamed or removed, this fails loudly rather
+# than silently testing nothing.
+awk '/^ *verified=0$/{on=1} on{print} /expected 4/{tail=1} tail && /^ *fi$/{exit}' "$WORKFLOW" | sed 's/^ \{0,10\}//' > "$WORK/loop.sh"
+if [ ! -s "$WORK/loop.sh" ] || ! grep -q 'expected 4' "$WORK/loop.sh"; then
+  echo "FAIL  could not extract the checksum loop from $WORKFLOW"
+  exit 1
+fi
+
+# The four platform binaries a release actually publishes.
+ASSETS="doiget-linux-x86_64 doiget-macos-aarch64 doiget-macos-x86_64 doiget-windows-x86_64.exe"
+
+seed() {
+  local dir="$1"
+  mkdir -p "$dir"
+  for a in $ASSETS; do
+    printf 'fake-binary-%s' "$a" > "$dir/$a"
+    ( cd "$dir" && sha256sum "$a" > "$a.sha256" )
+  done
+}
+
+run_loop() {
+  ( cd "$1" && bash "$WORK/loop.sh" > "$1/out" 2>&1; echo $? )
+}
+
+# 1. A clean release verifies all four and exits 0.
+seed "$WORK/clean"
+rc="$(run_loop "$WORK/clean")"
+if [ "$rc" = "0" ]; then
+  check ok "a complete release verifies"
+else
+  check no "a complete release verifies"
+  cat "$WORK/clean/out"
+fi
+
+# 2. A checksum whose payload was never downloaded must fail. This is the
+#    exact shape of the original bug: the SBOM's .sha256 arrived, its
+#    payload did not.
+seed "$WORK/orphan"
+sed 's/doiget-linux-x86_64/doiget-sbom.spdx.json/' "$WORK/orphan/doiget-linux-x86_64.sha256" \
+  > "$WORK/orphan/doiget-sbom.spdx.json.sha256"
+rc="$(run_loop "$WORK/orphan")"
+if [ "$rc" != "0" ]; then
+  check ok "an orphaned checksum fails the job"
+else
+  check no "an orphaned checksum fails the job"
+  cat "$WORK/orphan/out"
+fi
+
+# 3. A release missing one platform binary must fail on the count rather
+#    than pass quietly having verified three. That is what `-ne 4` is for.
+seed "$WORK/short"
+rm -f "$WORK/short/doiget-macos-aarch64" "$WORK/short/doiget-macos-aarch64.sha256"
+rc="$(run_loop "$WORK/short")"
+if [ "$rc" != "0" ]; then
+  check ok "a missing platform binary fails the count"
+else
+  check no "a missing platform binary fails the count"
+  cat "$WORK/short/out"
+fi
+if grep -q 'expected 4' "$WORK/short/out"; then
+  check ok "the count failure says what was expected"
+else
+  check no "the count failure says what was expected"
+  cat "$WORK/short/out"
+fi
+
+# 4. A tampered binary must fail verification.
+seed "$WORK/corrupt"
+printf 'tampered' > "$WORK/corrupt/doiget-linux-x86_64"
+rc="$(run_loop "$WORK/corrupt")"
+if [ "$rc" != "0" ]; then
+  check ok "a corrupted binary fails verification"
+else
+  check no "a corrupted binary fails verification"
+  cat "$WORK/corrupt/out"
+fi
+
+exit "$fail"

--- a/npm/doiget/test/stage-npm.test.sh
+++ b/npm/doiget/test/stage-npm.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Runs scripts/stage-npm.sh against fixture binaries and checks the layout it
+# produces (#511 follow-up).
+#
+# The script had no executable test at all — only a posture-lint grep
+# comparing name lists across three files. A grep cannot catch a sed that
+# stops stamping the version, a cp that drops the shim, or a missing-asset
+# guard that has stopped guarding. Those would surface only at release time,
+# inside a job that is `continue-on-error`.
+#
+# Everything happens inside a mktemp directory; the repository is read-only
+# to this test.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+for a in doiget-linux-x86_64 doiget-macos-aarch64 doiget-macos-x86_64 doiget-windows-x86_64.exe; do
+  printf 'fake-binary-%s' "$a" > "$BIN/$a"
+done
+
+if ! bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out" > "$WORK/log" 2>&1; then
+  echo "FAIL  stage-npm.sh exited non-zero"
+  cat "$WORK/log"
+  exit 1
+fi
+
+fail=0
+check() {
+  if [ "$1" = "ok" ]; then
+    echo "ok    $2"
+  else
+    echo "FAIL  $2"
+    fail=1
+  fi
+}
+
+for d in doiget doiget-darwin-arm64 doiget-darwin-x64 doiget-linux-x64 doiget-win32-x64; do
+  if [ -d "$WORK/out/$d" ]; then check ok "staged $d"; else check no "staged $d"; fi
+done
+
+# Every manifest carries the stamped version, never the 0.0.0 placeholder.
+for f in "$WORK/out"/*/package.json; do
+  name="$(basename "$(dirname "$f")")"
+  if grep -q '"0\.0\.0"' "$f"; then
+    check no "version stamped in $name"
+  else
+    check ok "version stamped in $name"
+  fi
+done
+
+if grep -q '"version": "9.9.9"' "$WORK/out/doiget/package.json"; then
+  check ok "wrapper version is 9.9.9"
+else
+  check no "wrapper version is 9.9.9"
+fi
+
+# The wrapper pins its platform packages to the exact same version; a drift
+# here publishes a wrapper that resolves nothing.
+if grep -q '"doiget-linux-x64": "9.9.9"' "$WORK/out/doiget/package.json"; then
+  check ok "optionalDependencies pinned to the same version"
+else
+  check no "optionalDependencies pinned to the same version"
+fi
+
+# Windows keeps the .exe suffix; the others must not.
+if [ -f "$WORK/out/doiget-win32-x64/bin/doiget.exe" ]; then
+  check ok "win32 binary is doiget.exe"
+else
+  check no "win32 binary is doiget.exe"
+fi
+if [ -f "$WORK/out/doiget-linux-x64/bin/doiget" ]; then
+  check ok "linux binary is doiget"
+else
+  check no "linux binary is doiget"
+fi
+
+# The shim and the table it requires must both ship, or `npx doiget` throws
+# MODULE_NOT_FOUND on first run.
+for f in doiget.js platform.js; do
+  if [ -f "$WORK/out/doiget/bin/$f" ]; then
+    check ok "wrapper ships bin/$f"
+  else
+    check no "wrapper ships bin/$f"
+  fi
+done
+
+# A missing release asset must fail loudly rather than stage a package with
+# no binary in it.
+rm -f "$BIN/doiget-linux-x86_64"
+if bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out2" >/dev/null 2>&1; then
+  check no "a missing release asset fails the staging script"
+else
+  check ok "a missing release asset fails the staging script"
+fi
+
+exit "$fail"

--- a/npm/doiget/test/stage-npm.test.sh
+++ b/npm/doiget/test/stage-npm.test.sh
@@ -92,11 +92,30 @@ done
 
 # A missing release asset must fail loudly rather than stage a package with
 # no binary in it.
+#
+# The exit code alone proves nothing: `set -euo pipefail` makes the `cp` after
+# the guard fail too, so deleting the guard outright still exits non-zero —
+# with a raw `cp: cannot stat` instead of the `::error::` annotation, and,
+# since `mkdir`/`stamp_version` run before that `cp`, with a half-staged
+# package left on disk. So assert on the annotation AND on the absence of the
+# wreckage, never on the exit code alone.
 rm -f "$BIN/doiget-linux-x86_64"
-if bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out2" >/dev/null 2>&1; then
+if bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out2" > "$WORK/log2" 2>&1; then
   check no "a missing release asset fails the staging script"
 else
   check ok "a missing release asset fails the staging script"
+fi
+if grep -q '::error::missing release asset' "$WORK/log2"; then
+  check ok "the failure names the missing asset"
+else
+  check no "the failure names the missing asset"
+  cat "$WORK/log2"
+fi
+if [ -e "$WORK/out2/doiget-linux-x64" ]; then
+  check no "no half-staged package is left behind"
+  find "$WORK/out2/doiget-linux-x64" -print
+else
+  check ok "no half-staged package is left behind"
 fi
 
 exit "$fail"

--- a/scripts/stage-npm.sh
+++ b/scripts/stage-npm.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# stage-npm.sh — assemble the npm packages for a release (#511).
+#
+#   scripts/stage-npm.sh <version> <bindir> <outdir>
+#
+# <bindir> holds the release assets as downloaded from the GitHub Release
+# (`doiget-linux-x86_64`, `doiget-macos-aarch64`, `doiget-macos-x86_64`,
+# `doiget-windows-x86_64.exe`). <outdir> is created and filled with one
+# directory per package, each ready for `npm publish`.
+#
+# Layout, and why: the wrapper `doiget` declares the four platform packages
+# as `optionalDependencies`, so npm resolves exactly the one matching the
+# host and skips the rest. There is deliberately NO postinstall download —
+# see `npm/doiget/bin/doiget.js` for the four reasons.
+#
+# The asset names use x86_64/aarch64; npm's `cpu` field uses x64/arm64. That
+# mapping lives HERE and in `npm/doiget/bin/doiget.js`, and the
+# `npm-mapping` check in `.github/workflows/ci.yml` fails if the two drift.
+#
+# Dependency-light bash on purpose, matching scripts/build-mcpb.sh.
+
+set -euo pipefail
+
+VERSION="${1:?usage: stage-npm.sh <version> <bindir> <outdir>}"
+BINDIR="${2:?usage: stage-npm.sh <version> <bindir> <outdir>}"
+OUTDIR="${3:?usage: stage-npm.sh <version> <bindir> <outdir>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC="$REPO_ROOT/npm"
+
+[ -d "$SRC" ] || { echo "::error::npm/ template directory not found at $SRC" >&2; exit 1; }
+
+# Refuse to reuse a stale staging directory rather than deleting one the
+# caller may not have meant to name.
+[ -e "$OUTDIR" ] && { echo "::error::$OUTDIR already exists; remove it or pass a fresh path" >&2; exit 1; }
+mkdir -p "$OUTDIR"
+
+# pkg-name : release-asset : binary-name-inside-the-package
+MAP="
+doiget-darwin-arm64:doiget-macos-aarch64:doiget
+doiget-darwin-x64:doiget-macos-x86_64:doiget
+doiget-linux-x64:doiget-linux-x86_64:doiget
+doiget-win32-x64:doiget-windows-x86_64.exe:doiget.exe
+"
+
+# `0.0.0` is the placeholder in every template manifest; the release stamps
+# the real version so nothing in the tree is bumped by hand and drift is
+# impossible. `mcpb/manifest.json` uses the same trick via jq.
+stamp_version() {
+  sed "s/\"0\.0\.0\"/\"$VERSION\"/g" "$1" > "$2"
+}
+
+echo "$MAP" | while IFS=: read -r pkg asset binname; do
+  [ -n "$pkg" ] || continue
+  [ -f "$BINDIR/$asset" ] || { echo "::error::missing release asset $BINDIR/$asset for $pkg" >&2; exit 1; }
+  mkdir -p "$OUTDIR/$pkg/bin"
+  stamp_version "$SRC/$pkg/package.json" "$OUTDIR/$pkg/package.json"
+  cp "$BINDIR/$asset" "$OUTDIR/$pkg/bin/$binname"
+  chmod +x "$OUTDIR/$pkg/bin/$binname"
+  echo "staged $pkg  <- $asset"
+done
+
+mkdir -p "$OUTDIR/doiget/bin"
+stamp_version "$SRC/doiget/package.json" "$OUTDIR/doiget/package.json"
+cp "$SRC/doiget/bin/doiget.js" "$OUTDIR/doiget/bin/doiget.js"
+cp "$REPO_ROOT/crates/doiget-cli/README.md" "$OUTDIR/doiget/README.md"
+echo "staged doiget (wrapper)"
+
+echo
+echo "npm packages staged in $OUTDIR at version $VERSION"

--- a/scripts/stage-npm.sh
+++ b/scripts/stage-npm.sh
@@ -15,7 +15,8 @@
 #
 # The asset names use x86_64/aarch64; npm's `cpu` field uses x64/arm64. That
 # mapping lives HERE and in `npm/doiget/bin/doiget.js`, and the
-# `npm-mapping` check in `.github/workflows/ci.yml` fails if the two drift.
+# `npm platform packages cover every release binary` step in
+# `.github/workflows/posture-lint.yml` fails if they drift.
 #
 # Dependency-light bash on purpose, matching scripts/build-mcpb.sh.
 
@@ -63,7 +64,11 @@ done
 
 mkdir -p "$OUTDIR/doiget/bin"
 stamp_version "$SRC/doiget/package.json" "$OUTDIR/doiget/package.json"
-cp "$SRC/doiget/bin/doiget.js" "$OUTDIR/doiget/bin/doiget.js"
+# Every file under bin/, not just the entry point: the shim `require`s
+# `platform.js`, and copying only `doiget.js` publishes a package that
+# throws MODULE_NOT_FOUND on first run. Caught by
+# `npm/doiget/test/stage-npm.test.sh`.
+cp "$SRC"/doiget/bin/*.js "$OUTDIR/doiget/bin/"
 cp "$REPO_ROOT/crates/doiget-cli/README.md" "$OUTDIR/doiget/README.md"
 echo "staged doiget (wrapper)"
 

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -186,7 +186,7 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 | `DOIGET_ENABLE_OPENAIRE` | presence | Enables OpenAIRE (European repository aggregation, Graph API v1). Mixed access rights: only a COAR `c_abf2` (OPEN) `bestAccessRight` is accepted; EMBARGO / RESTRICTED / CLOSED / absent are refused (#416). |
 | `DOIGET_ENABLE_CORE` | presence | Enables CORE, the broadest cross-repository OA index and therefore the last fallback in the chain (#417). |
 | `DOIGET_CORE_API_KEY` | value | **Optional.** Your own free CORE key, raising the rate limit. Absent (or blank) degrades to the key-less limit rather than failing. Never bundled; sent as a bearer header and never logged. A 401/403 with a key set is reported as a transport error, distinct from "not found", so a bad key does not look like a missing paper. |
-| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). OA subset only: gated on `isOpenAccess`, **not** `inEPMC` — a record can be in the archive while its full text is subscription-only (#415). |
+| `DOIGET_ENABLE_EUROPE_PMC` | presence | Enables Europe PMC (biomedical OA full text Unpaywall does not index). Gated on the record advertising a retrievable PDF — a `fullTextUrlList` entry with `documentStyle = pdf` and `availabilityCode` `F` or `OA` (#503) — **not** on `inEPMC` (presence is not openness, #415) and **not** on `isOpenAccess` (bulk-subset membership, which is reported rather than a veto). |
 | `DOIGET_AGREE_TDM_ELSEVIER` | `=1` | Acknowledges Elsevier TDM ToS. Pairs with key. |
 | `DOIGET_KEY_ELSEVIER` | secret string | Elsevier API key. Read into `Secret<String>`. |
 | `DOIGET_AGREE_TDM_APS` | `=1` | Acknowledges APS Harvest TDM ToS. |

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -133,9 +133,13 @@ impl CapabilityProfile {
     }
 }
 
-fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, CapabilityError> {
+// `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
+// BELOW the env var (#509, ADR-0050). The agreement has no file rung.
+fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+    -> Result<Option<TdmGrant>, CapabilityError>
+{
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
-    let key    = env::var(key_var).ok();
+    let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {
         (true, Some(k)) => Ok(Some(TdmGrant {
             // `secrecy` 0.10: `SecretString::from(String)` replaces the
@@ -158,6 +162,15 @@ fn read_tdm_grant(agree_var: &str, key_var: &str) -> Result<Option<TdmGrant>, Ca
 ```
 
 ### Three resolution rules
+
+The **key** may come from `DOIGET_KEY_<PUBLISHER>` or from
+`[tdm.<publisher>] api_key` in `credentials.toml`, env first
+([`CONFIG.md`](CONFIG.md) §6). The **agreement** has no file rung: it is
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` in the environment or it does not exist, so
+that it is an act taken in the session that runs the fetch rather than a
+boolean written once and forgotten ([`LEGAL.md`](LEGAL.md) §6a.2, ADR-0050).
+The three rules below are unchanged by that — a key from the file still needs
+the agreement, so rule 3 now also fires for a file-supplied key.
 
 1. **`agree=1` + key present** → `Some(TdmGrant)`. The source is enabled this session.
 2. **`agree=1` but key missing** → `Err(AgreedButNoKey)`. Startup fails; user has agreed

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -124,10 +124,10 @@ impl CapabilityProfile {
                 core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
                 europe_pmc:      env::var("DOIGET_ENABLE_EUROPE_PMC").is_ok(),
             },
-            tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
-            tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
-            tdm_springer: read_tdm_grant("DOIGET_AGREE_TDM_SPRINGER", "DOIGET_KEY_SPRINGER")?,
-            tdm_ieee:     read_tdm_grant("DOIGET_AGREE_TDM_IEEE",     "DOIGET_KEY_IEEE")?,
+            tdm_elsevier: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"), KeyVar::new("DOIGET_KEY_ELSEVIER"))?,
+            tdm_aps:      read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_APS"),      KeyVar::new("DOIGET_KEY_APS"))?,
+            tdm_springer: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_SPRINGER"), KeyVar::new("DOIGET_KEY_SPRINGER"))?,
+            tdm_ieee:     read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_IEEE"),     KeyVar::new("DOIGET_KEY_IEEE"))?,
             rate_limits:  RateLimits::HARD_CODED,
         })
     }
@@ -135,9 +135,15 @@ impl CapabilityProfile {
 
 // `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
 // BELOW the env var (#509, ADR-0050). The agreement has no file rung.
-fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+//
+// `AgreeVar`/`KeyVar` are newtypes over `&'static str` with private fields:
+// two adjacent `&str` parameters could be transposed at a call site and the
+// build would then treat the KEY as the agreement signal. The real signature
+// also takes `feature: &str` and `feature_enabled: bool`, elided here.
+fn read_tdm_grant(agree: AgreeVar, key: KeyVar, file_key: Option<&str>)
     -> Result<Option<TdmGrant>, CapabilityError>
 {
+    let (agree_var, key_var) = (agree.0, key.0);
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
     let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -257,21 +257,21 @@ mode resolution above.
 
 ## 6. Credentials file
 
+This file carries **API keys only**. The per-publisher agreement is
+environment-only and cannot be given here — see below, and ADR-0050.
+
 ```toml
-# ~/.config/doiget/credentials.toml — optional, alternative to env vars
-# Permissions MUST be 0600 on POSIX; doiget warns at startup otherwise.
+# ~/.config/doiget/credentials.toml — optional.
+# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
 
 [tdm.elsevier]
 api_key = "..."
-agreed = true
 
 [tdm.aps]
 api_key = "..."
-agreed = true
 
 [tdm.springer]
 api_key = "..."
-agreed = true
 
 # Requires a build with `--features tdm-ieee`. The endpoint and response
 # shape are INFERRED from IEEE's public developer portal, not confirmed
@@ -280,10 +280,33 @@ agreed = true
 # rather than silently returning nothing.
 [tdm.ieee]
 api_key = "..."
-agreed = true
 ```
 
-If both env var and credentials.toml provide the same key, env var wins.
+**Precedence.** `DOIGET_KEY_<PUBLISHER>` wins over `[tdm.<publisher>] api_key`,
+per §1. A blank value on either rung counts as unset.
+
+**The agreement is not here.** Each TDM source needs
+`DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, in addition to a key
+from either rung. An `agreed` key in this file is read only so doiget can warn
+that it does nothing; it grants nothing. [`LEGAL.md`](LEGAL.md) §6a.2 makes the
+agreement an *enforced control*, and part of why it is meaningful is that it is
+an act taken in the session that runs the fetch — a boolean written once into a
+file and forgotten is weaker, and weakening it as a side effect of adding a
+convenience is not a trade this file is worth (ADR-0050).
+
+So the three states are:
+
+| key | `DOIGET_AGREE_TDM_<PUB>=1` | result |
+|---|---|---|
+| env or file | yes | grant (if the `tdm-*` feature is compiled in) |
+| env or file | no | `KeyButNotAgreed` — refuses, names the variable |
+| none | yes | `AgreedButNoKey` — refuses, names both |
+
+**Before #509 this file was read by nothing.** It was specified here in full,
+including the `0600` warning, and no code path opened it; a user who followed
+this section wrote their key into a file doiget ignored and then reported the
+source unavailable for want of a key. Both the reader and the permission
+warning exist as of 0.8.11.
 
 ## 6.1 Institutional networks: what works and what does not
 

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -270,22 +270,53 @@ If both env var and credentials.toml provide the same key, env var wins.
 ## 6.1 Institutional networks: what works and what does not
 
 Being on a subscribing university network does **not** make paywalled content
-fetchable. Two independent things sit in the way, and only one of them is doiget's:
+fetchable. Three things sit in the way, in this order — and until 0.8.11 this section
+listed only the last two, which meant it sent readers after fixes that could not help.
+
+0. **Nothing is attempted at all**, and this comes first. The fetch path carries only
+   OA locations an enabled source reported. For a closed work there are none, so the
+   leg ends before any host is chosen: not refused, **never attempted**. The run exits
+   **0** with `metadata-only: no OA PDF available`, which reads as "this paper has no
+   OA copy".
+
+   Both blockers below sit behind this one and are never reached, so widening the
+   allowlist or obtaining TDM credentials does not change the outcome for a closed
+   DOI. Until 0.8.11 this section listed only (1) and (2), and therefore sent readers
+   after two fixes that could not help.
+
+   **This is not a bug awaiting a fix.** #517 asked whether Crossref's publisher link
+   could fill the gap. Measured across six live DOIs and eight captured responses,
+   every `link[]` entry Crossref returns is scoped to Similarity Check, syndication or
+   a TDM programme, and none is general-purpose - so following one would mean using a
+   licensed route without the licence. See [`LEGAL.md`](LEGAL.md) §2a(a-i) and
+   ADR-0052. **The supported route for a closed work is a TDM credential (§6)**, which
+   is the licensed version of exactly that.
 
 1. **The allowlist.** IEEE, ACM, SIAM and AMS are not on the default `oa-publisher`
-   allowlist, so doiget will not attempt the publisher leg for them at all. IEEE now
-   has a TDM route instead (`[tdm.ieee]` above, `--features tdm-ieee`) — that is a
-   different host (`ieeexploreapi.ieee.org`, the API) under a different source key,
-   not a widening of `oa-publisher`.
+   allowlist, so the attempt is refused at the redirect policy with
+   `error[CAPABILITY_DENIED] ... redirect_not_in_allowlist` naming the host. IEEE has
+   a TDM route instead (`[tdm.ieee]` above, `--features tdm-ieee`) — a different host
+   (`ieeexploreapi.ieee.org`, the API) under a different source key, not a widening of
+   `oa-publisher` (ADR-0039).
 2. **The publisher's bot wall.** Even from a subscribing address, a scripted client
    commonly gets `202 Accepted` with an **empty body** — a challenge holding response,
    not a paywall and not a 403. The subscription is not the binding constraint; being a
    program is.
 
 So widening the allowlist alone would not fix such a fetch; it would move the failure
-one step later. `HTTPS_PROXY` is honoured (§4), but a proxy fixes *addressing*, never
-the bot wall — and if you are already on the subscribing network, tunnelling elsewhere
-routes you away from your entitlement.
+one step later. That is now demonstrable rather than asserted: the request is formed
+and refused by name, so you can see which of (1) and (2) you are hitting.
+`HTTPS_PROXY` is honoured (§4), but a proxy fixes *addressing*, never the bot wall —
+and if you are already on the subscribing network, tunnelling elsewhere routes you
+away from your entitlement.
+
+**Where this does work.** For a closed work whose publisher **is** on the
+`oa-publisher` allowlist — the physics societies and diamond-OA hosts of ADR-0027, or
+a host you added yourself via `[[network.additional_hosts]]` / `trust_academic_repos`
+/ `trust_oa_registries` — the attempt now goes out, and on an entitled network it can
+succeed. That is not circumvention: the URL is the one Crossref reports, the request
+carries no credential doiget invented, and any access control on the far side applies
+unchanged.
 
 The two routes that do work:
 

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -262,7 +262,8 @@ environment-only and cannot be given here — see below, and ADR-0050.
 
 ```toml
 # ~/.config/doiget/credentials.toml — optional.
-# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
+# Permissions SHOULD be 0600 on POSIX. `doiget config doctor` fails on a
+# group- or world-readable file, and the fetch path logs a warning.
 
 [tdm.elsevier]
 api_key = "..."
@@ -307,6 +308,14 @@ including the `0600` warning, and no code path opened it; a user who followed
 this section wrote their key into a file doiget ignored and then reported the
 source unavailable for want of a key. Both the reader and the permission
 warning exist as of 0.8.11.
+
+**Where the problems show up.** Run `doiget config doctor`. A file that cannot
+be read or does not parse fails a check naming the position — never quoting the
+line, because the line that fails to parse is usually the one holding the key. A
+file that parses fails a check for each thing worth acting on: a group- or
+world-readable mode, an `api_key` present but blank, an `agreed` that grants
+nothing, a `[tdm.<publisher>]` naming a publisher doiget does not know. None of
+these is fatal to a fetch, and none of them is silent.
 
 ## 6.1 Institutional networks: what works and what does not
 

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -374,7 +374,7 @@ network (--network):
   egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)
                   a proxy fixes addressing, never a bot wall
   unpaywall       polite pool as you@institution.edu
-  oa-publisher    22 host patterns allowlisted
+  oa-publisher    24 host patterns allowlisted
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -28,7 +28,8 @@ A value set higher in the chain overrides any value set lower.
 | `log.path` | POSIX: `$HOME/.config/doiget/access.log`. Windows: `%APPDATA%\doiget\access.log`. |
 | `log.retention_days` | `90` |
 | `network.user_agent` | `doiget/<version> (+https://github.com/QAtlasHub/doiget)` |
-| `network.unpaywall_email` | unset; if unset, Unpaywall calls go to non-polite pool |
+| `network.contact_email` | unset; if unset, every outbound request identifies as `doiget@localhost` and goes to the non-polite pool |
+| `network.unpaywall_email` | unset; falls back to `network.contact_email` |
 | `network.connect_timeout_sec` | `10` |
 | `network.read_timeout_sec` | `60` |
 | `network.total_timeout_sec` | `300` |
@@ -68,6 +69,12 @@ retention_days = 90
 
 [network]
 user_agent = "doiget/0.1.0 (+https://github.com/QAtlasHub/doiget; user=alice@example.org)"
+# Polite-pool contact for every outbound request. Overridden by
+# DOIGET_CONTACT_EMAIL, one rung above. This is what `doiget config doctor`
+# checks, and `doctor` names which rung answered.
+contact_email = "alice@example.org"
+# Only if Unpaywall should see a different address. Overridden by
+# DOIGET_UNPAYWALL_EMAIL; falls back to contact_email above.
 unpaywall_email = "alice@example.org"
 connect_timeout_sec = 10
 read_timeout_sec = 60
@@ -202,18 +209,29 @@ All `DOIGET_*` env vars use `SCREAMING_SNAKE_CASE`. Boolean env vars accept `1` 
 | `DOIGET_LOG_PATH` | `log.path` |
 | `DOIGET_LOG_RETENTION_DAYS` | `log.retention_days` |
 | `DOIGET_USER_AGENT` | `network.user_agent` |
-| `DOIGET_CONTACT_EMAIL` | Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
+| `DOIGET_CONTACT_EMAIL` | `network.contact_email`. Polite-pool contact address; also the default for `DOIGET_UNPAYWALL_EMAIL`. |
 | `DOIGET_UNPAYWALL_EMAIL` | `network.unpaywall_email` |
 | `DOIGET_MODE` | `output.mode` |
 | `NO_COLOR` | Forces `output.color = "never"` (xdg standard). |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | reqwest honors these (system standard). |
 
-With neither email set, doiget still queries Unpaywall — it sends the placeholder
+Both addresses are resolved **per field**, across the §1 chain: the env var, then
+`[network]` in `config.toml`, then the next-broader default. `DOIGET_UNPAYWALL_EMAIL` →
+`[network] unpaywall_email` → whatever `contact_email` resolved to → `doiget@localhost`.
+The more specific field wins at each rung.
+
+With neither set, doiget still queries Unpaywall — it sends the placeholder
 `doiget@localhost`, which lands in the non-polite pool and may be rate-limited or refused.
-Setting `DOIGET_CONTACT_EMAIL` is therefore worth doing before any batch run, and it is what
-`doiget config doctor` flags. It also makes the automatic arXiv preprint fallback reliable:
-when a DOI's OA PDF is blocked, doiget retries via the arXiv preprint that Unpaywall named,
-so a throttled Unpaywall response costs you that fallback too.
+Setting one is worth doing before any batch run, and it is what `doiget config doctor`
+flags. It also makes the automatic arXiv preprint fallback reliable: when a DOI's OA PDF is
+blocked, doiget retries via the arXiv preprint that Unpaywall named, so a throttled
+Unpaywall response costs you that fallback too — and the run still exits 0 saying
+`no OA PDF available`, which is why a degraded search and a true negative looked the same.
+
+`doiget config doctor` reports **which rung answered**, e.g.
+`[ ok ] contact_email set (from: [network] contact_email in config.toml)`. Before #504 the
+file rung did not exist for either address, so a `config.toml` written from the `config init`
+template was inert while `doctor` reported the store root correctly from the same file.
 
 CapabilityProfile-related env vars are documented in [`CAPABILITY.md`](CAPABILITY.md).
 

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -212,8 +212,8 @@ Neither ever renders "no trace" as `[]`.
 | Exit | Meaning |
 |---|---|
 | `0` | Success (all refs ok). |
-| `1` | At least one fetch failed. |
-| `2` | Misuse (bad arguments, missing config). |
+| `1` | At least one fetch was attempted and failed. |
+| `2` | Misuse — a bad argument or missing config. Covers both an argv shape `clap` rejects **and** a well-formed argument whose *value* fails validation, which is why `INVALID_REF` and `AMBIGUOUS` are both 2 (ADR-0049). |
 | `3` | Capability denied (no source could serve). |
 | `4` | I/O failure (store / log unwritable). |
 | `64..=78` | `sysexits.h` mapping for select cases. |

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -87,11 +87,36 @@ Given a ref, doiget attempts retrieval from exactly two kinds of location:
 **(a) A location an enabled source reported.** The URL appears verbatim in a response
 doiget received from a source that both the build and the runtime capability profile
 have enabled. In practice: Unpaywall's `best_oa_location` / `oa_locations` (Tier 1),
-and — only when the content leg was already blocked — CORE's `downloadUrl`, HAL's
+and - only when the content leg was already blocked - CORE's `downloadUrl`, HAL's
 `fileMain_s` (gated on `openAccess_bool`), or Europe PMC's `fullTextUrlList`, each
 behind its own `DOIGET_ENABLE_*` flag.
 *Enforced by:* `orchestrator::optional_source_oa_url`, which dispatches to one
 per-source extractor and returns `None` for any other source name.
+
+**(a-i) Crossref `link[]` is NOT one of them, and this was measured.** #517 asked
+whether the fetch path should carry the publisher link Crossref reports, so that a
+user on a subscribing network reaches the publisher instead of exiting 0 in silence.
+It should not, and the reason is what Crossref actually returns.
+
+Every `link[]` entry carries `intended-application`. `unspecified` would be a general
+full-text link; `text-mining`, `similarity-checking` and `syndication` scope the URL to
+a specific licensed programme. Measured 2026-08-26 across **six live DOIs** (SIAM,
+IEEE, AMS, ACM, Springer Nature, the Royal Society) and the **eight captured
+responses** in `tests/fixtures/real_world/` - 12 entries in total - **not one carried
+`unspecified`.** Every one was `text-mining` or `similarity-checking`.
+
+So Crossref `link[]` is a programme-scoped channel, not a general full-text one.
+Following it would mean using Similarity Check and TDM links without holding those
+licences - and doiget already has the licensed route: its Tier-3 TDM sources, with the
+user's own credential and a recorded per-publisher agreement (§6a.2). The ceiling is
+unchanged (ADR-0052).
+
+*Enforced by:* `orchestrator::extract_crossref_publisher_url`, which accepts only
+`unspecified` and refuses an unlabelled entry as well - an unlabelled link is a guess,
+and the line this section draws is documented-by-the-vendor versus guessed-by-us
+(ADR-0048 D2). Before #517 that function returned the first entry with no filtering,
+so `MetadataOnlyOutcome.oa_url` could hand a caller a Similarity Check URL under the
+name `oa_url`.
 
 **(b) An endpoint built from a vendor's own documented URL scheme, for the identifier
 the user supplied.** arXiv's `/pdf/<id>.pdf` and `/api/query?id_list=<id>`; ar5iv's

--- a/site/content/use/legal.md
+++ b/site/content/use/legal.md
@@ -217,30 +217,44 @@ These are mechanically enforced by code, type system, Cargo, or CI. Removing
 them requires changing source files that are gated by branch protection.
 
 1. **No bundled credentials.** No publisher API key is shipped in any doiget
-   binary. Credentials are read at runtime from **environment variables**
-   (`DOIGET_KEY_<PUBLISHER>`), wrapped in `secrecy::Secret`, and never logged in
-   raw form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the
-   `tracing` redactor.
+   binary. Keys are read at runtime from `DOIGET_KEY_<PUBLISHER>` or, one rung
+   below it, `[tdm.<publisher>] api_key` in `~/.config/doiget/credentials.toml`;
+   either way they are wrapped in `secrecy::Secret` and never logged in raw
+   form. *Enforced by:* `secrecy::Secret` types in `doiget-core`; the `tracing`
+   redactor; `doiget_core::credentials`.
 
-   Two corrections here (#494):
+   Two corrections here (#494), one of which has since been closed the other way:
 
    - This said credentials are also read from `~/.config/doiget/credentials.toml`.
-     They are not. `CapabilityProfile`'s TDM resolver reads `std::env::var` and
-     nothing else, and no code path opens that file — `docs/CONFIG.md` §6
-     specifies it in full anyway, which is tracked as #509. A user following that
-     section today writes a key into a file doiget ignores.
+     At the time they were not — `docs/CONFIG.md` §6 specified the file in full
+     and no code path opened it (#509). **As of 0.8.11 the sentence is true
+     again**, because the reader was built rather than the specification
+     deleted: a long-lived key is better off in a `0600` file than in the
+     environment of every subprocess, and the permission warning §6 promised now
+     exists too (ADR-0050). The **agreement** did not move — see §6a.2.
    - "*CI grep for embedded key patterns*" was listed as enforcement. **No such
      check exists.** `posture-lint.yml` greps for marketing terms, HTTP-server
-     imports, telemetry imports and non-rustls TLS backends; there is no secret
-     scanner in the tree. §6a is defined as controls a machine enforces, so an
-     enforcement clause that names nothing does not belong in it. The safeguard
-     itself stands on the type-level ones that are real.
+     imports, telemetry imports, non-rustls TLS backends and the npm platform
+     mapping; there is no secret scanner in the tree. §6a is defined as controls
+     a machine enforces, so an enforcement clause that names nothing does not
+     belong in it. The safeguard itself stands on the type-level ones that are
+     real.
 
 2. **Opt-in TDM agreement (per-publisher).** Each TDM-class source requires
-   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` AND provide
-   `DOIGET_KEY_<PUBLISHER>`. Missing or partial configurations fail closed at
-   `CapabilityProfile::from_env`. *Enforced by:* `CapabilityProfile`
-   resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2 rules 2 and 3).
+   the user to set `DOIGET_AGREE_TDM_<PUBLISHER>=1` **in the environment**, AND
+   to provide a key (env var or `credentials.toml`, §6a.1). Missing or partial
+   configurations fail closed at `CapabilityProfile::from_env`. *Enforced by:*
+   `CapabilityProfile` resolution algorithm ([`CAPABILITY.md`](CAPABILITY.md) §2
+   rules 2 and 3).
+
+   **The agreement is environment-only, and deliberately did not follow the key
+   into the file** (ADR-0050). Part of what makes this control meaningful is
+   that it is an act taken in the session that runs the fetch; a boolean written
+   once into a config file and forgotten is a weaker consent, and letting a
+   convenience dilute an enforced control is the kind of accident ADR-0048 was
+   written about. An `agreed` key in `credentials.toml` is parsed only so doiget
+   can warn that it grants nothing — a documented field with no reader being the
+   defect #509 was about in the first place.
 
 3. **Compile-time feature gating.** Each TDM source is behind a Cargo feature
    (`tdm-elsevier`, `tdm-aps`, `tdm-springer`, `tdm-ieee`). Default builds and

--- a/tests/fixtures/real_world/doi/10.1007-s10994-021-06087-3/expected.toml
+++ b/tests/fixtures/real_world/doi/10.1007-s10994-021-06087-3/expected.toml
@@ -1,4 +1,24 @@
 safekey = "doi_10.1007_s10994-021-06087-3"
 source  = "crossref"
 title   = "A representative-shape illustration of a Springer ML-journal article"
-oa_url  = "https://link.springer.com/content/pdf/10.1007/s10994-021-06087-3.pdf"
+
+# `oa_url` is deliberately ABSENT, and this entry is why the field's old
+# value was worth measuring (#517).
+#
+# The captured Crossref response carries exactly one `link[]` entry:
+#
+#   { "URL": "https://link.springer.com/content/pdf/10.1007/s10994-021-06087-3.pdf",
+#     "content-type": "application/pdf",
+#     "intended-application": "text-mining" }
+#
+# `text-mining` scopes that URL to Springer's TDM programme. doiget joins
+# such programmes through its Tier-3 sources, with the user's own key and a
+# recorded per-publisher agreement — so surfacing this URL as `oa_url`
+# labelled a programme-scoped link as an Open Access one, to a caller the
+# field's own docs invite to act on it.
+#
+# This fixture asserted that behaviour, which is the strongest evidence
+# that it was behaviour rather than an accident. `oa_url` is now `None`
+# here, and stays `None` for every real Crossref response measured:
+# 12 `link[]` entries across six live DOIs and eight captured fixtures,
+# none of them `unspecified`. See ADR-0052.

--- a/tests/fixtures/real_world/doi/10.1101-2024.01.01.000001/expected.toml
+++ b/tests/fixtures/real_world/doi/10.1101-2024.01.01.000001/expected.toml
@@ -1,4 +1,15 @@
 safekey = "doi_10.1101_2024.01.01.000001"
 source  = "crossref"
 title   = "A representative-shape illustration of a bioRxiv preprint"
-oa_url  = "https://www.biorxiv.org/content/10.1101/2024.01.01.000001v1.full.pdf"
+
+# `oa_url` is deliberately ABSENT (#517).
+#
+# The captured Crossref response's only `link[]` entry is
+# `intended-application: syndication`, which scopes that URL to a specific licensed
+# programme (Similarity Check / syndication / the publisher's TDM
+# programme). Surfacing it as `oa_url` labelled a programme-scoped link as
+# an Open Access one, to a caller the field's own docs invite to act on it.
+#
+# Measured 2026-08-26: 12 `link[]` entries across six live DOIs and eight
+# captured fixtures, and NOT ONE carried `unspecified`. That is what
+# settled #517 — see ADR-0052.

--- a/tests/fixtures/real_world/doi/10.1234-special-chars/expected.toml
+++ b/tests/fixtures/real_world/doi/10.1234-special-chars/expected.toml
@@ -1,4 +1,15 @@
 safekey = "doi_10.1234_abc_2024_.foo-bar_baz_v1"
 source  = "crossref"
 title   = "A representative-shape illustration of a DOI with special chars in the suffix"
-oa_url  = "https://example.org/special-chars.pdf"
+
+# `oa_url` is deliberately ABSENT (#517).
+#
+# The captured Crossref response's only `link[]` entry is
+# `intended-application: syndication`, which scopes that URL to a specific licensed
+# programme (Similarity Check / syndication / the publisher's TDM
+# programme). Surfacing it as `oa_url` labelled a programme-scoped link as
+# an Open Access one, to a caller the field's own docs invite to act on it.
+#
+# Measured 2026-08-26: 12 `link[]` entries across six live DOIs and eight
+# captured fixtures, and NOT ONE carried `unspecified`. That is what
+# settled #517 — see ADR-0052.

--- a/tests/fixtures/real_world/doi/10.1371-journal.pone.0001428/expected.toml
+++ b/tests/fixtures/real_world/doi/10.1371-journal.pone.0001428/expected.toml
@@ -1,4 +1,15 @@
 safekey = "doi_10.1371_journal.pone.0001428"
 source  = "crossref"
 title   = "A representative-shape illustration of a PLOS gold-OA article"
-oa_url  = "https://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.0001428&type=printable"
+
+# `oa_url` is deliberately ABSENT (#517).
+#
+# The captured Crossref response's only `link[]` entry is
+# `intended-application: similarity-checking`, which scopes that URL to a specific licensed
+# programme (Similarity Check / syndication / the publisher's TDM
+# programme). Surfacing it as `oa_url` labelled a programme-scoped link as
+# an Open Access one, to a caller the field's own docs invite to act on it.
+#
+# Measured 2026-08-26: 12 `link[]` entries across six live DOIs and eight
+# captured fixtures, and NOT ONE carried `unspecified`. That is what
+# settled #517 — see ADR-0052.

--- a/tests/fixtures/real_world/doi/10.3389-fonc.2020.567984/expected.toml
+++ b/tests/fixtures/real_world/doi/10.3389-fonc.2020.567984/expected.toml
@@ -1,4 +1,15 @@
 safekey = "doi_10.3389_fonc.2020.567984"
 source  = "crossref"
 title   = "A representative-shape illustration of a Frontiers in Oncology article"
-oa_url  = "https://www.frontiersin.org/articles/10.3389/fonc.2020.567984/pdf"
+
+# `oa_url` is deliberately ABSENT (#517).
+#
+# The captured Crossref response's only `link[]` entry is
+# `intended-application: similarity-checking`, which scopes that URL to a specific licensed
+# programme (Similarity Check / syndication / the publisher's TDM
+# programme). Surfacing it as `oa_url` labelled a programme-scoped link as
+# an Open Access one, to a caller the field's own docs invite to act on it.
+#
+# Measured 2026-08-26: 12 `link[]` entries across six live DOIs and eight
+# captured fixtures, and NOT ONE carried `unspecified`. That is what
+# settled #517 — see ADR-0052.

--- a/tests/fixtures/real_world/doi/10.3390-atmos11070732/expected.toml
+++ b/tests/fixtures/real_world/doi/10.3390-atmos11070732/expected.toml
@@ -1,4 +1,15 @@
 safekey = "doi_10.3390_atmos11070732"
 source  = "crossref"
 title   = "A representative-shape illustration of an MDPI Atmosphere article"
-oa_url  = "https://www.mdpi.com/2073-4433/11/7/732/pdf"
+
+# `oa_url` is deliberately ABSENT (#517).
+#
+# The captured Crossref response's only `link[]` entry is
+# `intended-application: similarity-checking`, which scopes that URL to a specific licensed
+# programme (Similarity Check / syndication / the publisher's TDM
+# programme). Surfacing it as `oa_url` labelled a programme-scoped link as
+# an Open Access one, to a caller the field's own docs invite to act on it.
+#
+# Measured 2026-08-26: 12 `link[]` entries across six live DOIs and eight
+# captured fixtures, and NOT ONE carried `unspecified`. That is what
+# settled #517 — see ADR-0052.

--- a/tests/fixtures/real_world/doi/10.7554-eLife.46313/expected.toml
+++ b/tests/fixtures/real_world/doi/10.7554-eLife.46313/expected.toml
@@ -1,4 +1,15 @@
 safekey = "doi_10.7554_eLife.46313"
 source  = "crossref"
 title   = "A representative-shape illustration of an eLife article"
-oa_url  = "https://elifesciences.org/articles/46313.pdf"
+
+# `oa_url` is deliberately ABSENT (#517).
+#
+# The captured Crossref response's `link[]` entries are
+# `intended-application: similarity-checking`, which scopes those URLs to a specific
+# licensed programme (Similarity Check, syndication, or the publisher's TDM
+# programme). Surfacing one as `oa_url` labelled a programme-scoped link as
+# an Open Access one, to a caller the field's own docs invite to act on it.
+#
+# Measured 2026-08-26: 12 `link[]` entries across six live DOIs and eight
+# captured fixtures, and NOT ONE carried `unspecified`. That is what
+# settled #517 — see ADR-0052.


### PR DESCRIPTION
## Promotion: `next` → `main` for 0.8.11

Twelve issue PRs, the CLA, and two rounds of pre-release review. `main` is at 0.8.10.

Merging this makes `main` the 0.8.11 tree. The release itself is the **signed `v0.8.11` tag**, pushed afterwards — `scripts/release-version-gate.sh` G0–G6 pass against this head (G7 needs the real tag object), and all three crates are unpublished on crates.io at 0.8.11.

### What ships

Read `CHANGELOG.md`'s `## [0.8.11]` section — it is the curated list and it is long. In outline:

- **Added** — DCO enforcement (ADR-0051), `credentials.toml` is read at last (#509, ADR-0050), npm packages (#511), a Claude Code plugin (#513), MCP registry packages (#483).
- **Changed** — the CONTRIBUTING one-liner becomes a real CLA (ADR-0051); **breaking for scripts**, an unparsable ref exits 2 everywhere rather than 1 (#492, ADR-0049); `CONFIG.md` §6.1 rewritten around what actually blocks a paywalled fetch (#517, ADR-0052); six `INTEGRATION/` guides that said "wait for Phase 3" filled in (#512); the dead `.cargo/config.local.toml` channel removed (#521); the back-merge failure made self-describing (#426).
- **Fixed** — `oa_url` was handing callers Similarity Check and TDM URLs (#517); every Tier-2 source died at `UnknownSource` in a `--features metadata` build (#516); Europe PMC discarded retrievable Free PDFs (#503); `unpaywall_email` was written by `config init` and read by nothing (#504); the npm publish would have failed on every release, silently (#511).

### Review rounds

Two `/review-pr` passes ran against this PR, each six agents, each finding real defects — recorded here because both rounds found that a shipped claim was not yet true, which is the thing worth carrying forward.

**Round 1 (#542)** — thirteen findings. The load-bearing ones: `tex-source` and `frontier` never routed through the shared ref parser, so the "exit 2 on every ref-taking command" this release leads with was false for two of them; the e2e table that was supposed to enforce it was hand-written and had silently omitted them; `CONFIG.md` §6.1 printed 22 allowlisted hosts where the code generates 24; and the npm sha256 glob matched checksums whose binaries are never downloaded.

**Round 2 (#543)** — round 1 introduced five defects of its own, three of which turned this PR's CI red, and one of which was worse than what it fixed:

- Making `credentials::parse` fallible put a `toml::de::Error` in the error variant. That type's `Display` quotes the offending source line verbatim, and the commonest way `credentials.toml` breaks is a pasted API key with a stray quote — so **the error most likely to reach a terminal was the one whose quoted line is the key**, printed by `config doctor`, thirteen lines under a comment reading `keys are never printed`. Round 1 closed a `derive(Debug)` leak and opened a more direct one on the way past.
- `posture-lint` went red **with an empty log**: its grep read a table that round 1 had moved to another file, and under `set -euo pipefail` a grep matching nothing exits 1 before printing anything.
- `dco` could never pass here. A promotion's range is the whole release, which for this release contains commits predating the CLA on a protected branch. Exempted structurally, alongside merge commits and bots.
- The whole rule set for `resolve_tdm_grant` was rendering as the docs of a one-line newtype (a missing blank line between two `///` runs).
- The contact-email ladder stopped at the MCP boundary; five CLI commands still ignored `config.toml`.

### Known and deliberate

- `version-bump` is **red by design**. `next` carries the clean `0.8.11` from the cut, so ADR-0033's gate would demand `0.8.11-beta.0` and regress it. Same on the cut itself, on #491 and on both review PRs.
- Required checks remain `test (ubuntu-latest)` and `test (windows-latest)` only.

### After merge

1. Push the signed `v0.8.11` tag on `main`.
2. `release-plz` publishes three crates, the GitHub Release with 16 assets, the `.mcpb`, and — new this release — the npm packages over Trusted Publishing. **npm Trusted Publishing has not been configured on npmjs.com yet**, so that job will fail; it is `continue-on-error` and the rest of the release proceeds.
3. The `main → next` back-merge still needs a working `RELEASE_PLZ_TOKEN` (#426).

Closes #516, #503, #504, #521, #492, #512, #517, #509, #511, #513, #483, #426
