### PR TITLE
fix: round 2 of the #541 pre-release review

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,6 +15,17 @@ name: dco
 #                      cannot grant a copyright license, so asking them to
 #                      certify one is meaningless. Matched on the `[bot]`
 #                      suffix GitHub appends to every App author name.
+#   * promotion PRs  — `next` -> `main` is not a contribution. It re-presents
+#                      commits this same job already gated when they landed
+#                      on `next`, so checking them again asks one question
+#                      twice and can answer it differently: a promotion's
+#                      range is the whole release, and for any release
+#                      spanning ADR-0051's own introduction that range holds
+#                      commits which predate the CLA and can never acquire a
+#                      trailer — `next` is protected, its history cannot be
+#                      rewritten. A job that is red whatever the author does
+#                      is not a gate; it is noise that teaches people to
+#                      ignore the gate.
 #
 # Third-party Actions are SHA-pinned (repo invariant / ADR-0013 supply-chain).
 
@@ -47,7 +58,27 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
+      # Structural, not discretionary — see the exemption list in the header.
+      # `head_ref` is compared too, so a topic branch that merely targets
+      # `main` is still checked; only the literal `next` -> `main` promotion
+      # is exempt.
+      - name: Is this the next -> main promotion?
+        id: promotion
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$BASE_REF" = "main" ] && [ "$HEAD_REF" = "next" ]; then
+            echo "promotion=true" >> "$GITHUB_OUTPUT"
+            echo "next -> main promotion: every commit here was sign-off gated when it landed on next."
+          else
+            echo "promotion=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Every non-bot, non-merge commit carries a Signed-off-by trailer
+        if: steps.promotion.outputs.promotion != 'true'
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -126,20 +126,37 @@ jobs:
           # The npm `os`/`cpu` names (darwin/win32, x64/arm64) and the release
           # asset names (macos/windows, x86_64/aarch64) are different
           # vocabularies for the same four targets, so the mapping is written
-          # twice: `scripts/stage-npm.sh` (MAP) and `npm/doiget/bin/doiget.js`
+          # twice: `scripts/stage-npm.sh` (MAP) and `npm/doiget/bin/platform.js`
           # (PACKAGES). Two hand-maintained copies of one table is the #454 /
           # #504 shape, so it is checked rather than trusted.
           #
           # Third copy, and the one that moves: the `sign` matrix in
           # release-plz.yml. A new target added there with no npm package
           # would publish a wrapper that cannot run on it.
-          assets="$(grep -oE 'artifact: doiget-[a-z0-9_.-]+' .github/workflows/release-plz.yml \
+          #
+          # `capture` exists because each of these greps is itself a silent
+          # failure waiting to happen: under `set -euo pipefail` a grep that
+          # matches nothing exits 1 and kills the step with NO output at all.
+          # Not hypothetical — the PACKAGES table moved from `doiget.js` to
+          # `platform.js` and this step went red with an empty log, which
+          # reads as infrastructure flake rather than as the drift it was
+          # actually detecting.
+          capture() {
+            local out
+            out="$(grep -oE "$1" "$2" || true)"
+            if [ -z "$out" ]; then
+              echo "::error::posture-lint npm: /$1/ matched nothing in $2 — the table it reads has moved or been renamed (#511)"
+              exit 1
+            fi
+            printf '%s\n' "$out"
+          }
+          assets="$(capture 'artifact: doiget-[a-z0-9_.-]+' .github/workflows/release-plz.yml \
                     | sed 's/artifact: //' | sort -u)"
-          staged="$(grep -oE '^doiget-[a-z0-9-]+:doiget-[a-z0-9_.-]+:' scripts/stage-npm.sh \
+          staged="$(capture '^doiget-[a-z0-9-]+:doiget-[a-z0-9_.-]+:' scripts/stage-npm.sh \
                     | cut -d: -f2 | sort -u)"
