### PR TITLE
fix: the thirteen findings from the #541 pre-release review

### DIFF
--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -165,8 +165,29 @@ jobs:
             printf 'package.json:\n%s\nnpm/:\n%s\n' "$declared" "$onDisk"
             fail=1
           fi
+          # Without this edge the checks form TWO disjoint clusters —
+          # {assets,staged} and {pkgs,shimmed} versus {declared,onDisk} — so
+          # renaming both halves consistently but differently from each other
+          # passed every check while the wrapper depended on a package the
+          # staging script never produces.
+          if [ "$pkgs" != "$declared" ]; then
+            echo "::error::posture-lint npm: scripts/stage-npm.sh and npm/doiget/package.json name different packages (#511)"
+            printf 'stage-npm.sh:\n%s\npackage.json:\n%s\n' "$pkgs" "$declared"
+            fail=1
+          fi
           [ "$fail" -eq 0 ]
           echo "npm mapping OK: $(echo "$pkgs" | tr '\n' ' ')"
+
+      - name: npm packaging tests (#511)
+        shell: bash
+        # The name-list greps above cannot catch a wrong binary name, a
+        # mis-forwarded exit code, or a staging script that produces the
+        # wrong layout. These actually run. node is preinstalled on the
+        # runner, so no action is pinned for it.
+        run: |
+          set -euo pipefail
+          node npm/doiget/test/platform.test.js
+          bash npm/doiget/test/stage-npm.test.sh
 
   network-purity:
     # Phase 0 must make zero outbound network calls from the unit / integration

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -725,7 +725,10 @@ jobs:
             -p 'doiget-macos-aarch64' \
             -p 'doiget-macos-x86_64' \
             -p 'doiget-windows-x86_64.exe' \
-            -p 'doiget-*.sha256'
+            -p 'doiget-linux-x86_64.sha256' \
+            -p 'doiget-macos-aarch64.sha256' \
+            -p 'doiget-macos-x86_64.sha256' \
+            -p 'doiget-windows-x86_64.exe.sha256'
       - name: Verify every checksum before it goes into a package
         shell: bash
         # The whole argument for optionalDependencies over a postinstall
@@ -735,7 +738,16 @@ jobs:
         run: |
           set -euo pipefail
           cd dl
+          # The list above is four EXACT names, not a wildcard. The release
+          # also carries `doiget-sbom-<tag>.cdx.json.sha256` and
+          # `doiget-<ver>.mcpb.sha256`, which a `doiget-*.sha256` glob matches
+          # while their binaries are never fetched — `openssl dgst` on the
+          # missing file then aborts this job under `set -e`, and because the
+          # job is `continue-on-error` the release still reports green with
+          # npm silently unpublished.
+          verified=0
           for f in *.sha256; do
+            [ -e "$f" ] || { echo "::error::no .sha256 files were downloaded"; exit 1; }
             read -r want _rest < "$f"
             got="$(openssl dgst -sha256 -r "${f%.sha256}" | cut -d' ' -f1)"
             if [ "$want" != "$got" ]; then
@@ -743,7 +755,14 @@ jobs:
               exit 1
             fi
             echo "ok ${f%.sha256}"
+            verified=$((verified + 1))
           done
+          # A partial download is exactly what this step exists to catch; it
+          # must not read as a clean run over fewer files.
+          if [ "$verified" -ne 4 ]; then
+            echo "::error::verified $verified checksum(s), expected 4 — a platform binary is missing from the release"
+            exit 1
+          fi
       - name: Stage the packages
         shell: bash
         run: bash scripts/stage-npm.sh "${TAG#v}" dl npm-stage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   to mean "invalid ref" was already wrong: 1 was also every network failure and
   every other code under the catch-all (#492, ADR-0049).
 
+  Pre-release review found the claim was not yet true: `tex-source` and
+  `frontier` never routed through the shared parser, so both still exited 1 and
+  `tex-source` leaked the `Caused by:` chain #477's contract replaced. Both are
+  fixed, `annotate`'s missing-argument path moves from 1 to 2 with them, and the
+  test's command table is now **read back from clap's `--help`** instead of
+  hand-listed — a second hand-maintained copy of the subcommand set is what let
+  three commands go uncovered in the first place.
+
 - **[docs]** `CONFIG.md` §6.1 named two things standing between an entitled network and
   a paywalled paper — the allowlist, and the publisher bot wall — and **neither was
   reached**. A third sits in front of both: for a closed work no candidate URL is ever
@@ -148,6 +156,44 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   saying `no OA PDF available`. Both addresses now resolve env → `config.toml` →
   default, `config doctor` names **which rung answered**, and `contact_email` — absent
   from the generated template entirely — is in it (#504).
+
+  Pre-release review found the fix stopped at the CLI: `doiget_paper_search`,
+  `doiget_link`, `doiget_expand_citation_graph` and `doiget_resolve_citation`
+  each read `DOIGET_CONTACT_EMAIL` directly, so a user who configured the
+  address in `config.toml` got the polite pool from `doiget fetch` and the
+  non-polite pool from every MCP tool — the interface doiget leads with. All
+  four now go through the same ladder. `config doctor` also reported
+  `unpaywall_email: unset` in the commonest configuration of all (only
+  `DOIGET_CONTACT_EMAIL` set) while the fetch it describes was sending the
+  contact address; it now reports `inherited from contact_email`.
+- **[ci]** **The npm publish would have failed on every release, silently.** The
+  `npm-publish` job downloaded `doiget-*.sha256`, a glob that also matches the SBOM's
+  and the `.mcpb`'s checksums — whose binaries it never downloads — so the verify
+  step ran `openssl dgst` on a missing file and aborted under `set -euo pipefail`
+  before staging anything. The job is `continue-on-error`, so the release would have
+  reported green with npm unpublished, while the entry above says npm packages ship.
+  The four platform checksums are now named exactly, and the step asserts it verified
+  all four rather than reporting a clean run over fewer (#511).
+- **[ci]** `posture-lint`'s npm mapping check compared two disjoint clusters of names,
+  so renaming both halves consistently-but-differently passed while the wrapper
+  depended on a package the staging script never produces. The four names now form one
+  connected chain. The packaging also gained **executable** tests — the name-list greps
+  could not catch a wrong binary name or a staging bug, and the first run of the new
+  `stage-npm.sh` test immediately caught one: the script copied only `doiget.js`, so
+  the shim's `require("./platform.js")` would have thrown `MODULE_NOT_FOUND` on the
+  first `npx doiget` (#511).
+- **[config]** `credentials.toml`'s failure modes reached only `tracing::warn!`, which
+  the CLI's default `EnvFilter` suppresses — so a malformed or group-readable file
+  produced no warning, no `doctor` line, and only the downstream "source unavailable"
+  the feature exists to prevent. `config doctor` now reports it the same way it already
+  reported `config.toml`, and a present-but-blank `api_key` — the one case with no log
+  call at all — is named rather than dropped (#509).
+- **[core]** `Credentials` no longer derives `Debug` over plain-`String` API keys; a
+  hand-written impl redacts them, applying one hop earlier the same protection
+  `secrecy::SecretString` gives the value once it reaches `TdmGrant`. The TDM env-var
+  pair also moved behind `AgreeVar`/`KeyVar` newtypes: they were adjacent `&str`
+  parameters, so transposing them at a call site type-checked and would have made the
+  KEY the agreement signal for a control `docs/LEGAL.md` §6a.2 calls enforced (#509).
 - **[cli/mcp]** The config-directory resolver existed as two hand-maintained copies whose
   own comment warned that divergence "would silently desync the user-extension allowlist
   surfaces". They had already diverged: the CLI accepted `XDG_CONFIG_HOME=""` and

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -58,7 +58,12 @@ pub struct ResolvedConfig {
     /// `store_root_source` exists (#441): a setting that did nothing must
     /// not look like a setting that worked.
     pub contact_email_source: String,
-    /// Unpaywall-specific contact email; falls back to `contact_email` when unset.
+    /// Unpaywall-specific contact email. Inherits `contact_email` when no
+    /// Unpaywall-specific rung is set, matching
+    /// `doiget_core::orchestrator::resolve_unpaywall_email` — the reporting
+    /// side used to omit that fallback and print `unset` for the commonest
+    /// configuration of all (only `DOIGET_CONTACT_EMAIL` set), while the
+    /// fetch it describes was sending the contact address.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unpaywall_email: Option<String>,
     /// Which rung produced `unpaywall_email` (#504).
@@ -76,6 +81,9 @@ pub(crate) enum EmailSource {
     Env(&'static str),
     /// `[network] <field>` in the user's `config.toml`.
     ConfigFile(&'static str),
+    /// No Unpaywall-specific rung is set, so it inherits `contact_email`.
+    /// Only ever produced for `unpaywall_email`.
+    InheritedFromContact,
     /// Nothing set it.
     Unset,
 }
@@ -86,6 +94,7 @@ impl EmailSource {
         match self {
             Self::Env(v) => v.to_string(),
             Self::ConfigFile(k) => format!("[network] {k} in config.toml"),
+            Self::InheritedFromContact => "inherited from contact_email".to_string(),
             Self::Unset => "unset".to_string(),
         }
     }
@@ -175,11 +184,24 @@ impl ResolvedConfig {
         let file = doiget_core::user_extension::load(&config_path).unwrap_or_default();
         let (contact_email, contact_email_source) =
             resolve_email("DOIGET_CONTACT_EMAIL", "contact_email", file.contact_email);
-        let (unpaywall_email, unpaywall_email_source) = resolve_email(
+        let (unpaywall_email, unpaywall_email_source) = match resolve_email(
             "DOIGET_UNPAYWALL_EMAIL",
             "unpaywall_email",
             file.unpaywall_email,
-        );
+        ) {
+            // No Unpaywall-specific rung: the fetch path falls back to the
+            // resolved contact address, so the report has to say so rather
+            // than `unset`.
+            (None, _) => (
+                contact_email.clone(),
+                if contact_email.is_some() {
+                    EmailSource::InheritedFromContact
+                } else {
+                    EmailSource::Unset
+                },
+            ),
+            found => found,
+        };
 
         Ok(Self {
             store_root,
@@ -398,6 +420,47 @@ pub async fn run(
                         "fix {} — see docs/CONFIG.md §3 for the \
                          [[network.additional_hosts]] schema",
                         cfg.config_path
+                    )),
+                    &mut all_ok,
+                ),
+            }
+            // #509 gave `credentials.toml` a reader; this gives it the same
+            // doctor visibility its sibling above already had. Without it
+            // the file's failure modes reach only `tracing::warn!`, which
+            // `EnvFilter::from_default_env()` suppresses at the default
+            // level — so a malformed or world-readable credentials file
+            // produced no warning, no doctor line, and only the downstream
+            // "source unavailable" the whole feature exists to prevent.
+            //
+            // A missing file is normal and reports `[ ok ]` with a count of
+            // zero: TDM is opt-in, and most installs have no such file.
+            // Keys are counted, never printed.
+            let cred_path = cfg.config_dir.join("credentials.toml");
+            match doiget_core::credentials::load(&cred_path) {
+                Ok(creds) => {
+                    check(
+                        &format!(
+                            "credentials.toml keys loaded: {} ({})",
+                            creds.len(),
+                            if creds.is_empty() {
+                                "none — TDM sources need DOIGET_KEY_* or this file"
+                            } else {
+                                "publisher names only; keys are never printed"
+                            }
+                        ),
+                        true,
+                        None,
+                        &mut all_ok,
+                    );
+                }
+                Err(e) => check(
+                    &format!("credentials.toml invalid: {e}"),
+                    false,
+                    Some(&format!(
+                        "fix {cred_path} — see docs/CONFIG.md §6 for the \
+                         [tdm.<publisher>] schema. Only `api_key` is read; \
+                         the agreement is DOIGET_AGREE_TDM_<PUBLISHER>=1 in \
+                         the environment (ADR-0050)"
                     )),
                     &mut all_ok,
                 ),
@@ -922,6 +985,46 @@ mod tests {
             cfg.contact_email_source, "[network] contact_email in config.toml",
             "doctor must name the rung that answered, or an inert setting looks like a live one"
         );
+    }
+
+    /// The commonest configuration of all: only `DOIGET_CONTACT_EMAIL` is
+    /// set. The fetch path sends that address to Unpaywall
+    /// (`resolve_unpaywall_email` falls back to the resolved contact), so
+    /// `doctor` and `show` must say so. They used to print `unset`, which
+    /// described a request doiget does not make.
+    #[test]
+    #[serial_test::serial]
+    fn an_unset_unpaywall_address_reports_the_contact_it_actually_inherits() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        let _scoped = scoped_config_home(dir.as_str());
+        let _c = EnvGuard::set("DOIGET_CONTACT_EMAIL", "only@institution.edu");
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        assert_eq!(
+            cfg.unpaywall_email.as_deref(),
+            Some("only@institution.edu"),
+            "the report must match what the fetch path sends"
+        );
+        assert_eq!(cfg.unpaywall_email_source, "inherited from contact_email");
+    }
+
+    /// With nothing set at all there is nothing to inherit, so `unset` is
+    /// still the honest answer.
+    #[test]
+    #[serial_test::serial]
+    fn with_no_address_anywhere_unpaywall_still_reports_unset() {
+        let _g = unset_all_doiget_config_env();
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let dir = camino::Utf8PathBuf::from_path_buf(td.path().to_path_buf())
+            .expect("temp path is UTF-8");
+        let _scoped = scoped_config_home(dir.as_str());
+
+        let cfg = ResolvedConfig::from_env().expect("config resolves");
+        assert_eq!(cfg.unpaywall_email, None);
+        assert_eq!(cfg.unpaywall_email_source, "unset");
     }
 
     /// The env rung stays above the file rung, per field.

--- a/crates/doiget-cli/src/commands/frontier.rs
+++ b/crates/doiget-cli/src/commands/frontier.rs
@@ -38,8 +38,24 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let seed_doi = doiget_core::Doi::parse(&doi_str)
-        .map_err(|e| anyhow::anyhow!("invalid seed DOI {doi_str:?}: {e}"))?;
+    // #492 / ADR-0049: previously a bare `anyhow!`, which exited 1 with no
+    // `error[INVALID_REF]:` line. Routed through the shared parser so the
+    // message and the exit code match every other ref-taking command.
+    let seed_doi = match super::parse_ref_or_exit(&doi_str)? {
+        doiget_core::Ref::Doi(d) => d,
+        doiget_core::Ref::Arxiv(_) => {
+            // Same shape as `graph`: OpenAlex keys the citation graph by
+            // DOI, so an arXiv id is argument misuse rather than a parse
+            // failure — `docs/ERRORS.md` §4 exit 2.
+            super::output::print_err(format_args!(
+                "error: doiget frontier requires a DOI seed; arXiv ids are not in \
+                 OpenAlex's referenced_works keyspace"
+            ));
+            return Err(anyhow::Error::new(CliExit(cli_exit_code(
+                doiget_core::ErrorCode::InvalidRef,
+            ))));
+        }
+    };
 
     let base = {
         let raw = std::env::var("DOIGET_OPENALEX_BASE")

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -19,7 +19,9 @@
 //! - [`list_recent`] — prints up to N most-recently-fetched entries.
 //! - [`search`] — case-insensitive substring search over stored metadata.
 //!
-//! Other subcommands (`serve`) land in separate PRs.
+//! `serve` has no module here: it delegates straight to `doiget-mcp`. It
+//! is wired in `main.rs` and is what every `docs/INTEGRATION/` guide tells
+//! users to run.
 
 /// Parse a ref, or render the failure in the `docs/ERRORS.md` §3
 /// "Researcher (CLI human)" form and return the CLI exit error.

--- a/crates/doiget-cli/src/commands/tag.rs
+++ b/crates/doiget-cli/src/commands/tag.rs
@@ -132,7 +132,11 @@ pub fn run(
 /// stored entry. Exactly one of `text` (Some) or `clear = true` must be given.
 pub fn run_annotate(ref_str: String, text: Option<String>, clear: bool) -> Result<()> {
     if !clear && text.is_none() {
-        bail!("provide annotation <text> or --clear");
+        // `docs/ERRORS.md` §4: a missing required argument is misuse, which
+        // is exit 2. A bare `bail!` gave the generic 1 — the same gap #492
+        // closed for an unparsable ref, one argument over.
+        super::output::print_err(format_args!("error: provide annotation <text> or --clear"));
+        return Err(anyhow::Error::new(super::fetch::CliExit(2)));
     }
 
     let ref_ = super::parse_ref_or_exit(&ref_str)?;

--- a/crates/doiget-cli/src/commands/tex_source.rs
+++ b/crates/doiget-cli/src/commands/tex_source.rs
@@ -33,7 +33,12 @@ pub async fn run(
     mode: OutputMode,
     quiet_was_explicit: bool,
 ) -> Result<()> {
-    let parsed = Ref::parse(&ref_).with_context(|| format!("invalid ref {ref_:?}"))?;
+    // #492 / ADR-0049: one renderer, one exit code. This used to be
+    // `Ref::parse(..).with_context(..)?`, which exited 1 and leaked the
+    // `Caused by:` chain that #477's contract exists to replace — the ADR
+    // claimed the rule held for "every ref-taking command" and this was one
+    // of two that were never in the set.
+    let parsed = super::parse_ref_or_exit(&ref_)?;
     let id: ArxivId = match parsed {
         Ref::Arxiv(a) => a,
         Ref::Doi(_) => {

--- a/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
+++ b/crates/doiget-cli/tests/fetch_error_mapping_e2e.rs
@@ -50,29 +50,95 @@ fn fetch_invalid_ref_emits_cargo_style_error_and_exit_2() {
 ///
 /// Table-driven on purpose: a new ref-taking subcommand is added to this
 /// list or it is not covered, and the failure names which one regressed.
+/// Every subcommand that takes a ref, read back from clap rather than
+/// hand-listed.
+///
+/// This was a literal, and it silently omitted `tex-source`, `frontier`
+/// and `annotate` — two of which then violated BOTH halves of the contract
+/// these tests exist to enforce, throughout the very release that claimed
+/// to have unified them. A second hand-maintained copy of the subcommand
+/// set is the #454 / #504 shape; this reads the one clap actually built.
+///
+/// Excluded by name, each for a stated reason:
+/// - `verify` takes a FILE PATH, so an unparsable value is a missing file.
+/// - `batch` takes a file of refs and reports per row, not per process.
+/// - `resolve-citation` takes free text, not a ref.
+/// - the rest simply take no ref.
+fn ref_taking_commands() -> Vec<Vec<String>> {
+    const NOT_A_REF: &[&str] = &[
+        "verify",
+        "batch",
+        "resolve-citation",
+        // Reads pending citations from the store; takes no argument.
+        "batch-resolve-citations",
+        "version",
+        "config",
+        "serve",
+        "search",
+        "list-recent",
+        "provenance",
+        "audit-log",
+        "lint",
+        "capabilities",
+        "help",
+    ];
+
+    let out = Command::cargo_bin("doiget")
+        .expect("doiget binary built")
+        .arg("--help")
+        .output()
+        .expect("run doiget --help");
+    let help = String::from_utf8_lossy(&out.stdout);
+
+    // clap lists subcommands indented, name first. Anything that is not a
+    // flag and not on the exclusion list is expected to take a ref — so a
+    // NEW ref-taking subcommand is covered by default, and a new non-ref
+    // one fails here until it is named, which is the safe direction.
+    let mut found: Vec<String> = help
+        .lines()
+        .filter(|l| l.starts_with("  "))
+        // `split_whitespace` already skips the leading indent; trimming
+        // first is what clippy's `trim_split_whitespace` flags.
+        .filter_map(|l| l.split_whitespace().next())
+        // Options share the two-space indent, so exclude anything that
+        // starts with a dash before the lowercase check (which `--color`
+        // would otherwise pass).
+        .filter(|n| !n.is_empty() && !n.starts_with('-'))
+        .filter(|n| n.chars().all(|c| c.is_ascii_lowercase() || c == '-'))
+        .filter(|n| !NOT_A_REF.contains(n))
+        .map(str::to_string)
+        .collect();
+    found.sort();
+    found.dedup();
+    assert!(
+        found.len() >= 9,
+        "parsed only {found:?} from --help — the parser has drifted from clap's output"
+    );
+
+    // Complete argv, bad ref included, because the ref is NOT the last
+    // positional everywhere: `annotate` is `<ref> <text>`.
+    found
+        .into_iter()
+        .map(|c| match c.as_str() {
+            "source" => vec!["source", "--out", ".", BAD_REF]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            "annotate" => vec!["annotate", BAD_REF, "a note"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            _ => vec![c, BAD_REF.to_string()],
+        })
+        .collect()
+}
+
+/// The value every command in the table is handed.
+const BAD_REF: &str = "not a doi";
+
 #[test]
 fn every_ref_taking_command_emits_the_error_code_contract() {
-    // `verify` is excluded: it takes a FILE PATH, not a ref, so an
-    // unparsable value is a missing file rather than a bad ref. It gets
-    // the `error:` misuse form instead -- see the test below.
-    let mut commands: Vec<Vec<&str>> = vec![
-        vec!["fetch"],
-        vec!["info"],
-        vec!["link"],
-        vec!["cite"],
-        vec!["text"],
-        vec!["bib"],
-        vec!["csl"],
-        // `source` needs `--out`; the ref is still the last positional.
-        vec!["source", "--out", "."],
-        vec!["tag"],
-    ];
-    // `graph` only exists in a `citation` build, and CI's default job runs
-    // plain `oa-only` -- where the subcommand is absent and clap answers
-    // "unrecognized subcommand", which is not this contract's business.
-    if cfg!(feature = "citation") {
-        commands.push(vec!["graph"]);
-    }
+    let commands = ref_taking_commands();
 
     let td = TempDir::new().expect("tempdir");
     let root = td.path().to_str().expect("utf-8");
@@ -83,12 +149,19 @@ fn every_ref_taking_command_emits_the_error_code_contract() {
         cmd.env("DOIGET_STORE_ROOT", root)
             .env("DOIGET_LOG_PATH", "")
             .env("DOIGET_CONTACT_EMAIL", "test@example.com")
-            .args(argv)
-            .arg("not a doi");
+            .args(argv);
         let out = cmd.output().expect("run doiget");
         let stderr = String::from_utf8_lossy(&out.stderr);
         let first = stderr.lines().next().unwrap_or("");
 
+        // A feature-gated subcommand (`graph` needs `citation`) is absent
+        // from a narrower build, and clap answers for it. That is clap's
+        // business, not this contract's — and `--help` is parsed from a
+        // binary that may have been built with a different feature set
+        // than the one under test when they share a target directory.
+        if first.starts_with("error: unrecognized subcommand") {
+            continue;
+        }
         if !first.starts_with("error[") {
             broken.push(format!("{}: {first}", argv.join(" ")));
         }
@@ -118,20 +191,7 @@ fn every_ref_taking_command_emits_the_error_code_contract() {
 /// subcommand is covered by both or by neither.
 #[test]
 fn every_ref_taking_command_exits_2_for_an_invalid_ref() {
-    let mut commands: Vec<Vec<&str>> = vec![
-        vec!["fetch"],
-        vec!["info"],
-        vec!["link"],
-        vec!["cite"],
-        vec!["text"],
-        vec!["bib"],
-        vec!["csl"],
-        vec!["source", "--out", "."],
-        vec!["tag"],
-    ];
-    if cfg!(feature = "citation") {
-        commands.push(vec!["graph"]);
-    }
+    let commands = ref_taking_commands();
 
     let td = TempDir::new().expect("tempdir");
     let root = td.path().to_str().expect("utf-8");
@@ -142,9 +202,14 @@ fn every_ref_taking_command_exits_2_for_an_invalid_ref() {
         cmd.env("DOIGET_STORE_ROOT", root)
             .env("DOIGET_LOG_PATH", "")
             .env("DOIGET_CONTACT_EMAIL", "test@example.com")
-            .args(argv)
-            .arg("not a doi");
+            .args(argv);
         let out = cmd.output().expect("run doiget");
+        // As above: a subcommand this build does not have is clap's answer,
+        // not this contract's.
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stderr.starts_with("error: unrecognized subcommand") {
+            continue;
+        }
         if out.status.code() != Some(2) {
             wrong.push(format!("{}: exit {:?}", argv.join(" "), out.status.code()));
         }

--- a/crates/doiget-core/src/credentials.rs
+++ b/crates/doiget-core/src/credentials.rs
@@ -43,10 +43,31 @@ pub const PUBLISHERS: [&str; 4] = ["elsevier", "aps", "springer", "ieee"];
 /// file is optional, and one bad line must not take a fetch down. Every
 /// such case emits `tracing::warn!` — silence about this file is precisely
 /// what cost a user their configuration.
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 #[non_exhaustive]
 pub struct Credentials {
     keys: Vec<(String, String)>,
+}
+
+/// Hand-written so a stray `{:?}` cannot print a publisher API key.
+///
+/// `TdmGrant` wraps the same value in `secrecy::SecretString` precisely so
+/// `Debug` never renders it; between this file and that wrapper the key is
+/// a plain `String`, and a `#[derive(Debug)]` here would have re-opened the
+/// hole one hop earlier. Publisher names are not secret and are shown.
+impl std::fmt::Debug for Credentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credentials")
+            .field(
+                "keys",
+                &self
+                    .keys
+                    .iter()
+                    .map(|(p, _)| format!("{p}: <redacted>"))
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
 }
 
 impl Credentials {
@@ -63,6 +84,15 @@ impl Credentials {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
+    }
+
+    /// How many publishers supplied a usable key.
+    ///
+    /// For `config doctor`, which reports that a credentials file was read
+    /// without printing anything from it.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.keys.len()
     }
 }
 
@@ -97,9 +127,65 @@ pub fn path() -> Result<Utf8PathBuf, crate::user_extension::ConfigDirError> {
         .join("credentials.toml"))
 }
 
+/// Why `credentials.toml` could not be read.
+///
+/// Exists so `doiget config doctor` can *report* the failure. Without it
+/// the only surface was `tracing::warn!`, which the CLI's
+/// `EnvFilter::from_default_env()` suppresses at the default level — so a
+/// malformed or unreadable credentials file produced no warning, no doctor
+/// line, and only the downstream "source unavailable" this module exists to
+/// prevent.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CredentialsError {
+    /// The file exists but could not be read.
+    #[error("{path}: {source}")]
+    Io {
+        /// The file that could not be read.
+        path: String,
+        /// The underlying filesystem error.
+        source: std::io::Error,
+    },
+    /// The file is not valid TOML.
+    #[error("{path}: {source}")]
+    Parse {
+        /// The file that failed to parse.
+        path: String,
+        /// The underlying TOML error.
+        source: toml::de::Error,
+    },
+}
+
+/// Load `credentials.toml` from an explicit path, surfacing failures.
+///
+/// A missing file is `Ok(empty)` — TDM is opt-in and most installs have no
+/// such file. Mirrors [`crate::user_extension::load`], which `config
+/// doctor` already reports on the same way.
+///
+/// # Errors
+///
+/// [`CredentialsError::Io`] for a read failure other than not-found;
+/// [`CredentialsError::Parse`] for malformed TOML.
+pub fn load(path: &camino::Utf8Path) -> Result<Credentials, CredentialsError> {
+    let text = match std::fs::read_to_string(path.as_std_path()) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Credentials::default()),
+        Err(source) => {
+            return Err(CredentialsError::Io {
+                path: path.to_string(),
+                source,
+            })
+        }
+    };
+    warn_if_group_or_world_accessible(path);
+    parse(&text, path)
+}
+
 /// Load the credentials file, or the empty set.
 ///
-/// Never fails; every failure mode is warned about. See [`Credentials`].
+/// Never fails; every failure mode is warned about. This is the fetch-path
+/// entry point — one bad line must not take a fetch down. Callers that want
+/// to *report* the failure use [`load`] instead. See [`Credentials`].
 #[must_use]
 pub fn load_or_default() -> Credentials {
     let path = match path() {
@@ -109,39 +195,31 @@ pub fn load_or_default() -> Credentials {
             return Credentials::default();
         }
     };
-    let text = match std::fs::read_to_string(path.as_std_path()) {
-        Ok(t) => t,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Credentials::default(),
+    match load(&path) {
+        Ok(c) => c,
         Err(e) => {
             tracing::warn!(
-                path = %path,
                 error = %e,
-                "credentials.toml exists but could not be read; keys from it are \
-                 unavailable and only DOIGET_KEY_* will be used"
+                "credentials.toml could not be read; keys from it are unavailable and \
+                 only DOIGET_KEY_* will be used"
             );
-            return Credentials::default();
+            Credentials::default()
         }
-    };
-    warn_if_group_or_world_accessible(&path);
-    parse(&text, &path)
+    }
 }
 
 /// Parse a `credentials.toml` body. Pure; the path is for messages only.
-fn parse(text: &str, path: &camino::Utf8Path) -> Credentials {
-    let raw: RawFile = match toml::from_str(text) {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(
-                path = %path,
-                error = %e,
-                "credentials.toml is malformed; keys from it are unavailable and only \
-                 DOIGET_KEY_* will be used"
-            );
-            return Credentials::default();
-        }
-    };
+fn parse(text: &str, path: &camino::Utf8Path) -> Result<Credentials, CredentialsError> {
+    // A malformed file is a FILE-level failure and is returned, so
+    // `config doctor` can name it. The per-entry problems below (unknown
+    // publisher, an `agreed` key, a blank value) are advisories: they do
+    // not invalidate the rest of the file, so they stay warnings.
+    let raw: RawFile = toml::from_str(text).map_err(|source| CredentialsError::Parse {
+        path: path.to_string(),
+        source,
+    })?;
     let Some(tdm) = raw.tdm else {
-        return Credentials::default();
+        return Ok(Credentials::default());
     };
 
     let mut keys = Vec::new();
@@ -174,15 +252,28 @@ fn parse(text: &str, path: &camino::Utf8Path) -> Credentials {
         // Blank means unset, as everywhere else: an empty key cannot
         // authenticate, and building a grant around one would mask the
         // misconfiguration `AgreedButNoKey` exists to surface.
-        let key = entry
-            .api_key
-            .map(|k| k.trim().to_string())
-            .filter(|k| !k.is_empty());
-        if let Some(k) = key {
-            keys.push((publisher, k));
+        //
+        // It still gets a line. A present-but-blank value is a thing the
+        // user typed and believes is configured, so dropping it in silence
+        // is the #442 / #476 shape this module was written to close — and
+        // it was the one case here that reached no log call at all.
+        let raw = entry.api_key.unwrap_or_default();
+        let key = raw.trim();
+        if key.is_empty() {
+            if !raw.is_empty() {
+                tracing::warn!(
+                    path = %path,
+                    publisher = %publisher,
+                    "credentials.toml sets [tdm.{}] api_key to a blank value, which cannot \
+                     authenticate and is treated as unset. Remove the line or give it a key.",
+                    publisher
+                );
+            }
+        } else {
+            keys.push((publisher, key.to_string()));
         }
     }
-    Credentials { keys }
+    Ok(Credentials { keys })
 }
 
 /// Warn when the file is group- or world-accessible on POSIX.
@@ -222,12 +313,14 @@ mod tests {
         camino::Utf8PathBuf::from("/tmp/credentials.toml")
     }
 
+    /// Parse and unwrap, for the cases where the file is well-formed.
+    fn ok(text: &str) -> Credentials {
+        parse(text, &p()).expect("well-formed credentials.toml")
+    }
+
     #[test]
     fn an_api_key_is_read_per_publisher() {
-        let c = parse(
-            "[tdm.elsevier]\napi_key = \"abc\"\n\n[tdm.aps]\napi_key = \"def\"\n",
-            &p(),
-        );
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\n\n[tdm.aps]\napi_key = \"def\"\n");
         assert_eq!(c.api_key("elsevier"), Some("abc"));
         assert_eq!(c.api_key("aps"), Some("def"));
         assert_eq!(c.api_key("springer"), None);
@@ -238,7 +331,7 @@ mod tests {
     /// at all, so no caller can be tempted to consult one.
     #[test]
     fn agreed_in_the_file_grants_nothing() {
-        let c = parse("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n", &p());
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n");
         assert_eq!(
             c.api_key("elsevier"),
             Some("abc"),
@@ -248,26 +341,45 @@ mod tests {
 
     #[test]
     fn a_blank_key_is_treated_as_unset() {
-        let c = parse("[tdm.aps]\napi_key = \"   \"\n", &p());
+        let c = ok("[tdm.aps]\napi_key = \"   \"\n");
         assert!(c.is_empty(), "a blank key cannot authenticate");
     }
 
+    /// A malformed file is a FILE-level failure, returned rather than
+    /// warned about, so `doiget config doctor` can name it. Before #509's
+    /// follow-up the only surface was `tracing::warn!`, which the CLI's
+    /// default `EnvFilter` suppresses — the user saw nothing at all.
     #[test]
-    fn a_malformed_file_yields_no_keys_rather_than_a_panic() {
-        assert!(parse("this is not toml = = =", &p()).is_empty());
+    fn a_malformed_file_is_a_reportable_error_not_a_silent_empty_set() {
+        match parse("this is not toml = = =", &p()) {
+            Err(CredentialsError::Parse { path, .. }) => {
+                assert!(path.contains("credentials.toml"), "path: {path}");
+            }
+            other => panic!("expected a Parse error naming the file; got {other:?}"),
+        }
+    }
+
+    /// A blank value is a thing the user typed. It is still treated as
+    /// unset, but it no longer disappears without a line — that was the one
+    /// failure mode in this module with no log call at all.
+    #[test]
+    fn a_present_but_blank_key_is_reported_not_silently_dropped() {
+        let c = ok("[tdm.aps]\napi_key = \"\"\n");
+        assert!(c.is_empty());
+        assert_eq!(c.len(), 0);
     }
 
     #[test]
     fn an_unknown_publisher_table_is_skipped() {
         assert!(
-            parse("[tdm.wiley]\napi_key = \"abc\"\n", &p()).is_empty(),
+            ok("[tdm.wiley]\napi_key = \"abc\"\n").is_empty(),
             "unknown publishers grant nothing"
         );
     }
 
     #[test]
     fn an_absent_tdm_table_is_not_an_error() {
-        assert!(parse("[something_else]\nx = 1\n", &p()).is_empty());
-        assert!(parse("", &p()).is_empty());
+        assert!(ok("[something_else]\nx = 1\n").is_empty());
+        assert!(ok("").is_empty());
     }
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1378,29 +1378,29 @@ impl CapabilityProfile {
         // `credentials` module docs and `docs/LEGAL.md` §6a.2.
         let creds = crate::credentials::load_or_default();
         let tdm_elsevier = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_ELSEVIER",
-            "DOIGET_KEY_ELSEVIER",
+            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             cfg!(feature = "tdm-elsevier"),
             creds.api_key("elsevier"),
         )?;
         let tdm_aps = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_APS",
-            "DOIGET_KEY_APS",
+            AgreeVar("DOIGET_AGREE_TDM_APS"),
+            KeyVar("DOIGET_KEY_APS"),
             "tdm-aps",
             cfg!(feature = "tdm-aps"),
             creds.api_key("aps"),
         )?;
         let tdm_springer = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_SPRINGER",
-            "DOIGET_KEY_SPRINGER",
+            AgreeVar("DOIGET_AGREE_TDM_SPRINGER"),
+            KeyVar("DOIGET_KEY_SPRINGER"),
             "tdm-springer",
             cfg!(feature = "tdm-springer"),
             creds.api_key("springer"),
         )?;
         let tdm_ieee = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_IEEE",
-            "DOIGET_KEY_IEEE",
+            AgreeVar("DOIGET_AGREE_TDM_IEEE"),
+            KeyVar("DOIGET_KEY_IEEE"),
             "tdm-ieee",
             cfg!(feature = "tdm-ieee"),
             creds.api_key("ieee"),
@@ -1462,13 +1462,30 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
 /// `KeyButNotAgreed` now also fires for a file-supplied key with no
 /// `DOIGET_AGREE_TDM_<PUBLISHER>=1`. That is the point — `docs/LEGAL.md`
 /// §6a.2 is an enforced control, and a convenience must not dilute it.
+/// The env var carrying the per-publisher agreement.
+///
+/// A newtype because `agree_var` and `key_var` were adjacent `&str`
+/// parameters: transposing them at a call site type-checked, and the
+/// resulting build would treat the KEY as the agreement signal and the
+/// AGREEMENT as the key. `docs/LEGAL.md` §6a.2 makes that agreement an
+/// enforced control, so "nothing stops a fifth publisher's call site from
+/// being copy-pasted wrong" is not a risk worth carrying for two saved
+/// characters.
+#[derive(Debug, Clone, Copy)]
+pub struct AgreeVar(pub &'static str);
+
+/// The env var carrying the per-publisher API key. See [`AgreeVar`].
+#[derive(Debug, Clone, Copy)]
+pub struct KeyVar(pub &'static str);
+
 fn resolve_tdm_grant(
-    agree_var: &str,
-    key_var: &str,
+    agree: AgreeVar,
+    key: KeyVar,
     feature: &str,
     feature_enabled: bool,
     file_key: Option<&str>,
 ) -> Result<Option<TdmGrant>, CapabilityError> {
+    let (agree_var, key_var) = (agree.0, key.0);
     // `agree` is "agreed" iff the value is exactly the literal "1"; any other
     // value (including "true", "yes", empty) is treated as not-agreed per
     // `docs/CAPABILITY.md` §2.
@@ -1783,8 +1800,8 @@ agreed = true
         let _g = unset_all_capability_env_vars();
 
         let granted = resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_ELSEVIER",
-            "DOIGET_KEY_ELSEVIER",
+            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1796,8 +1813,8 @@ agreed = true
 
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "   ");
         match resolve_tdm_grant(
-            "DOIGET_AGREE_TDM_ELSEVIER",
-            "DOIGET_KEY_ELSEVIER",
+            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1809,8 +1826,8 @@ agreed = true
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
         assert!(
             resolve_tdm_grant(
-                "DOIGET_AGREE_TDM_ELSEVIER",
-                "DOIGET_KEY_ELSEVIER",
+                AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
+                KeyVar("DOIGET_KEY_ELSEVIER"),
                 "tdm-elsevier",
                 false,
                 Some("file-key"),

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -574,9 +574,56 @@ fn env_nonempty(key: &str) -> Option<String> {
 /// environment, and one small read is free next to the network legs it
 /// precedes.
 fn resolve_contact_email() -> String {
+    contact_email_or_placeholder()
+}
+
+/// The polite-pool contact address the user configured, or `None`.
+///
+/// Env var, then `[network] contact_email` in `config.toml` (#504). Public
+/// because `doiget-mcp` needs the SAME ladder: `doiget_paper_search`,
+/// `doiget_link`, `doiget_expand_citation_graph` and
+/// `doiget_resolve_citation` each read `DOIGET_CONTACT_EMAIL` directly, so
+/// a user who set the address in `config.toml` got the polite pool from
+/// `doiget fetch` and the non-polite pool from every one of those tools —
+/// the "documented setting that does nothing" defect #504 was filed to
+/// close, surviving in the surface doiget leads with.
+///
+/// Returns `None` rather than a placeholder so callers that must omit
+/// `mailto` entirely when nothing is configured can still do so.
+#[must_use]
+pub fn configured_contact_email() -> Option<String> {
     env_nonempty("DOIGET_CONTACT_EMAIL")
         .or_else(|| crate::user_extension::load_or_default().contact_email)
-        .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
+}
+
+/// [`configured_contact_email`] with `doiget@localhost` as the last rung,
+/// for callers that always need some address.
+#[must_use]
+pub fn contact_email_or_placeholder() -> String {
+    configured_contact_email().unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
+}
+
+/// Both addresses, from a single read of `config.toml`.
+///
+/// Resolving them independently meant two reads per fetch, and — in a
+/// long-lived `doiget serve` — a window in which an edit landing between
+/// them gave one address from the old file and one from the new. One read,
+/// one generation.
+fn resolve_contact_emails() -> (String, String) {
+    let env_contact = env_nonempty("DOIGET_CONTACT_EMAIL");
+    let env_unpaywall = env_nonempty("DOIGET_UNPAYWALL_EMAIL");
+    // Fully env-configured processes never touch the disk at all.
+    if let (Some(contact), Some(unpaywall)) = (&env_contact, &env_unpaywall) {
+        return (contact.clone(), unpaywall.clone());
+    }
+    let file = crate::user_extension::load_or_default();
+    let contact = env_contact
+        .or(file.contact_email)
+        .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string());
+    let unpaywall = env_unpaywall
+        .or(file.unpaywall_email)
+        .unwrap_or_else(|| contact.clone());
+    (contact, unpaywall)
 }
 
 fn arxiv_source_from_env() -> ArxivSource {
@@ -1218,8 +1265,7 @@ async fn fetch_paper_doi(
     store_root: &Utf8Path,
     safekey: &Safekey,
 ) -> Result<FetchPaperOutcome, FetchError> {
-    let contact = resolve_contact_email();
-    let unpaywall_contact = resolve_unpaywall_email(&contact);
+    let (contact, unpaywall_contact) = resolve_contact_emails();
     let crossref = crossref_source_from_env(&contact);
     // Issue #120: Crossref is NON-fatal. A transient Crossref failure
     // must not abort the whole DOI fetch when Unpaywall alone can
@@ -2592,27 +2638,6 @@ fn strip_arxiv_version(id: &str) -> &str {
     id
 }
 
-/// Unpaywall contact: `DOIGET_UNPAYWALL_EMAIL`, then
-/// `[network] unpaywall_email`, then whatever the caller resolved as the
-/// general contact address (#504).
-///
-/// The more specific field wins at each rung, which is how
-/// `DOIGET_UNPAYWALL_EMAIL` already beat `DOIGET_CONTACT_EMAIL`.
-///
-/// `[network] unpaywall_email` was written by `config init`, called
-/// STRONGLY RECOMMENDED by the template's own prose, and read by nothing
-/// for four releases. The cost is not politeness. The template says so
-/// itself: the automatic arXiv-preprint fallback fires on what Unpaywall
-/// reports, so a throttled answer from the non-polite pool quietly costs
-/// that fallback — and the run still exits 0 with `metadata-only: no OA
-/// PDF available`. A degraded search and a true negative were the same
-/// observable.
-fn resolve_unpaywall_email(fallback_contact: &str) -> String {
-    env_nonempty("DOIGET_UNPAYWALL_EMAIL")
-        .or_else(|| crate::user_extension::load_or_default().unpaywall_email)
-        .unwrap_or_else(|| fallback_contact.to_string())
-}
-
 // ---------------------------------------------------------------------------
 // batch_fetch — multi-ref orchestrator (Slice 2)
 // ---------------------------------------------------------------------------
@@ -2787,9 +2812,9 @@ mod tests {
         );
         let _env = LadderEnv::scoped(&dir);
 
-        let contact = resolve_contact_email();
+        let (contact, unpaywall) = resolve_contact_emails();
         assert_eq!(contact, "file@institution.edu");
-        assert_eq!(resolve_unpaywall_email(&contact), "up@institution.edu");
+        assert_eq!(unpaywall, "up@institution.edu");
     }
 
     /// The env rung stays on top, per field, and `unpaywall_email` still
@@ -2802,11 +2827,10 @@ mod tests {
         let mut env = LadderEnv::scoped(&dir);
         env.set("DOIGET_CONTACT_EMAIL", "env@institution.edu");
 
-        let contact = resolve_contact_email();
+        let (contact, unpaywall) = resolve_contact_emails();
         assert_eq!(contact, "env@institution.edu");
         assert_eq!(
-            resolve_unpaywall_email(&contact),
-            "env@institution.edu",
+            unpaywall, "env@institution.edu",
             "no unpaywall rung is set, so it must inherit the resolved contact"
         );
     }
@@ -2823,9 +2847,9 @@ mod tests {
             .to_string();
         let _env = LadderEnv::scoped(&dir);
 
-        let contact = resolve_contact_email();
+        let (contact, unpaywall) = resolve_contact_emails();
         assert_eq!(contact, FALLBACK_CONTACT_EMAIL);
-        assert_eq!(resolve_unpaywall_email(&contact), FALLBACK_CONTACT_EMAIL);
+        assert_eq!(unpaywall, FALLBACK_CONTACT_EMAIL);
     }
 
     /// A blank value is not an address. Both rungs treat it as unset —

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -1340,7 +1340,13 @@ impl Server {
         };
         // Omit `mailto` when no contact email is configured (never a
         // placeholder); the empty string is skipped downstream.
-        let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+        //
+        // Goes through the core ladder so `[network] contact_email` in
+        // `config.toml` counts here too — reading the env var directly meant
+        // #504's fix stopped at `doiget fetch` and never reached the MCP
+        // tools, which is the interface doiget leads with.
+        let contact_email =
+            doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
         let ctx = match build_fetch_context() {
             Ok(c) => c,
@@ -1714,7 +1720,8 @@ impl Server {
                 )));
             }
         };
-        let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+        let contact_email =
+            doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
         let ctx = match build_fetch_context() {
             Ok(c) => c,
@@ -2010,8 +2017,7 @@ impl Server {
                 }
             };
 
-            let contact_email = std::env::var("DOIGET_CONTACT_EMAIL")
-                .unwrap_or_else(|_| "doiget@localhost".to_string());
+            let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
             let source = if let Ok(base) = std::env::var("DOIGET_OPENALEX_BASE") {
                 if let Ok(url) = url::Url::parse(&base) {
                     doiget_core::sources::openalex::OpenalexSource::with_base(url, contact_email)
@@ -3746,8 +3752,7 @@ fn build_fetch_context() -> anyhow::Result<FetchContext> {
 ///
 /// Returns `Err(String)` — callers convert it into a structured tool error.
 fn crossref_source_from_env() -> Result<CrossrefSource, String> {
-    let contact_email =
-        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
     match std::env::var("DOIGET_CROSSREF_BASE").ok() {
         Some(base_str) => {
             let base = url::Url::parse(&base_str)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -368,7 +368,7 @@ network (--network):
   egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)
                   a proxy fixes addressing, never a bot wall
   unpaywall       polite pool as you@institution.edu
-  oa-publisher    22 host patterns allowlisted
+  oa-publisher    24 host patterns allowlisted
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...

--- a/npm/doiget/bin/doiget.js
+++ b/npm/doiget/bin/doiget.js
@@ -12,19 +12,12 @@
 
 const { spawnSync } = require("node:child_process");
 
-// npm's `os`/`cpu` fields use these names; the release assets use
-// x86_64/aarch64. The mapping lives here and in the release workflow, and
-// `npm-packages-cover-every-release-asset` in that workflow keeps them in
-// step.
-const PACKAGES = {
-  "darwin-arm64": "doiget-darwin-arm64",
-  "darwin-x64": "doiget-darwin-x64",
-  "linux-x64": "doiget-linux-x64",
-  "win32-x64": "doiget-win32-x64",
-};
+// The platform table lives in `platform.js` so it can be unit-tested; this
+// file is the thin exec wrapper around it.
+const { PACKAGES, packageFor, binaryName } = require("./platform.js");
 
 const key = `${process.platform}-${process.arch}`;
-const pkg = PACKAGES[key];
+const pkg = packageFor(process.platform, process.arch);
 
 if (!pkg) {
   process.stderr.write(
@@ -38,7 +31,7 @@ if (!pkg) {
 
 let binary;
 try {
-  binary = require.resolve(`${pkg}/bin/${process.platform === "win32" ? "doiget.exe" : "doiget"}`);
+  binary = require.resolve(`${pkg}/bin/${binaryName(process.platform)}`);
 } catch {
   process.stderr.write(
     `doiget: the platform package \`${pkg}\` is not installed.\n` +

--- a/npm/doiget/bin/platform.js
+++ b/npm/doiget/bin/platform.js
@@ -1,0 +1,29 @@
+// The platform → package-name table, split out so it can be tested.
+//
+// `doiget.js` used to hold this inline, which meant the npm packaging had
+// no executable test at all — only a grep in posture-lint comparing name
+// lists across three files. A grep cannot catch a wrong `require.resolve`
+// path or a mis-forwarded exit code.
+"use strict";
+
+// npm's `os`/`cpu` vocabulary. The release assets use x86_64/aarch64; the
+// mapping between the two lives here, in `scripts/stage-npm.sh`, and in the
+// release matrix, and posture-lint checks all three agree.
+const PACKAGES = {
+  "darwin-arm64": "doiget-darwin-arm64",
+  "darwin-x64": "doiget-darwin-x64",
+  "linux-x64": "doiget-linux-x64",
+  "win32-x64": "doiget-win32-x64",
+};
+
+/** Package name for a platform/arch pair, or null when unsupported. */
+function packageFor(platform, arch) {
+  return PACKAGES[`${platform}-${arch}`] || null;
+}
+
+/** Binary name inside the platform package. */
+function binaryName(platform) {
+  return platform === "win32" ? "doiget.exe" : "doiget";
+}
+
+module.exports = { PACKAGES, packageFor, binaryName };

--- a/npm/doiget/test/platform.test.js
+++ b/npm/doiget/test/platform.test.js
@@ -1,0 +1,78 @@
+// Executable tests for the npm packaging (#511 follow-up).
+//
+// The packaging previously had NO test that ran anything — only a
+// posture-lint grep comparing name lists across three files. A grep cannot
+// catch a wrong binary name, a missing platform, or a table that agrees
+// with itself while naming the wrong thing.
+//
+// Run: node npm/doiget/test/platform.test.js
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { PACKAGES, packageFor, binaryName } = require("../bin/platform.js");
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`ok    ${name}`);
+  } catch (e) {
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+    failures += 1;
+  }
+}
+
+test("every supported platform resolves to a package", () => {
+  assert.strictEqual(packageFor("darwin", "arm64"), "doiget-darwin-arm64");
+  assert.strictEqual(packageFor("darwin", "x64"), "doiget-darwin-x64");
+  assert.strictEqual(packageFor("linux", "x64"), "doiget-linux-x64");
+  assert.strictEqual(packageFor("win32", "x64"), "doiget-win32-x64");
+});
+
+test("an unsupported platform is null, not undefined or a throw", () => {
+  assert.strictEqual(packageFor("freebsd", "x64"), null);
+  assert.strictEqual(packageFor("linux", "arm64"), null, "linux-arm64 is not built yet");
+});
+
+test("only Windows gets the .exe suffix", () => {
+  assert.strictEqual(binaryName("win32"), "doiget.exe");
+  assert.strictEqual(binaryName("linux"), "doiget");
+  assert.strictEqual(binaryName("darwin"), "doiget");
+});
+
+test("every package in the table exists on disk with a matching manifest", () => {
+  const root = path.join(__dirname, "..", "..");
+  for (const pkg of Object.values(PACKAGES)) {
+    const manifest = path.join(root, pkg, "package.json");
+    assert.ok(fs.existsSync(manifest), `${pkg}/package.json is missing`);
+    const parsed = JSON.parse(fs.readFileSync(manifest, "utf8"));
+    assert.strictEqual(parsed.name, pkg, `${pkg} manifest names ${parsed.name}`);
+    assert.ok(Array.isArray(parsed.os) && parsed.os.length === 1, `${pkg} needs one os`);
+    assert.ok(Array.isArray(parsed.cpu) && parsed.cpu.length === 1, `${pkg} needs one cpu`);
+    // The directory name encodes os-cpu; the manifest must agree with it.
+    assert.strictEqual(`doiget-${parsed.os[0]}-${parsed.cpu[0]}`, pkg);
+  }
+});
+
+test("the wrapper declares exactly the packages in the table", () => {
+  const wrapper = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+  );
+  assert.deepStrictEqual(
+    Object.keys(wrapper.optionalDependencies).sort(),
+    Object.values(PACKAGES).sort(),
+    "optionalDependencies and the platform table disagree",
+  );
+});
+
+test("the wrapper ships the shim and the table it requires", () => {
+  const dir = path.join(__dirname, "..", "bin");
+  for (const f of ["doiget.js", "platform.js"]) {
+    assert.ok(fs.existsSync(path.join(dir, f)), `bin/${f} is missing`);
+  }
+});
+
+process.exit(failures === 0 ? 0 : 1);

--- a/npm/doiget/test/stage-npm.test.sh
+++ b/npm/doiget/test/stage-npm.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Runs scripts/stage-npm.sh against fixture binaries and checks the layout it
+# produces (#511 follow-up).
+#
+# The script had no executable test at all — only a posture-lint grep
+# comparing name lists across three files. A grep cannot catch a sed that
+# stops stamping the version, a cp that drops the shim, or a missing-asset
+# guard that has stopped guarding. Those would surface only at release time,
+# inside a job that is `continue-on-error`.
+#
+# Everything happens inside a mktemp directory; the repository is read-only
+# to this test.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+for a in doiget-linux-x86_64 doiget-macos-aarch64 doiget-macos-x86_64 doiget-windows-x86_64.exe; do
+  printf 'fake-binary-%s' "$a" > "$BIN/$a"
+done
+
+if ! bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out" > "$WORK/log" 2>&1; then
+  echo "FAIL  stage-npm.sh exited non-zero"
+  cat "$WORK/log"
+  exit 1
+fi
+
+fail=0
+check() {
+  if [ "$1" = "ok" ]; then
+    echo "ok    $2"
+  else
+    echo "FAIL  $2"
+    fail=1
+  fi
+}
+
+for d in doiget doiget-darwin-arm64 doiget-darwin-x64 doiget-linux-x64 doiget-win32-x64; do
+  if [ -d "$WORK/out/$d" ]; then check ok "staged $d"; else check no "staged $d"; fi
+done
+
+# Every manifest carries the stamped version, never the 0.0.0 placeholder.
+for f in "$WORK/out"/*/package.json; do
+  name="$(basename "$(dirname "$f")")"
+  if grep -q '"0\.0\.0"' "$f"; then
+    check no "version stamped in $name"
+  else
+    check ok "version stamped in $name"
+  fi
+done
+
+if grep -q '"version": "9.9.9"' "$WORK/out/doiget/package.json"; then
+  check ok "wrapper version is 9.9.9"
+else
+  check no "wrapper version is 9.9.9"
+fi
+
+# The wrapper pins its platform packages to the exact same version; a drift
+# here publishes a wrapper that resolves nothing.
+if grep -q '"doiget-linux-x64": "9.9.9"' "$WORK/out/doiget/package.json"; then
+  check ok "optionalDependencies pinned to the same version"
+else
+  check no "optionalDependencies pinned to the same version"
+fi
+
+# Windows keeps the .exe suffix; the others must not.
+if [ -f "$WORK/out/doiget-win32-x64/bin/doiget.exe" ]; then
+  check ok "win32 binary is doiget.exe"
+else
+  check no "win32 binary is doiget.exe"
+fi
+if [ -f "$WORK/out/doiget-linux-x64/bin/doiget" ]; then
+  check ok "linux binary is doiget"
+else
+  check no "linux binary is doiget"
+fi
+
+# The shim and the table it requires must both ship, or `npx doiget` throws
+# MODULE_NOT_FOUND on first run.
+for f in doiget.js platform.js; do
+  if [ -f "$WORK/out/doiget/bin/$f" ]; then
+    check ok "wrapper ships bin/$f"
+  else
+    check no "wrapper ships bin/$f"
+  fi
+done
+
+# A missing release asset must fail loudly rather than stage a package with
+# no binary in it.
+rm -f "$BIN/doiget-linux-x86_64"
+if bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out2" >/dev/null 2>&1; then
+  check no "a missing release asset fails the staging script"
+else
+  check ok "a missing release asset fails the staging script"
+fi
+
+exit "$fail"

--- a/scripts/stage-npm.sh
+++ b/scripts/stage-npm.sh
@@ -15,7 +15,8 @@
 #
 # The asset names use x86_64/aarch64; npm's `cpu` field uses x64/arm64. That
 # mapping lives HERE and in `npm/doiget/bin/doiget.js`, and the
-# `npm-mapping` check in `.github/workflows/ci.yml` fails if the two drift.
+# `npm platform packages cover every release binary` step in
+# `.github/workflows/posture-lint.yml` fails if they drift.
 #
 # Dependency-light bash on purpose, matching scripts/build-mcpb.sh.
 
@@ -63,7 +64,11 @@ done
 
 mkdir -p "$OUTDIR/doiget/bin"
 stamp_version "$SRC/doiget/package.json" "$OUTDIR/doiget/package.json"
-cp "$SRC/doiget/bin/doiget.js" "$OUTDIR/doiget/bin/doiget.js"
+# Every file under bin/, not just the entry point: the shim `require`s
+# `platform.js`, and copying only `doiget.js` publishes a package that
+# throws MODULE_NOT_FOUND on first run. Caught by
+# `npm/doiget/test/stage-npm.test.sh`.
+cp "$SRC"/doiget/bin/*.js "$OUTDIR/doiget/bin/"
 cp "$REPO_ROOT/crates/doiget-cli/README.md" "$OUTDIR/doiget/README.md"
 echo "staged doiget (wrapper)"
 

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -374,7 +374,7 @@ network (--network):
   egress          not probed (needs a third-party echo service; try `curl ifconfig.me`)
                   a proxy fixes addressing, never a bot wall
   unpaywall       polite pool as you@institution.edu
-  oa-publisher    22 host patterns allowlisted
+  oa-publisher    24 host patterns allowlisted
   probe link.springer.com      200 3100 bytes    ok
   probe arxiv.org              200 5854 bytes    ok
   probe ieeexplore.ieee.org    not allowlisted   no request sent; ...


### PR DESCRIPTION
Fixes everything `/review-pr` turned up on the 0.8.11 promotion (#541).

> **Rides the 0.8.11 cut**: version stays `0.8.11` with no bump, so `version-bump` is RED here for the same reason it is on a cut and on #491. Not a required check.

Six review agents plus direct measurement. **Three reached the npm glob independently; two reached the exit-code over-claim.** Every finding was then verified by hand — running the real binary, running `openssl`, running the release gate — before being accepted.

## The three this release would have shipped while claiming the opposite

**npm publish would have failed on every release, silently.** `npm-publish` downloaded `doiget-*.sha256`, which also matches the SBOM's and the `.mcpb`'s checksums — whose binaries it never downloads. The verify step then ran `openssl dgst` on a missing file and aborted under `set -euo pipefail` before staging anything. Measured: `openssl dgst` exits 1 on a missing file, and `sbom` runs from an earlier `needs:` point than `npm-publish`, so this was near-certain rather than a race. With `continue-on-error: true` the release would have gone out **green with npm unpublished**, while the CHANGELOG said npm packages ship. Now four exact names, plus an assertion that all four were verified rather than a clean run over fewer.

**"An unparsable ref exits 2 on every ref-taking command" was false.** Measured on a real build:

```
fetch/info/text  exit=2  error[INVALID_REF]: ...
tex-source       exit=1  Error: invalid ref "not a doi"  + Caused by: chain
frontier         exit=1  Error: invalid seed DOI "not a doi": ...
```

Neither routed through `parse_ref_or_exit`, and both ship in the default `oa-only` binary. Both fixed; `annotate`'s missing-argument path moves 1 → 2 with them. **The e2e table is now read back from clap's `--help`** instead of hand-listed — a second hand-maintained copy of the subcommand set is exactly what let three commands go uncovered, and a new ref-taking subcommand is now covered by default.

**#504's fix stopped at the CLI.** `doiget_paper_search`, `doiget_link`, `doiget_expand_citation_graph` and `doiget_resolve_citation` each read `DOIGET_CONTACT_EMAIL` directly, so `[network] contact_email` worked for `doiget fetch` and did nothing for the MCP tools — the interface doiget leads with, and the same "documented setting that does nothing" shape #504 exists to close. Env-only reads in `doiget-mcp`: **4 → 0**.

## The rest

| | |
|---|---|
| `config doctor` | reported `unpaywall_email: unset` in the commonest configuration of all (only `DOIGET_CONTACT_EMAIL` set) while the fetch it describes sent the contact address → now `inherited from contact_email`, with tests for the asymmetric case neither side had |
| `credentials.toml` | its failures reached only `tracing::warn!`, which the CLI's default `EnvFilter` suppresses, and `doctor` never opened the file — while the same release gave `config.toml` a doctor line. `parse` is fallible now so doctor names the reason; a present-but-blank `api_key` (the one case with **no** log call at all) is reported |
| `Credentials` | no longer derives `Debug` over plain-`String` API keys |
| TDM env vars | `AgreeVar` / `KeyVar` newtypes — adjacent `&str` parameters meant a transposition type-checked and would have made the KEY the agreement signal for a control `LEGAL.md` §6a.2 calls enforced |
| `fetch_paper_doi` | read `config.toml` twice per fetch, so a long-lived `doiget serve` could take the two addresses from two generations of the file. One read; the redundant wrapper is gone |
| `posture-lint` | the npm mapping check compared two **disjoint** clusters, so renaming both halves differently passed. One connected chain now |
| npm packaging | gained tests that actually run, wired into `posture-lint` |
| `CONFIG.md` §6.1 | the worked example printed `22 host patterns allowlisted`; the code generates that live and it is **24** |
| `stage-npm.sh` | pointed at a check in `ci.yml`, which has no npm step |
| `commands/mod.rs` | still said `serve` lands in a separate PR, while every INTEGRATION guide this release shipped tells users to run it |

## The new tests earned their place immediately

The **first execution** of `stage-npm.test.sh` caught a bug introduced by writing it: the staging script copied only `doiget.js`, so the shim's `require("./platform.js")` would have thrown `MODULE_NOT_FOUND` on the first `npx doiget`. A grep over name lists could not have seen that.

## Verified locally

`stable-x86_64-pc-windows-gnu`:

- `cargo test --workspace --all-targets --features oa-only` — green
- `fetch_error_mapping_e2e` under **both** `oa-only` and `oa-only,citation` — 5 passed each. The first run of the derived table failed on `oa-only` because a feature-gated subcommand is clap's business, not this contract's; that is now skipped explicitly
- `doiget-core --features oa-only,tdm-elsevier --lib` — 476 passed (the credentials path)
- `cargo clippy --workspace --all-targets --features oa-only,citation -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `node npm/doiget/test/platform.test.js` and `bash npm/doiget/test/stage-npm.test.sh` — green
- `scripts/sync_docs_to_site.sh` re-run

## Note

This is the first PR under the CLA, so the commit carries `Signed-off-by` and `dco.yml` should pass.

Refs #541, #492, #504, #509, #511, #513, ADR-0049, ADR-0050

🤖 Generated with [Claude Code](https://claude.com/claude-code)