-          shimmed="$(grep -oE '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/bin/doiget.js \
+          shimmed="$(capture '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/bin/platform.js \
                      | tr -d '"' | sort -u)"
-          pkgs="$(grep -oE '^doiget-[a-z0-9-]+:' scripts/stage-npm.sh | tr -d ':' | sort -u)"
+          pkgs="$(capture '^doiget-[a-z0-9-]+:' scripts/stage-npm.sh | tr -d ':' | sort -u)"
 
           fail=0
           # `.exe` is appended by the matrix `ext:` field, so compare stems.
@@ -150,14 +167,14 @@ jobs:
             fail=1
           fi
           if [ "$pkgs" != "$shimmed" ]; then
-            echo "::error::posture-lint npm: scripts/stage-npm.sh and npm/doiget/bin/doiget.js name different packages (#511)"
+            echo "::error::posture-lint npm: scripts/stage-npm.sh and npm/doiget/bin/platform.js name different packages (#511)"
             printf 'stage-npm.sh:\n%s\nshim:\n%s\n' "$pkgs" "$shimmed"
             fail=1
           fi
           # Every package the wrapper declares must exist as a directory, and
           # vice versa — an optionalDependency that resolves to nothing fails
           # SILENTLY at install time, which is the whole failure mode.
-          declared="$(grep -oE '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/package.json \
+          declared="$(capture '"doiget-(darwin|linux|win32)-[a-z0-9]+"' npm/doiget/package.json \
                       | tr -d '"' | sort -u)"
           onDisk="$(find npm -maxdepth 1 -mindepth 1 -type d -name 'doiget-*' -printf '%f\n' | sort -u)"
           if [ "$declared" != "$onDisk" ]; then
@@ -177,6 +194,10 @@ jobs:
           fi
           [ "$fail" -eq 0 ]
           echo "npm mapping OK: $(echo "$pkgs" | tr '\n' ' ')"
+
+      - name: release checksum verification test (#511)
+        shell: bash
+        run: bash npm/doiget/test/release-checksums.test.sh
 
       - name: npm packaging tests (#511)
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,10 +162,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   each read `DOIGET_CONTACT_EMAIL` directly, so a user who configured the
   address in `config.toml` got the polite pool from `doiget fetch` and the
   non-polite pool from every MCP tool — the interface doiget leads with. All
-  four now go through the same ladder. `config doctor` also reported
+  four now go through the same ladder. `config show` also reported
   `unpaywall_email: unset` in the commonest configuration of all (only
   `DOIGET_CONTACT_EMAIL` set) while the fetch it describes was sending the
   contact address; it now reports `inherited from contact_email`.
+
+  Round 2 found that fix had stopped at the MCP boundary: `graph`, `frontier`,
+  `link`, `search` and `resolve-citation` still read `DOIGET_CONTACT_EMAIL`
+  directly and so still ignored `config.toml`, with the fallback hand-copied five
+  times into two mutually inconsistent policies. All of them, and the dormant copy
+  in `OrchestratorConfig`, now go through the core resolver. `config doctor` also
+  gained the `unpaywall_email` line it never had — the round-1 note above credited
+  `doctor` for a change that landed in `show`, and `doctor` is the surface meant to
+  be worth trusting.
 - **[ci]** **The npm publish would have failed on every release, silently.** The
   `npm-publish` job downloaded `doiget-*.sha256`, a glob that also matches the SBOM's
   and the `.mcpb`'s checksums — whose binaries it never downloads — so the verify
@@ -185,15 +194,71 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 - **[config]** `credentials.toml`'s failure modes reached only `tracing::warn!`, which
   the CLI's default `EnvFilter` suppresses — so a malformed or group-readable file
   produced no warning, no `doctor` line, and only the downstream "source unavailable"
-  the feature exists to prevent. `config doctor` now reports it the same way it already
-  reported `config.toml`, and a present-but-blank `api_key` — the one case with no log
-  call at all — is named rather than dropped (#509).
+  the feature exists to prevent. Everything a reader can learn about the file is now
+  data rather than a log record: file-level failures are a `CredentialsError`, and
+  per-entry problems — a world-readable mode, an `api_key` the user typed and left
+  blank, an `agreed` doiget does not read — are `Advisory` values `config doctor`
+  prints as failing lines (#509).
+
+  Round 1 of the pre-release review claimed both halves of this and delivered
+  neither in full. `config doctor` surfaced only whole-file parse and IO errors: a
+  `chmod 644` on a file holding publisher keys still reported `[ ok ]`, which made
+  "the `0600` check is a real control rather than a sentence" untrue in the module
+  whose own doc comment says it. And the blank-key warning did not fire for
+  `api_key = ""` — `Option::unwrap_or_default()` collapses `None` and `Some("")` to
+  one empty string, so the commonest form of the case was still the silent one. Its
+  test used that exact input and asserted only the key count, so it passed.
 - **[core]** `Credentials` no longer derives `Debug` over plain-`String` API keys; a
   hand-written impl redacts them, applying one hop earlier the same protection
-  `secrecy::SecretString` gives the value once it reaches `TdmGrant`. The TDM env-var
-  pair also moved behind `AgreeVar`/`KeyVar` newtypes: they were adjacent `&str`
-  parameters, so transposing them at a call site type-checked and would have made the
-  KEY the agreement signal for a control `docs/LEGAL.md` §6a.2 calls enforced (#509).
+  `secrecy::SecretString` gives the value once it reaches `TdmGrant`. The two raw
+  deserialisation structs, which hold the key untrimmed and unredacted one hop before
+  that, no longer derive `Debug` either. The TDM env-var pair also moved behind
+  `AgreeVar`/`KeyVar` newtypes: they were adjacent `&str` parameters, so transposing
+  them at a call site type-checked and would have made the KEY the agreement signal
+  for a control `docs/LEGAL.md` §6a.2 calls enforced (#509).
+
+  Round 1 of the review closed that hole and **opened a more direct one**: making
+  `parse` fallible put a `toml::de::Error` inside `CredentialsError::Parse`, and that
+  error's `Display` quotes the offending source line verbatim. The commonest way this
+  file is malformed is a pasted key with a stray quote in it — so the error most
+  likely to reach a terminal was the one whose quoted line *is* the key, and `config
+  doctor` printed it. Its `Debug` is worse: it carries the whole file. The variant now
+  carries the path, line, column and the parser's own message, and a test asserts a
+  planted key appears in neither `Display` nor `Debug`.
+- **[ci]** `posture-lint`'s npm mapping check went red **with an empty log**. Its
+  grep read the platform table out of `npm/doiget/bin/doiget.js` after that table had
+  moved to `platform.js`; under `set -euo pipefail` a grep matching nothing exits 1
+  and kills the step before it can print anything, so a check that had correctly
+  detected drift looked like infrastructure flake — and the packaging tests queued
+  behind it never ran at all. Every grep in the step now goes through a helper that
+  turns "matched nothing" into a named error (#511).
+- **[ci]** `dco` could never pass on a `next → main` promotion. A promotion's commit
+  range is the whole release, and for the release that introduces ADR-0051 that range
+  holds commits predating the CLA which can never acquire a trailer — `next` is
+  protected and its history cannot be rewritten. A job that is red whatever the author
+  does is not a gate. Promotions are now exempt on the same structural grounds as
+  merge commits and bots: they re-present commits this job already gated when they
+  landed on `next` (ADR-0051).
+- **[cli]** `fetch` and `graph` were the last two commands carrying
+  `parse_ref_or_exit`'s body hand-inlined rather than calling it, which is how they
+  came to disagree about the exit code in the first place (#492).
+- **[core]** The whole rule set for `resolve_tdm_grant` — `docs/CAPABILITY.md` §2's
+  behaviour, the `AgreedButNoKey` / `KeyButNotAgreed` cases, the `credentials.toml`
+  precedence note — was rendering as the documentation of a one-line newtype. The
+  round-1 commit put `AgreeVar`'s doc block directly after the function's with no
+  separator, and rustdoc attaches a `///` run to the next item only, so the function
+  it describes had none at all. `AgreeVar`/`KeyVar` are `pub(crate)` with private
+  fields now: their only consumer is a private `fn`, and the public tuple field left
+  `AgreeVar("DOIGET_KEY_ELSEVIER")` — the same transposition expressed as content
+  rather than position — compiling cleanly (#509).
+- **[ci]** The `npm-publish` checksum loop and `stage-npm.sh`'s missing-asset guard
+  both gained tests that fail when they are broken. The guard's existing test checked
+  only the exit code, which stays non-zero when the guard is deleted because the `cp`
+  behind it fails too — so deleting it outright still passed, while leaving a
+  half-staged package on disk. The checksum loop, the fix for the defect this cluster
+  started from, had no test at all: it is now extracted from the workflow and run
+  against synthetic release directories, including the orphaned-checksum case that
+  caused the original silent failure (#511).
 - **[cli/mcp]** The config-directory resolver existed as two hand-maintained copies whose
   own comment warned that divergence "would silently desync the user-extension allowlist
   surfaces". They had already diverged: the CLI accepted `XDG_CONFIG_HOME=""` and

--- a/crates/doiget-cli/src/commands/config.rs
+++ b/crates/doiget-cli/src/commands/config.rs
@@ -60,7 +60,7 @@ pub struct ResolvedConfig {
     pub contact_email_source: String,
     /// Unpaywall-specific contact email. Inherits `contact_email` when no
     /// Unpaywall-specific rung is set, matching
-    /// `doiget_core::orchestrator::resolve_unpaywall_email` — the reporting
+    /// `doiget_core::orchestrator::resolve_contact_emails` — the reporting
     /// side used to omit that fallback and print `unset` for the commonest
     /// configuration of all (only `DOIGET_CONTACT_EMAIL` set), while the
     /// fetch it describes was sending the contact address.
@@ -102,7 +102,7 @@ impl EmailSource {
 
 /// Resolve one address across env → `config.toml` → nothing.
 ///
-/// Mirrors `doiget_core::orchestrator::resolve_contact_email`. Two
+/// Mirrors `doiget_core::orchestrator::configured_contact_email`. Two
 /// separate readers is the hazard #441 named, so the shared half — which
 /// file, and how it parses — lives in `doiget_core::user_extension`, and
 /// only the rung order is restated here. Both ends are pinned:
@@ -364,6 +364,21 @@ pub async fn run(
                 ),
                 &mut all_ok,
             );
+            // `config show` reports which rung answered for Unpaywall;
+            // doctor did not mention the address at all, so the surface
+            // meant to be the trustworthy one was silent about a request
+            // doiget actually makes. Never a failure on its own — it
+            // inherits `contact_email`, whose line above carries the remedy.
+            check(
+                &format!(
+                    "unpaywall_email: {} (from: {})",
+                    cfg.unpaywall_email.as_deref().unwrap_or("unset"),
+                    cfg.unpaywall_email_source
+                ),
+                true,
+                None,
+                &mut all_ok,
+            );
             // ADR-0028 D2: surface user-extension allowlist health. A
             // missing config.toml is normal (curated set only); a
             // present-but-malformed config.toml is a doctor failure so
@@ -452,6 +467,23 @@ pub async fn run(
                         None,
                         &mut all_ok,
                     );
+                    // A file that parses can still be wrong in ways that
+                    // cost the user a key: mode 0644 on a file holding
+                    // publisher credentials, an `api_key = ""` they believe
+                    // is set, an `agreed` this tool does not read. Each was
+                    // a `tracing::warn!` and nothing else, which the
+                    // default `EnvFilter` throws away — so the `0600` check
+                    // `docs/CONFIG.md` §6 promises reached nobody. Each is
+                    // a failing line here, because each is a thing the user
+                    // has to act on.
+                    for advisory in creds.advisories() {
+                        check(
+                            &format!("credentials.toml: {advisory}"),
+                            false,
+                            None,
+                            &mut all_ok,
+                        );
+                    }
                 }
                 Err(e) => check(
                     &format!("credentials.toml invalid: {e}"),
@@ -989,7 +1021,7 @@ mod tests {
 
     /// The commonest configuration of all: only `DOIGET_CONTACT_EMAIL` is
     /// set. The fetch path sends that address to Unpaywall
-    /// (`resolve_unpaywall_email` falls back to the resolved contact), so
+    /// (`resolve_contact_emails` falls back to the resolved contact), so
     /// `doctor` and `show` must say so. They used to print `unset`, which
     /// described a request doiget does not make.
     #[test]
@@ -1368,6 +1400,90 @@ mod tests {
             .downcast_ref::<CliExit>()
             .expect("failing doctor must carry a CliExit");
         assert_eq!(cli_exit.0, 2);
+    }
+
+    /// `credentials.toml`'s reader is unit-tested; its WIRING into doctor
+    /// was not. Nothing failed if `cred_path` were built from the wrong
+    /// directory, or if the `Err` arm stopped setting `all_ok = false` —
+    /// which is the whole reason the check was added.
+    ///
+    /// Linux only, for the same reason as
+    /// `doctor_fails_with_malformed_user_extension_config`: `XDG_CONFIG_HOME`
+    /// is the only hermetic way to redirect the config dir.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn doctor_fails_when_credentials_toml_is_malformed() {
+        let _g = unset_all_doiget_config_env();
+        let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        // An unterminated string: the commonest way a pasted key breaks
+        // this file, and the case whose parser message must not be echoed.
+        std::fs::write(
+            doiget_dir.join("credentials.toml").as_std_path(),
+            "[tdm.elsevier]\napi_key = \"sk-unterminated\n",
+        )
+        .expect("write credentials.toml");
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+
+        let err = run(
+            "doctor".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("doctor must fail when credentials.toml is malformed");
+        assert_eq!(
+            err.downcast_ref::<CliExit>()
+                .expect("failing doctor must carry a CliExit")
+                .0,
+            2
+        );
+    }
+
+    /// A file that parses but carries an advisory must fail doctor too.
+    /// Otherwise `[ ok ] credentials.toml keys loaded: 0` is the entire
+    /// report for a user who typed a key and did not get one.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn doctor_fails_when_credentials_toml_carries_an_advisory() {
+        let _g = unset_all_doiget_config_env();
+        let _email = EnvGuard::set("DOIGET_CONTACT_EMAIL", "alice@example.org");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg_root = camino::Utf8Path::from_path(tmp.path()).expect("utf8 tempdir");
+        let doiget_dir = cfg_root.join("doiget");
+        std::fs::create_dir_all(doiget_dir.as_std_path()).expect("mk dir");
+        // Well-formed TOML; the key is present and blank.
+        std::fs::write(
+            doiget_dir.join("credentials.toml").as_std_path(),
+            "[tdm.aps]\napi_key = \"\"\n",
+        )
+        .expect("write credentials.toml");
+        let _x = EnvGuard::set("XDG_CONFIG_HOME", cfg_root.as_str());
+
+        let err = run(
+            "doctor".into(),
+            crate::commands::output::OutputMode::Human,
+            false,
+            false,
+            false,
+        )
+        .await
+        .expect_err("a blank api_key must be reported, not passed over");
+        assert_eq!(
+            err.downcast_ref::<CliExit>()
+                .expect("failing doctor must carry a CliExit")
+                .0,
+            2
+        );
     }
 
     /// Issue #322: `check` must emit a `tip:` line to stderr when the

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -399,10 +399,14 @@ impl OrchestratorConfig {
     fn from_env() -> Result<Self> {
         let store_root = super::resolve_store_root()?;
         let log_path = resolve_log_path()?;
-        let contact_email =
-            std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".into());
-        let unpaywall_email =
-            std::env::var("DOIGET_UNPAYWALL_EMAIL").unwrap_or_else(|_| contact_email.clone());
+        // Through the core resolver even though this struct is not read
+        // yet: a dormant third copy of the ladder is still a copy, and it
+        // is the one nobody would think to update.
+        let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
+        let unpaywall_email = std::env::var("DOIGET_UNPAYWALL_EMAIL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| contact_email.clone());
         Ok(Self {
             store_root,
             log_path,
@@ -723,17 +727,11 @@ pub async fn run_with_options(
     // mode.
     // Step 1: parse + safekey. Issue #119: render the cargo-style
     // `error[INVALID_REF]:` line + carry the exit code, rather than
-    // letting the granular `RefParseError` fall out as an opaque
-    // anyhow `{:?}` dump.
-    let ref_ = match Ref::parse(&input) {
-        Ok(r) => r,
-        Err(e) => {
-            super::render_ref_parse_error(&e);
-            return Err(anyhow::Error::new(CliExit(cli_exit_code(
-                ErrorCode::InvalidRef,
-            ))));
-        }
-    };
+    // letting the granular `RefParseError` fall out as an opaque anyhow
+    // `{:?}` dump. Through the shared helper (#492) so a change to the
+    // wording or the code reaches every command at once — this and `graph`
+    // were the last two hand-inlined copies of its body.
+    let ref_ = super::parse_ref_or_exit(&input)?;
 
     // Dry-run branch: build the plan and emit it. NO harness, NO network,
     // NO store write, NO provenance row. Posture-lint ADR-0022 §5 will

--- a/crates/doiget-cli/src/commands/frontier.rs
+++ b/crates/doiget-cli/src/commands/frontier.rs
@@ -63,7 +63,10 @@ pub async fn run(
         url::Url::parse(&raw)
             .with_context(|| format!("DOIGET_OPENALEX_BASE is not a URL: {raw}"))?
     };
-    let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+    // `unwrap_or_default`, not the placeholder: an unset address means
+    // `mailto` is omitted rather than sent as `doiget@localhost`. Routed
+    // through the core resolver so config.toml's rung counts (#504).
+    let contact_email = doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
     let harness = FetchHarness::from_env().context("building fetch harness")?;
     harness

--- a/crates/doiget-cli/src/commands/graph.rs
+++ b/crates/doiget-cli/src/commands/graph.rs
@@ -55,21 +55,12 @@ pub async fn run(
     // `_mode` is threaded per ADR-0017 / #144. Graph's JSON output is
     // product output (the requested artifact), not informational; Quiet
     // does NOT suppress it.
-    let ref_ = match Ref::parse(&input) {
-        Ok(r) => r,
-        Err(e) => {
-            // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2
-            // (issue #149). Routed through `cli_exit_code` since #492:
-            // this used to hard-code the 2 while `fetch` fell to the
-            // generic 1, so the same input got two answers out of one
-            // binary and the comment here asserted a consistency that
-            // did not hold.
-            super::render_ref_parse_error(&e);
-            return Err(anyhow::Error::new(CliExit(
-                crate::commands::fetch::cli_exit_code(doiget_core::ErrorCode::InvalidRef),
-            )));
-        }
-    };
+    // Bad ref string is user misuse -> `docs/ERRORS.md` §4 exit 2 (issue
+    // #149). Through the shared helper (#492): this used to hard-code the 2
+    // while `fetch` fell to the generic 1, so the same input got two
+    // answers out of one binary and the comment here asserted a consistency
+    // that did not hold. Sharing the helper is what makes it hold.
+    let ref_ = super::parse_ref_or_exit(&input)?;
     let doi = match &ref_ {
         Ref::Doi(d) => d.clone(),
         Ref::Arxiv(_) => {
@@ -101,8 +92,10 @@ pub async fn run(
         ))));
     }
 
-    let contact_email =
-        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    // Through the core resolver, not `std::env::var`: `[network]
+    // contact_email` in config.toml is a documented rung (#504), and a
+    // command that reads only the environment silently ignores it.
+    let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
     let source = if let Ok(base) = std::env::var("DOIGET_OPENALEX_BASE") {
         if let Ok(url) = url::Url::parse(&base) {
             OpenalexSource::with_base(url, contact_email)

--- a/crates/doiget-cli/src/commands/link.rs
+++ b/crates/doiget-cli/src/commands/link.rs
@@ -46,8 +46,9 @@ pub async fn run(ref_: String, mode: OutputMode, quiet_was_explicit: bool) -> Re
 
     let base = resolve_openalex_base()?;
     // Omit `mailto` when no contact email is configured (never a
-    // placeholder); the empty string is skipped downstream.
-    let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+    // placeholder); the empty string is skipped downstream. Resolved
+    // through the core ladder so config.toml's rung counts (#504).
+    let contact_email = doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
     let ctx = build_resolve_context().context("building fetch context")?;
 
     let links = match resolve_links_for_doi(&base, &contact_email, doi.as_str(), &ctx).await {

--- a/crates/doiget-cli/src/commands/mod.rs
+++ b/crates/doiget-cli/src/commands/mod.rs
@@ -56,8 +56,9 @@ pub fn parse_ref_or_exit(input: &str) -> anyhow::Result<doiget_core::Ref> {
     }
 }
 
-/// The renderer on its own, for the two call sites that build their own
-/// `CliExit` rather than going through [`parse_ref_or_exit`].
+/// The renderer on its own, for call sites holding a
+/// [`doiget_core::RefParseError`] that did not come from
+/// [`parse_ref_or_exit`].
 ///
 /// Both now take the exit code from `fetch::cli_exit_code(InvalidRef)`,
 /// which is **2** since #492 / ADR-0049. Before that `fetch` fell to the

--- a/crates/doiget-cli/src/commands/resolve_citation.rs
+++ b/crates/doiget-cli/src/commands/resolve_citation.rs
@@ -34,8 +34,10 @@ fn build_context() -> Result<FetchContext> {
 }
 
 fn build_crossref_source() -> Result<CrossrefSource> {
-    let contact_email =
-        std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_else(|_| "doiget@localhost".to_string());
+    // Through the core resolver, not `std::env::var`: `[network]
+    // contact_email` in config.toml is a documented rung (#504), and a
+    // command that reads only the environment silently ignores it.
+    let contact_email = doiget_core::orchestrator::contact_email_or_placeholder();
     match std::env::var("DOIGET_CROSSREF_BASE").ok() {
         Some(base_str) => {
             let base = url::Url::parse(&base_str).context("invalid DOIGET_CROSSREF_BASE")?;

--- a/crates/doiget-cli/src/commands/search.rs
+++ b/crates/doiget-cli/src/commands/search.rs
@@ -218,7 +218,8 @@ async fn run_external(
     // Leave `mailto` unset when no contact email is configured: send a real
     // address (polite pool) or none, never a non-routable placeholder. The
     // empty string is skipped by `build_search_url` / `resolve_entity_id`.
-    let contact_email = std::env::var("DOIGET_CONTACT_EMAIL").unwrap_or_default();
+    // Resolved through the core ladder so config.toml's rung counts (#504).
+    let contact_email = doiget_core::orchestrator::configured_contact_email().unwrap_or_default();
 
     let harness = FetchHarness::from_env().context("building fetch harness")?;
     harness

--- a/crates/doiget-core/src/credentials.rs
+++ b/crates/doiget-core/src/credentials.rs
@@ -11,7 +11,10 @@
 //! **`api_key`: yes.** A long-lived key is genuinely better off in a file
 //! than in the environment. It survives a shell restart, it is not visible
 //! in `ps`, and it does not leak into the environment of every subprocess.
-//! The `0600` check is then a real control rather than a sentence.
+//! The `0600` check is then a real control rather than a sentence — which
+//! means it has to be *visible*, so it is an [`Advisory`] that `config
+//! doctor` prints rather than a `tracing::warn!` the default log level
+//! throws away.
 //!
 //! **`agreed`: no.** `docs/LEGAL.md` §6a.2 makes the per-publisher
 //! agreement an *enforced control*, and part of why it is meaningful is
@@ -37,16 +40,93 @@ use serde::Deserialize;
 /// in `docs/CONFIG.md` §6 and the `tdm-<slug>` Cargo features.
 pub const PUBLISHERS: [&str; 4] = ["elsevier", "aps", "springer", "ieee"];
 
+/// Something worth telling the user that does not stop the rest of the
+/// file being used.
+///
+/// These were `tracing::warn!` calls and nothing else, which the CLI's
+/// `EnvFilter::from_default_env()` suppresses at the default level — so the
+/// permission warning `docs/CONFIG.md` §6 promises, and the "you typed a key
+/// that did not load" line, reached nobody. Carrying them as data lets
+/// `config doctor` print them, and lets tests assert on them rather than on
+/// log output that no assertion can see.
+///
+/// File-level failures (unreadable, malformed) are [`CredentialsError`]
+/// instead: those invalidate the whole file rather than one entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Advisory {
+    /// The file is readable beyond its owner. POSIX only.
+    InsecurePermissions {
+        /// The offending file.
+        path: String,
+        /// The permission bits, masked to `0o777`.
+        mode: u32,
+    },
+    /// `[tdm.<publisher>]` names a publisher doiget does not know.
+    UnknownPublisher {
+        /// The unrecognised slug.
+        publisher: String,
+    },
+    /// `agreed` is set. It is parsed only so it can be reported; the
+    /// agreement is environment-only (`docs/LEGAL.md` §6a.2).
+    AgreedIgnored {
+        /// The publisher whose table carried it.
+        publisher: String,
+    },
+    /// `api_key` is present but blank, so it cannot authenticate.
+    ///
+    /// Covers both `api_key = ""` and a whitespace-only value. The first is
+    /// the commoner typo and was, before this, indistinguishable from the
+    /// key being absent — `Option::unwrap_or_default()` collapsed `None` and
+    /// `Some("")` to the same empty string.
+    BlankKey {
+        /// The publisher whose table carried it.
+        publisher: String,
+    },
+}
+
+impl std::fmt::Display for Advisory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsecurePermissions { path, mode } => write!(
+                f,
+                "credentials.toml is readable beyond its owner (mode {mode:04o}); it holds \
+                 publisher API keys. Run: chmod 600 {path}"
+            ),
+            Self::UnknownPublisher { publisher } => write!(
+                f,
+                "credentials.toml has [tdm.{publisher}], which is not a publisher doiget \
+                 knows; expected one of {PUBLISHERS:?}"
+            ),
+            Self::AgreedIgnored { publisher } => write!(
+                f,
+                "credentials.toml sets [tdm.{publisher}] agreed, which doiget does NOT read. \
+                 The per-publisher agreement is environment-only \
+                 (DOIGET_AGREE_TDM_{}=1) so that it is an act taken in the session that runs \
+                 the fetch — docs/LEGAL.md §6a.2. Only api_key is read from this file.",
+                publisher.to_uppercase()
+            ),
+            Self::BlankKey { publisher } => write!(
+                f,
+                "credentials.toml sets [tdm.{publisher}] api_key to a blank value, which \
+                 cannot authenticate and is treated as unset. Remove the line or give it a key."
+            ),
+        }
+    }
+}
+
 /// Parsed `credentials.toml`.
 ///
-/// Absent, unreadable and malformed all yield the default (no keys): the
-/// file is optional, and one bad line must not take a fetch down. Every
-/// such case emits `tracing::warn!` — silence about this file is precisely
-/// what cost a user their configuration.
+/// An absent file yields the default (no keys); unreadable and malformed are
+/// [`CredentialsError`], which [`load_or_default`] turns back into the
+/// default for the fetch path so one bad line cannot take a fetch down.
+/// Per-entry problems ride along as [`Advisory`] values. Nothing about this
+/// file is dropped in silence — that is what cost a user their configuration.
 #[derive(Default, Clone)]
 #[non_exhaustive]
 pub struct Credentials {
     keys: Vec<(String, String)>,
+    advisories: Vec<Advisory>,
 }
 
 /// Hand-written so a stray `{:?}` cannot print a publisher API key.
@@ -66,6 +146,7 @@ impl std::fmt::Debug for Credentials {
                     .map(|(p, _)| format!("{p}: <redacted>"))
                     .collect::<Vec<_>>(),
             )
+            .field("advisories", &self.advisories)
             .finish()
     }
 }
@@ -94,9 +175,20 @@ impl Credentials {
     pub fn len(&self) -> usize {
         self.keys.len()
     }
+
+    /// Everything worth telling the user that did not stop the file being
+    /// used. See [`Advisory`].
+    #[must_use]
+    pub fn advisories(&self) -> &[Advisory] {
+        &self.advisories
+    }
 }
 
-#[derive(Debug, Default, Deserialize)]
+// No `Debug` on either raw type: `RawEntry::api_key` is the untrimmed key
+// straight off disk, one hop before the redacting `Debug` on `Credentials`.
+// A derive here is what a future `tracing::debug!(?raw, ..)` would leak
+// through.
+#[derive(Default, Deserialize)]
 struct RawFile {
     #[serde(default)]
     tdm: Option<std::collections::BTreeMap<String, RawEntry>>,
@@ -104,7 +196,7 @@ struct RawFile {
     _other: serde::de::IgnoredAny,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Default, Deserialize)]
 struct RawEntry {
     #[serde(default)]
     api_key: Option<String>,
@@ -147,13 +239,49 @@ pub enum CredentialsError {
         source: std::io::Error,
     },
     /// The file is not valid TOML.
-    #[error("{path}: {source}")]
+    ///
+    /// Deliberately **not** carrying the `toml::de::Error`. Its `Display`
+    /// renders the offending source line verbatim, and the commonest way
+    /// this file is malformed is an unterminated `api_key = "..."` — so the
+    /// error most likely to be printed is the one whose snippet *is* the
+    /// key. Its `Debug` is worse: it holds the whole file. `config doctor`
+    /// prints this variant, so it gets the position and the parser's
+    /// message and nothing off the line itself.
+    #[error("{path}:{line}:{column}: {message}")]
     Parse {
         /// The file that failed to parse.
         path: String,
-        /// The underlying TOML error.
-        source: toml::de::Error,
+        /// 1-based line of the failure.
+        line: usize,
+        /// 1-based column of the failure.
+        column: usize,
+        /// The parser's message, which quotes no file content.
+        message: String,
     },
+}
+
+/// Build a [`CredentialsError::Parse`] that names the position without
+/// echoing anything from the file. See the variant's own note.
+fn redacted_parse_error(
+    path: &camino::Utf8Path,
+    text: &str,
+    e: &toml::de::Error,
+) -> CredentialsError {
+    let offset = e.span().map_or(0, |s| s.start).min(text.len());
+    let before = &text[..offset];
+    let line = before.matches('\n').count() + 1;
+    let column = before
+        .rsplit_once('\n')
+        .map_or(before, |(_, tail)| tail)
+        .chars()
+        .count()
+        + 1;
+    CredentialsError::Parse {
+        path: path.to_string(),
+        line,
+        column,
+        message: e.message().to_string(),
+    }
 }
 
 /// Load `credentials.toml` from an explicit path, surfacing failures.
@@ -177,8 +305,13 @@ pub fn load(path: &camino::Utf8Path) -> Result<Credentials, CredentialsError> {
             })
         }
     };
-    warn_if_group_or_world_accessible(path);
-    parse(&text, path)
+    let mut creds = parse(&text, path)?;
+    // Prepended: a world-readable key file is the most serious thing this
+    // function can find, and `config doctor` prints advisories in order.
+    if let Some(a) = permission_advisory(path) {
+        creds.advisories.insert(0, a);
+    }
+    Ok(creds)
 }
 
 /// Load the credentials file, or the empty set.
@@ -196,7 +329,15 @@ pub fn load_or_default() -> Credentials {
         }
     };
     match load(&path) {
-        Ok(c) => c,
+        Ok(c) => {
+            // The fetch path has no checklist to print to, so advisories
+            // stay logs here. `config doctor` is the surface that shows
+            // them unconditionally.
+            for a in &c.advisories {
+                tracing::warn!(path = %path, "{a}");
+            }
+            c
+        }
         Err(e) => {
             tracing::warn!(
                 error = %e,
@@ -214,40 +355,24 @@ fn parse(text: &str, path: &camino::Utf8Path) -> Result<Credentials, Credentials
     // `config doctor` can name it. The per-entry problems below (unknown
     // publisher, an `agreed` key, a blank value) are advisories: they do
     // not invalidate the rest of the file, so they stay warnings.
-    let raw: RawFile = toml::from_str(text).map_err(|source| CredentialsError::Parse {
-        path: path.to_string(),
-        source,
-    })?;
+    let raw: RawFile = toml::from_str(text).map_err(|e| redacted_parse_error(path, text, &e))?;
     let Some(tdm) = raw.tdm else {
         return Ok(Credentials::default());
     };
 
     let mut keys = Vec::new();
+    let mut advisories = Vec::new();
     for (publisher, entry) in tdm {
         if !PUBLISHERS.contains(&publisher.as_str()) {
-            tracing::warn!(
-                path = %path,
-                publisher = %publisher,
-                "credentials.toml has [tdm.{}], which is not a publisher doiget knows; \
-                 expected one of {:?}",
-                publisher,
-                PUBLISHERS
-            );
+            advisories.push(Advisory::UnknownPublisher { publisher });
             continue;
         }
         if entry.agreed.is_some() {
             // Reported, not obeyed. A field parsed and discarded in silence
             // is exactly what #509 is about.
-            tracing::warn!(
-                path = %path,
-                publisher = %publisher,
-                "credentials.toml sets [tdm.{}] agreed, which doiget does NOT read. The \
-                 per-publisher agreement is environment-only (DOIGET_AGREE_TDM_{}=1) so \
-                 that it is an act taken in the session that runs the fetch — \
-                 docs/LEGAL.md §6a.2. Only api_key is read from this file.",
-                publisher,
-                publisher.to_uppercase()
-            );
+            advisories.push(Advisory::AgreedIgnored {
+                publisher: publisher.clone(),
+            });
         }
         // Blank means unset, as everywhere else: an empty key cannot
         // authenticate, and building a grant around one would mask the
@@ -255,54 +380,49 @@ fn parse(text: &str, path: &camino::Utf8Path) -> Result<Credentials, Credentials
         //
         // It still gets a line. A present-but-blank value is a thing the
         // user typed and believes is configured, so dropping it in silence
-        // is the #442 / #476 shape this module was written to close — and
-        // it was the one case here that reached no log call at all.
-        let raw = entry.api_key.unwrap_or_default();
-        let key = raw.trim();
-        if key.is_empty() {
-            if !raw.is_empty() {
-                tracing::warn!(
-                    path = %path,
-                    publisher = %publisher,
-                    "credentials.toml sets [tdm.{}] api_key to a blank value, which cannot \
-                     authenticate and is treated as unset. Remove the line or give it a key.",
-                    publisher
-                );
+        // is the #442 / #476 shape this module was written to close.
+        //
+        // Matched on the `Option` rather than through `unwrap_or_default()`:
+        // that collapsed `None` (no line at all, which is normal) and
+        // `Some("")` (a line the user wrote, which is the typo) into the
+        // same empty string, so the commonest form of the very case this
+        // reports produced no advisory at all.
+        if let Some(raw) = entry.api_key {
+            let key = raw.trim();
+            if key.is_empty() {
+                advisories.push(Advisory::BlankKey { publisher });
+            } else {
+                keys.push((publisher, key.to_string()));
             }
-        } else {
-            keys.push((publisher, key.to_string()));
         }
     }
-    Ok(Credentials { keys })
+    Ok(Credentials { keys, advisories })
 }
 
-/// Warn when the file is group- or world-accessible on POSIX.
+/// Report when the file is group- or world-accessible on POSIX.
 ///
 /// `docs/CONFIG.md` §6 promised this warning from the day it was written.
 /// It did not exist, and neither did the reader it was attached to (#509).
+/// Returned as data rather than logged, so `config doctor` can show it — as
+/// a `tracing::warn!` it was invisible at the CLI's default log level, which
+/// made "the `0600` check is a real control" untrue.
 #[cfg(unix)]
-fn warn_if_group_or_world_accessible(path: &camino::Utf8Path) {
+fn permission_advisory(path: &camino::Utf8Path) -> Option<Advisory> {
     use std::os::unix::fs::PermissionsExt;
-    let Ok(meta) = std::fs::metadata(path.as_std_path()) else {
-        return;
-    };
+    let meta = std::fs::metadata(path.as_std_path()).ok()?;
     let mode = meta.permissions().mode() & 0o777;
-    if mode & 0o077 != 0 {
-        tracing::warn!(
-            path = %path,
-            mode = format!("{mode:04o}"),
-            "credentials.toml is readable beyond its owner (mode {:04o}); it holds \
-             publisher API keys. Run: chmod 600 {}",
-            mode,
-            path
-        );
-    }
+    (mode & 0o077 != 0).then(|| Advisory::InsecurePermissions {
+        path: path.to_string(),
+        mode,
+    })
 }
 
-/// No-op off POSIX: Windows ACLs are not a mode, and a warning phrased in
+/// `None` off POSIX: Windows ACLs are not a mode, and a warning phrased in
 /// `chmod` terms would be advice the user cannot follow.
 #[cfg(not(unix))]
-fn warn_if_group_or_world_accessible(_path: &camino::Utf8Path) {}
+fn permission_advisory(_path: &camino::Utf8Path) -> Option<Advisory> {
+    None
+}
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
@@ -345,6 +465,29 @@ mod tests {
         assert!(c.is_empty(), "a blank key cannot authenticate");
     }
 
+    /// `agreed` is refused, but its presence must be *said*, not swallowed.
+    #[test]
+    fn agreed_in_the_file_is_reported() {
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\nagreed = true\n");
+        assert_eq!(
+            c.advisories(),
+            [Advisory::AgreedIgnored {
+                publisher: "elsevier".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn an_unknown_publisher_is_reported() {
+        let c = ok("[tdm.wiley]\napi_key = \"abc\"\n");
+        assert_eq!(
+            c.advisories(),
+            [Advisory::UnknownPublisher {
+                publisher: "wiley".to_string()
+            }]
+        );
+    }
+
     /// A malformed file is a FILE-level failure, returned rather than
     /// warned about, so `doiget config doctor` can name it. Before #509's
     /// follow-up the only surface was `tracing::warn!`, which the CLI's
@@ -359,14 +502,63 @@ mod tests {
         }
     }
 
+    /// `config doctor` prints this error. `toml::de::Error`'s own `Display`
+    /// quotes the offending source line, and the commonest malformation of
+    /// this file is an unterminated `api_key = "..."` — so rendering it
+    /// would print the key to the terminal, from the one module whose whole
+    /// job is that the key is never printed.
+    #[test]
+    fn a_parse_error_names_the_position_without_quoting_the_line() {
+        let secret = "sk-do-not-print-me";
+        let text = format!("[tdm.elsevier]\napi_key = \"{secret}\n");
+        let e = parse(&text, &p()).expect_err("an unterminated string must not parse");
+        let rendered = format!("{e}");
+        assert!(
+            !rendered.contains(secret),
+            "the key leaked through Display: {rendered}"
+        );
+        assert!(
+            !format!("{e:?}").contains(secret),
+            "the key leaked through Debug: {e:?}"
+        );
+        assert!(
+            rendered.contains(":2:"),
+            "the position is still named: {rendered}"
+        );
+    }
+
     /// A blank value is a thing the user typed. It is still treated as
-    /// unset, but it no longer disappears without a line — that was the one
-    /// failure mode in this module with no log call at all.
+    /// unset, but it must not disappear without a word.
+    ///
+    /// Asserts on the advisory, not just on the resulting key count: the
+    /// previous version of this test used `api_key = ""` and checked only
+    /// `is_empty()`, so it passed while the reporting it is named for did
+    /// not happen at all for that exact input.
     #[test]
     fn a_present_but_blank_key_is_reported_not_silently_dropped() {
-        let c = ok("[tdm.aps]\napi_key = \"\"\n");
+        for text in [
+            "[tdm.aps]\napi_key = \"\"\n",
+            "[tdm.aps]\napi_key = \"   \"\n",
+        ] {
+            let c = ok(text);
+            assert!(c.is_empty(), "{text:?} must grant no key");
+            assert_eq!(
+                c.advisories(),
+                [Advisory::BlankKey {
+                    publisher: "aps".to_string()
+                }],
+                "{text:?} must be reported, not dropped"
+            );
+        }
+    }
+
+    /// The absent case is normal and must stay quiet, or the advisory list
+    /// fills with noise on every well-formed file and stops being read.
+    #[test]
+    fn an_absent_key_is_not_an_advisory() {
+        let c = ok("[tdm.aps]\n");
         assert!(c.is_empty());
-        assert_eq!(c.len(), 0);
+        assert!(c.advisories().is_empty(), "{:?}", c.advisories());
     }
 
     #[test]
@@ -381,5 +573,12 @@ mod tests {
     fn an_absent_tdm_table_is_not_an_error() {
         assert!(ok("[something_else]\nx = 1\n").is_empty());
         assert!(ok("").is_empty());
+    }
+
+    /// A well-formed file must have nothing to say.
+    #[test]
+    fn a_clean_file_produces_no_advisories() {
+        let c = ok("[tdm.elsevier]\napi_key = \"abc\"\n");
+        assert!(c.advisories().is_empty(), "{:?}", c.advisories());
     }
 }

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -1378,29 +1378,29 @@ impl CapabilityProfile {
         // `credentials` module docs and `docs/LEGAL.md` §6a.2.
         let creds = crate::credentials::load_or_default();
         let tdm_elsevier = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-            KeyVar("DOIGET_KEY_ELSEVIER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar::new("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             cfg!(feature = "tdm-elsevier"),
             creds.api_key("elsevier"),
         )?;
         let tdm_aps = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_APS"),
-            KeyVar("DOIGET_KEY_APS"),
+            AgreeVar::new("DOIGET_AGREE_TDM_APS"),
+            KeyVar::new("DOIGET_KEY_APS"),
             "tdm-aps",
             cfg!(feature = "tdm-aps"),
             creds.api_key("aps"),
         )?;
         let tdm_springer = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_SPRINGER"),
-            KeyVar("DOIGET_KEY_SPRINGER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_SPRINGER"),
+            KeyVar::new("DOIGET_KEY_SPRINGER"),
             "tdm-springer",
             cfg!(feature = "tdm-springer"),
             creds.api_key("springer"),
         )?;
         let tdm_ieee = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_IEEE"),
-            KeyVar("DOIGET_KEY_IEEE"),
+            AgreeVar::new("DOIGET_AGREE_TDM_IEEE"),
+            KeyVar::new("DOIGET_KEY_IEEE"),
             "tdm-ieee",
             cfg!(feature = "tdm-ieee"),
             creds.api_key("ieee"),
@@ -1442,6 +1442,57 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
     }
 }
 
+/// The env var carrying the per-publisher agreement.
+///
+/// A newtype because `agree_var` and `key_var` were adjacent `&str`
+/// parameters: transposing them at a call site type-checked, and the
+/// resulting build would treat the KEY as the agreement signal and the
+/// AGREEMENT as the key. `docs/LEGAL.md` §6a.2 makes that agreement an
+/// enforced control, so "nothing stops a fifth publisher's call site from
+/// being copy-pasted wrong" is not a risk worth carrying for two saved
+/// characters.
+///
+/// `pub(crate)` with a private field: the only consumer is a private `fn`
+/// in this module, so a public tuple struct added semver surface nothing
+/// outside the crate can reach. The private field also closes the variant
+/// the newtype alone did not — `AgreeVar("DOIGET_KEY_ELSEVIER")` is the
+/// same transposition expressed as content rather than position, and it
+/// compiled. [`AgreeVar::new`] refuses it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AgreeVar(&'static str);
+
+/// The env var carrying the per-publisher API key. See [`AgreeVar`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct KeyVar(&'static str);
+
+impl AgreeVar {
+    /// # Panics
+    ///
+    /// If `var` is not a `DOIGET_AGREE_TDM_*` name. Every argument is a
+    /// literal in this file, so this is a typo caught at the first test
+    /// run, not a runtime failure mode.
+    pub(crate) fn new(var: &'static str) -> Self {
+        assert!(
+            var.starts_with("DOIGET_AGREE_TDM_"),
+            "{var} is not an agreement variable"
+        );
+        Self(var)
+    }
+}
+
+impl KeyVar {
+    /// # Panics
+    ///
+    /// If `var` is not a `DOIGET_KEY_*` name. See [`AgreeVar::new`].
+    pub(crate) fn new(var: &'static str) -> Self {
+        assert!(
+            var.starts_with("DOIGET_KEY_"),
+            "{var} is not a key variable"
+        );
+        Self(var)
+    }
+}
+
 /// Resolve a Tier 3 TDM grant from the agreement env var, the key (env var
 /// or `credentials.toml`), and the per-publisher Cargo feature.
 ///
@@ -1462,22 +1513,6 @@ fn resolve_metadata_flag(env_var: &str, feature: &str, feature_enabled: bool) ->
 /// `KeyButNotAgreed` now also fires for a file-supplied key with no
 /// `DOIGET_AGREE_TDM_<PUBLISHER>=1`. That is the point — `docs/LEGAL.md`
 /// §6a.2 is an enforced control, and a convenience must not dilute it.
-/// The env var carrying the per-publisher agreement.
-///
-/// A newtype because `agree_var` and `key_var` were adjacent `&str`
-/// parameters: transposing them at a call site type-checked, and the
-/// resulting build would treat the KEY as the agreement signal and the
-/// AGREEMENT as the key. `docs/LEGAL.md` §6a.2 makes that agreement an
-/// enforced control, so "nothing stops a fifth publisher's call site from
-/// being copy-pasted wrong" is not a risk worth carrying for two saved
-/// characters.
-#[derive(Debug, Clone, Copy)]
-pub struct AgreeVar(pub &'static str);
-
-/// The env var carrying the per-publisher API key. See [`AgreeVar`].
-#[derive(Debug, Clone, Copy)]
-pub struct KeyVar(pub &'static str);
-
 fn resolve_tdm_grant(
     agree: AgreeVar,
     key: KeyVar,
@@ -1800,8 +1835,8 @@ agreed = true
         let _g = unset_all_capability_env_vars();
 
         let granted = resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-            KeyVar("DOIGET_KEY_ELSEVIER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar::new("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1813,8 +1848,8 @@ agreed = true
 
         let _key = EnvGuard::set("DOIGET_KEY_ELSEVIER", "   ");
         match resolve_tdm_grant(
-            AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-            KeyVar("DOIGET_KEY_ELSEVIER"),
+            AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+            KeyVar::new("DOIGET_KEY_ELSEVIER"),
             "tdm-elsevier",
             false,
             Some("file-key"),
@@ -1826,8 +1861,8 @@ agreed = true
         let _agree = EnvGuard::set("DOIGET_AGREE_TDM_ELSEVIER", "1");
         assert!(
             resolve_tdm_grant(
-                AgreeVar("DOIGET_AGREE_TDM_ELSEVIER"),
-                KeyVar("DOIGET_KEY_ELSEVIER"),
+                AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"),
+                KeyVar::new("DOIGET_KEY_ELSEVIER"),
                 "tdm-elsevier",
                 false,
                 Some("file-key"),

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -603,27 +603,47 @@ pub fn contact_email_or_placeholder() -> String {
     configured_contact_email().unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string())
 }
 
+/// The two contact addresses a fetch sends, resolved together.
+///
+/// Named fields rather than a `(String, String)`: a tuple made "which
+/// address goes to which service" a matter of destructuring order, so
+/// reordering one `let` would silently hand Crossref the Unpaywall
+/// identity. That is the defect [`crate::AgreeVar`] exists to close, one
+/// module over, and it is worth closing the same way.
+struct ContactAddresses {
+    /// The polite-pool identity for Crossref, OpenAlex and the rest.
+    crossref: String,
+    /// The `email=` Unpaywall requires. Falls back to `crossref`.
+    unpaywall: String,
+}
+
 /// Both addresses, from a single read of `config.toml`.
 ///
 /// Resolving them independently meant two reads per fetch, and — in a
 /// long-lived `doiget serve` — a window in which an edit landing between
 /// them gave one address from the old file and one from the new. One read,
 /// one generation.
-fn resolve_contact_emails() -> (String, String) {
+fn resolve_contact_emails() -> ContactAddresses {
     let env_contact = env_nonempty("DOIGET_CONTACT_EMAIL");
     let env_unpaywall = env_nonempty("DOIGET_UNPAYWALL_EMAIL");
     // Fully env-configured processes never touch the disk at all.
-    if let (Some(contact), Some(unpaywall)) = (&env_contact, &env_unpaywall) {
-        return (contact.clone(), unpaywall.clone());
+    if let (Some(crossref), Some(unpaywall)) = (&env_contact, &env_unpaywall) {
+        return ContactAddresses {
+            crossref: crossref.clone(),
+            unpaywall: unpaywall.clone(),
+        };
     }
     let file = crate::user_extension::load_or_default();
-    let contact = env_contact
+    let crossref = env_contact
         .or(file.contact_email)
         .unwrap_or_else(|| FALLBACK_CONTACT_EMAIL.to_string());
     let unpaywall = env_unpaywall
         .or(file.unpaywall_email)
-        .unwrap_or_else(|| contact.clone());
-    (contact, unpaywall)
+        .unwrap_or_else(|| crossref.clone());
+    ContactAddresses {
+        crossref,
+        unpaywall,
+    }
 }
 
 fn arxiv_source_from_env() -> ArxivSource {
@@ -1265,7 +1285,9 @@ async fn fetch_paper_doi(
     store_root: &Utf8Path,
     safekey: &Safekey,
 ) -> Result<FetchPaperOutcome, FetchError> {
-    let (contact, unpaywall_contact) = resolve_contact_emails();
+    let addresses = resolve_contact_emails();
+    let contact = addresses.crossref;
+    let unpaywall_contact = addresses.unpaywall;
     let crossref = crossref_source_from_env(&contact);
     // Issue #120: Crossref is NON-fatal. A transient Crossref failure
     // must not abort the whole DOI fetch when Unpaywall alone can
@@ -2812,7 +2834,10 @@ mod tests {
         );
         let _env = LadderEnv::scoped(&dir);
 
-        let (contact, unpaywall) = resolve_contact_emails();
+        let ContactAddresses {
+            crossref: contact,
+            unpaywall,
+        } = resolve_contact_emails();
         assert_eq!(contact, "file@institution.edu");
         assert_eq!(unpaywall, "up@institution.edu");
     }
@@ -2827,7 +2852,10 @@ mod tests {
         let mut env = LadderEnv::scoped(&dir);
         env.set("DOIGET_CONTACT_EMAIL", "env@institution.edu");
 
-        let (contact, unpaywall) = resolve_contact_emails();
+        let ContactAddresses {
+            crossref: contact,
+            unpaywall,
+        } = resolve_contact_emails();
         assert_eq!(contact, "env@institution.edu");
         assert_eq!(
             unpaywall, "env@institution.edu",
@@ -2847,7 +2875,10 @@ mod tests {
             .to_string();
         let _env = LadderEnv::scoped(&dir);
 
-        let (contact, unpaywall) = resolve_contact_emails();
+        let ContactAddresses {
+            crossref: contact,
+            unpaywall,
+        } = resolve_contact_emails();
         assert_eq!(contact, FALLBACK_CONTACT_EMAIL);
         assert_eq!(unpaywall, FALLBACK_CONTACT_EMAIL);
     }

--- a/docs/CAPABILITY.md
+++ b/docs/CAPABILITY.md
@@ -118,10 +118,10 @@ impl CapabilityProfile {
                 core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
                 europe_pmc:      env::var("DOIGET_ENABLE_EUROPE_PMC").is_ok(),
             },
-            tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
-            tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
-            tdm_springer: read_tdm_grant("DOIGET_AGREE_TDM_SPRINGER", "DOIGET_KEY_SPRINGER")?,
-            tdm_ieee:     read_tdm_grant("DOIGET_AGREE_TDM_IEEE",     "DOIGET_KEY_IEEE")?,
+            tdm_elsevier: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"), KeyVar::new("DOIGET_KEY_ELSEVIER"))?,
+            tdm_aps:      read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_APS"),      KeyVar::new("DOIGET_KEY_APS"))?,
+            tdm_springer: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_SPRINGER"), KeyVar::new("DOIGET_KEY_SPRINGER"))?,
+            tdm_ieee:     read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_IEEE"),     KeyVar::new("DOIGET_KEY_IEEE"))?,
             rate_limits:  RateLimits::HARD_CODED,
         })
     }
@@ -129,9 +129,15 @@ impl CapabilityProfile {
 
 // `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
 // BELOW the env var (#509, ADR-0050). The agreement has no file rung.
-fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+//
+// `AgreeVar`/`KeyVar` are newtypes over `&'static str` with private fields:
+// two adjacent `&str` parameters could be transposed at a call site and the
+// build would then treat the KEY as the agreement signal. The real signature
+// also takes `feature: &str` and `feature_enabled: bool`, elided here.
+fn read_tdm_grant(agree: AgreeVar, key: KeyVar, file_key: Option<&str>)
     -> Result<Option<TdmGrant>, CapabilityError>
 {
+    let (agree_var, key_var) = (agree.0, key.0);
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
     let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -256,7 +256,8 @@ environment-only and cannot be given here — see below, and ADR-0050.
 
 ```toml
 # ~/.config/doiget/credentials.toml — optional.
-# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
+# Permissions SHOULD be 0600 on POSIX. `doiget config doctor` fails on a
+# group- or world-readable file, and the fetch path logs a warning.
 
 [tdm.elsevier]
 api_key = "..."
@@ -301,6 +302,14 @@ including the `0600` warning, and no code path opened it; a user who followed
 this section wrote their key into a file doiget ignored and then reported the
 source unavailable for want of a key. Both the reader and the permission
 warning exist as of 0.8.11.
+
+**Where the problems show up.** Run `doiget config doctor`. A file that cannot
+be read or does not parse fails a check naming the position — never quoting the
+line, because the line that fails to parse is usually the one holding the key. A
+file that parses fails a check for each thing worth acting on: a group- or
+world-readable mode, an `api_key` present but blank, an `agreed` that grants
+nothing, a `[tdm.<publisher>]` naming a publisher doiget does not know. None of
+these is fatal to a fetch, and none of them is silent.
 
 ## 6.1 Institutional networks: what works and what does not
 

--- a/npm/doiget/bin/platform.js
+++ b/npm/doiget/bin/platform.js
@@ -3,7 +3,7 @@
 // `doiget.js` used to hold this inline, which meant the npm packaging had
 // no executable test at all — only a grep in posture-lint comparing name
 // lists across three files. A grep cannot catch a wrong `require.resolve`
-// path or a mis-forwarded exit code.
+// path or an exit code forwarded wrongly.
 "use strict";
 
 // npm's `os`/`cpu` vocabulary. The release assets use x86_64/aarch64; the

--- a/npm/doiget/test/release-checksums.test.sh
+++ b/npm/doiget/test/release-checksums.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Runs the npm-publish checksum-verification loop out of release-plz.yml
+# against a synthetic download directory.
+#
+# That loop is the fix for the defect this cluster started from: the download
+# step used `-p 'doiget-*.sha256'`, which also matched the SBOM's and the
+# .mcpb's checksums, whose payloads are never downloaded — so `sha256sum -c`
+# failed on every release, inside a job that is `continue-on-error`. It had
+# no test at all: the one surface where a silent failure had already happened
+# was verified by prose.
+#
+# The loop is extracted from the workflow rather than copied, so this test
+# cannot drift into agreeing with a stale duplicate of it.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/release-plz.yml"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+fail=0
+check() {
+  if [ "$1" = "ok" ]; then echo "ok    $2"; else echo "FAIL  $2"; fail=1; fi
+}
+
+# Pull the `for f in *.sha256` block out of the workflow and strip its YAML
+# indentation. If the block is renamed or removed, this fails loudly rather
+# than silently testing nothing.
+awk '/^ *verified=0$/{on=1} on{print} /expected 4/{tail=1} tail && /^ *fi$/{exit}' "$WORKFLOW" | sed 's/^ \{0,10\}//' > "$WORK/loop.sh"
+if [ ! -s "$WORK/loop.sh" ] || ! grep -q 'expected 4' "$WORK/loop.sh"; then
+  echo "FAIL  could not extract the checksum loop from $WORKFLOW"
+  exit 1
+fi
+
+# The four platform binaries a release actually publishes.
+ASSETS="doiget-linux-x86_64 doiget-macos-aarch64 doiget-macos-x86_64 doiget-windows-x86_64.exe"
+
+seed() {
+  local dir="$1"
+  mkdir -p "$dir"
+  for a in $ASSETS; do
+    printf 'fake-binary-%s' "$a" > "$dir/$a"
+    ( cd "$dir" && sha256sum "$a" > "$a.sha256" )
+  done
+}
+
+run_loop() {
+  ( cd "$1" && bash "$WORK/loop.sh" > "$1/out" 2>&1; echo $? )
+}
+
+# 1. A clean release verifies all four and exits 0.
+seed "$WORK/clean"
+rc="$(run_loop "$WORK/clean")"
+if [ "$rc" = "0" ]; then
+  check ok "a complete release verifies"
+else
+  check no "a complete release verifies"
+  cat "$WORK/clean/out"
+fi
+
+# 2. A checksum whose payload was never downloaded must fail. This is the
+#    exact shape of the original bug: the SBOM's .sha256 arrived, its
+#    payload did not.
+seed "$WORK/orphan"
+sed 's/doiget-linux-x86_64/doiget-sbom.spdx.json/' "$WORK/orphan/doiget-linux-x86_64.sha256" \
+  > "$WORK/orphan/doiget-sbom.spdx.json.sha256"
+rc="$(run_loop "$WORK/orphan")"
+if [ "$rc" != "0" ]; then
+  check ok "an orphaned checksum fails the job"
+else
+  check no "an orphaned checksum fails the job"
+  cat "$WORK/orphan/out"
+fi
+
+# 3. A release missing one platform binary must fail on the count rather
+#    than pass quietly having verified three. That is what `-ne 4` is for.
+seed "$WORK/short"
+rm -f "$WORK/short/doiget-macos-aarch64" "$WORK/short/doiget-macos-aarch64.sha256"
+rc="$(run_loop "$WORK/short")"
+if [ "$rc" != "0" ]; then
+  check ok "a missing platform binary fails the count"
+else
+  check no "a missing platform binary fails the count"
+  cat "$WORK/short/out"
+fi
+if grep -q 'expected 4' "$WORK/short/out"; then
+  check ok "the count failure says what was expected"
+else
+  check no "the count failure says what was expected"
+  cat "$WORK/short/out"
+fi
+
+# 4. A tampered binary must fail verification.
+seed "$WORK/corrupt"
+printf 'tampered' > "$WORK/corrupt/doiget-linux-x86_64"
+rc="$(run_loop "$WORK/corrupt")"
+if [ "$rc" != "0" ]; then
+  check ok "a corrupted binary fails verification"
+else
+  check no "a corrupted binary fails verification"
+  cat "$WORK/corrupt/out"
+fi
+
+exit "$fail"

--- a/npm/doiget/test/stage-npm.test.sh
+++ b/npm/doiget/test/stage-npm.test.sh
@@ -92,11 +92,30 @@ done
 
 # A missing release asset must fail loudly rather than stage a package with
 # no binary in it.
+#
+# The exit code alone proves nothing: `set -euo pipefail` makes the `cp` after
+# the guard fail too, so deleting the guard outright still exits non-zero —
+# with a raw `cp: cannot stat` instead of the `::error::` annotation, and,
+# since `mkdir`/`stamp_version` run before that `cp`, with a half-staged
+# package left on disk. So assert on the annotation AND on the absence of the
+# wreckage, never on the exit code alone.
 rm -f "$BIN/doiget-linux-x86_64"
-if bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out2" >/dev/null 2>&1; then
+if bash "$ROOT/scripts/stage-npm.sh" 9.9.9 "$BIN" "$WORK/out2" > "$WORK/log2" 2>&1; then
   check no "a missing release asset fails the staging script"
 else
   check ok "a missing release asset fails the staging script"
+fi
+if grep -q '::error::missing release asset' "$WORK/log2"; then
+  check ok "the failure names the missing asset"
+else
+  check no "the failure names the missing asset"
+  cat "$WORK/log2"
+fi
+if [ -e "$WORK/out2/doiget-linux-x64" ]; then
+  check no "no half-staged package is left behind"
+  find "$WORK/out2/doiget-linux-x64" -print
+else
+  check ok "no half-staged package is left behind"
 fi
 
 exit "$fail"

--- a/site/content/developer/capability.md
+++ b/site/content/developer/capability.md
@@ -124,10 +124,10 @@ impl CapabilityProfile {
                 core:            env::var("DOIGET_ENABLE_CORE").is_ok(),
                 europe_pmc:      env::var("DOIGET_ENABLE_EUROPE_PMC").is_ok(),
             },
-            tdm_elsevier: read_tdm_grant("DOIGET_AGREE_TDM_ELSEVIER", "DOIGET_KEY_ELSEVIER")?,
-            tdm_aps:      read_tdm_grant("DOIGET_AGREE_TDM_APS",      "DOIGET_KEY_APS")?,
-            tdm_springer: read_tdm_grant("DOIGET_AGREE_TDM_SPRINGER", "DOIGET_KEY_SPRINGER")?,
-            tdm_ieee:     read_tdm_grant("DOIGET_AGREE_TDM_IEEE",     "DOIGET_KEY_IEEE")?,
+            tdm_elsevier: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_ELSEVIER"), KeyVar::new("DOIGET_KEY_ELSEVIER"))?,
+            tdm_aps:      read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_APS"),      KeyVar::new("DOIGET_KEY_APS"))?,
+            tdm_springer: read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_SPRINGER"), KeyVar::new("DOIGET_KEY_SPRINGER"))?,
+            tdm_ieee:     read_tdm_grant(AgreeVar::new("DOIGET_AGREE_TDM_IEEE"),     KeyVar::new("DOIGET_KEY_IEEE"))?,
             rate_limits:  RateLimits::HARD_CODED,
         })
     }
@@ -135,9 +135,15 @@ impl CapabilityProfile {
 
 // `file_key` is `[tdm.<publisher>] api_key` from credentials.toml, one rung
 // BELOW the env var (#509, ADR-0050). The agreement has no file rung.
-fn read_tdm_grant(agree_var: &str, key_var: &str, file_key: Option<&str>)
+//
+// `AgreeVar`/`KeyVar` are newtypes over `&'static str` with private fields:
+// two adjacent `&str` parameters could be transposed at a call site and the
+// build would then treat the KEY as the agreement signal. The real signature
+// also takes `feature: &str` and `feature_enabled: bool`, elided here.
+fn read_tdm_grant(agree: AgreeVar, key: KeyVar, file_key: Option<&str>)
     -> Result<Option<TdmGrant>, CapabilityError>
 {
+    let (agree_var, key_var) = (agree.0, key.0);
     let agreed = matches!(env::var(agree_var).as_deref(), Ok("1"));
     let key    = env::var(key_var).ok().or_else(|| file_key.map(str::to_string));
     match (agreed, key) {

--- a/site/content/developer/config.md
+++ b/site/content/developer/config.md
@@ -262,7 +262,8 @@ environment-only and cannot be given here — see below, and ADR-0050.
 
 ```toml
 # ~/.config/doiget/credentials.toml — optional.
-# Permissions SHOULD be 0600 on POSIX; doiget warns at startup otherwise.
+# Permissions SHOULD be 0600 on POSIX. `doiget config doctor` fails on a
+# group- or world-readable file, and the fetch path logs a warning.
 
 [tdm.elsevier]
 api_key = "..."
@@ -307,6 +308,14 @@ including the `0600` warning, and no code path opened it; a user who followed
 this section wrote their key into a file doiget ignored and then reported the
 source unavailable for want of a key. Both the reader and the permission
 warning exist as of 0.8.11.
+
+**Where the problems show up.** Run `doiget config doctor`. A file that cannot
+be read or does not parse fails a check naming the position — never quoting the
+line, because the line that fails to parse is usually the one holding the key. A
+file that parses fails a check for each thing worth acting on: a group- or
+world-readable mode, an `api_key` present but blank, an `agreed` that grants
+nothing, a `[tdm.<publisher>]` naming a publisher doiget does not know. None of
+these is fatal to a fetch, and none of them is silent.
 
 ## 6.1 Institutional networks: what works and what does not
 


### PR DESCRIPTION
Round 2 of the `/review-pr` pass on #541. Round 1 (#542) fixed thirteen findings and introduced five defects of its own, three of which turned #541's CI red.

## The one that matters

Round 1 made `credentials::parse` fallible so a malformed file could be *reported* rather than swallowed. It did that by putting the `toml::de::Error` inside `CredentialsError::Parse`, and that error's `Display` quotes the offending source line verbatim:

```
TOML parse error at line 2, column 34
  |
2 | api_key = "sk-SUPER-SECRET-abc123
  |                                  ^
invalid basic string, expected `"`
```

(measured against the pinned `toml 1.1`, not inferred)

The commonest way `credentials.toml` is malformed is a pasted key with a stray quote in it — so **the error most likely to reach a terminal is the one whose quoted line is the key**, printed by `config doctor`, thirteen lines below a comment reading `keys are never printed`. `toml::de::Error`'s `Debug` is worse: it holds the entire file.

The variant now carries `path`, `line`, `column` and the parser's own message. A test plants a key in a malformed file and asserts it appears in neither `Display` nor `Debug`.

## CI, all three red on #541

| check | cause |
|---|---|
| `lint` | posture-lint grepped the platform table out of `npm/doiget/bin/doiget.js` after round 1 moved it to `platform.js`. Under `set -euo pipefail` a grep matching nothing exits 1 and kills the step **with no output at all** — so a check that had correctly detected drift read as infrastructure flake, and round 1's own packaging tests, queued behind it, never ran. Every grep in the step now goes through a helper that turns "matched nothing" into a named error. |
| `typos` | `mis-forwarded` in `platform.js`. |
| `dco` | 18 of 20 commits, and **unfixable as written**. A promotion's range is the whole release; for the release that introduces ADR-0051 that range holds commits predating the CLA, on a protected branch whose history cannot be rewritten. A job that is red whatever the author does is not a gate. `next` → `main` is now exempt on the same structural grounds as merge commits and bot authors: it re-presents commits this job already gated when they landed on `next`. |

## The rest

- **`credentials.toml` advisories.** Per-entry problems are `Advisory` values now, not `tracing::warn!` calls the default `EnvFilter` throws away. A `chmod 644` on a file of publisher keys reported `[ ok ]` — the `0600` check the module doc calls *"a real control rather than a sentence"* reached nobody. And the blank-key warning **did not fire for `api_key = ""`**: `Option::unwrap_or_default()` collapses `None` and `Some("")`, so the commonest form of the case round 1 named was still the silent one. Its test used that exact input and asserted only the key count, so it passed.
- **Doc-comment misattachment.** The whole rule set for `resolve_tdm_grant` — `docs/CAPABILITY.md` §2's behaviour, `AgreedButNoKey`/`KeyButNotAgreed`, the `credentials.toml` precedence note — was rendering as the documentation of a one-line newtype. Round 1 inserted `AgreeVar`'s doc block directly after the function's with no separator, and rustdoc attaches a `///` run to the next item only. `AgreeVar`/`KeyVar` are `pub(crate)` with private fields now: their only consumer is a private `fn`, and the public tuple field left `AgreeVar("DOIGET_KEY_ELSEVIER")` — the same transposition expressed as content rather than position — compiling cleanly.
- **The contact-email ladder stopped at the MCP boundary.** `graph`, `frontier`, `link`, `search`, `resolve-citation` and the dormant copy in `OrchestratorConfig` still read `DOIGET_CONTACT_EMAIL` directly and so still ignored `config.toml`, with the fallback hand-copied five times into two inconsistent policies. `config doctor` gained the `unpaywall_email` line it never had — round 1's note credited `doctor` for a change that landed in `show`.
- **`resolve_contact_emails` returned `(String, String)`** — the same swappable-adjacent-same-typed-values shape `AgreeVar`/`KeyVar` exist to close, reintroduced in a brand-new function by the same commit. Named struct.
- **`fetch` and `graph`** were the last two commands carrying `parse_ref_or_exit`'s body inlined rather than calling it, which is how they came to disagree about the exit code in the first place.
- Three doc references to `resolve_unpaywall_email`, a function round 1 deleted; two were added by round 1 itself.

## Tests

Two of the above were things a passing test claimed to cover, so:

- **`release-checksums.test.sh`** extracts the npm-publish verification loop out of `release-plz.yml` (not a copy — extracted, so it cannot drift into agreeing with a stale duplicate) and runs it against synthetic release directories: clean, orphaned checksum, missing platform binary, tampered binary. That loop is the fix this whole cluster started from and had **no test at all**.
- **`stage-npm.sh`'s missing-asset guard** was asserted only through the exit code, which stays non-zero when the guard is deleted because the `cp` behind it fails too — while leaving a half-staged package on disk. Both the `::error::` annotation and the absence of the wreckage are checked now.
- **`config doctor`'s credentials wiring** had no CLI-level test; two now cover the malformed and the advisory paths.

Mutation-verified: deleting the missing-asset guard, and weakening `verified -ne 4` to `-lt 1`, each fail the new tests. Both passed before.

## Local verification

988 tests pass (`--workspace --all-features`), `clippy -D warnings` clean, `cargo doc` clean, `cargo fmt --check` clean, all three npm test files pass. `site/content/` regenerated.

## Version

No bump, same as #491 and #542: `next` holds the clean `0.8.11` cut, so the gate would demand `0.8.11-beta.0` and regress it. `version-bump` goes red here for the same reason it did on the cut.

Refs #509, #511, #492, #504, ADR-0049, ADR-0050, ADR-0051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
