### PR TITLE
fix: npm publish never reached the registry on the 0.8.11 release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -779,7 +779,14 @@ jobs:
           # Platform packages first: the wrapper pins them by exact version
           # in optionalDependencies, so publishing it first would leave a
           # window in which `npm i doiget` resolves nothing to run.
-          for p in npm-stage/doiget-*; do
+          #
+          # The `./` is load-bearing. A bare `npm-stage/doiget-darwin-arm64`
+          # matches npm's `owner/repo` shorthand for a GitHub dependency, so
+          # npm never looks at the directory: on v0.8.11 it answered
+          # `EALLOWGIT: Refusing to fetch "github:npm-stage/doiget-darwin-arm64"`
+          # and the job died before reaching the registry at all. A path spec
+          # has to look like a path.
+          for p in ./npm-stage/doiget-*; do
             npm publish "$p" --provenance --access public --tag "$DIST_TAG"
           done
-          npm publish npm-stage/doiget --provenance --access public --tag "$DIST_TAG"
+          npm publish ./npm-stage/doiget --provenance --access public --tag "$DIST_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[ci]** **The npm publish failed on the 0.8.11 release**, for a reason no part of
+  the two review rounds had looked for. `npm publish npm-stage/doiget-darwin-arm64`
+  is two path segments with no leading `./`, which is exactly npm's `owner/repo`
+  shorthand for a GitHub dependency — so npm never opened the directory and answered
+  `EALLOWGIT: Refusing to fetch "github:npm-stage/doiget-darwin-arm64"` before
+  reaching the registry at all. The job is `continue-on-error`, so 0.8.11 released
+  green with three crates, 18 signed assets, an MCP registry entry, and no npm
+  packages. The specs carry `./` now.
+
+  `stage-npm.test.sh` could not have caught it: it verified the staged tree and
+  stopped there, one step short of the command that consumes it. It now reads the
+  publish specs out of the workflow and runs `npm publish --dry-run` on each,
+  **verbatim**, from a directory laid out the way the release job lays it out —
+  rewriting them to absolute paths first would destroy the only property under
+  test, since npm accepts an absolute path either way and the collision is a fact
+  about the literal spelling (#511).
+
 ## [0.8.11] - 2026-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.11"
+version = "0.8.12-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.11"
+version = "0.8.12-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.11"
+version = "0.8.12-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.11"
+version       = "0.8.12-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.11" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.11" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.11" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/npm/doiget/test/stage-npm.test.sh
+++ b/npm/doiget/test/stage-npm.test.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/../../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/release-plz.yml"
 WORK="$(mktemp -d)"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
@@ -116,6 +117,54 @@ if [ -e "$WORK/out2/doiget-linux-x64" ]; then
   find "$WORK/out2/doiget-linux-x64" -print
 else
   check ok "no half-staged package is left behind"
+fi
+
+# Every path the publish step hands to `npm publish` must be one npm reads as
+# a directory. `npm-stage/doiget-darwin-arm64` is two segments with no leading
+# `./`, which is exactly npm's `owner/repo` shorthand for a GitHub dependency,
+# so npm never looks at the directory. That is how the v0.8.11 npm publish
+# died: `EALLOWGIT: Refusing to fetch "github:npm-stage/doiget-darwin-arm64"`,
+# before any registry call, in a job that is `continue-on-error`.
+#
+# The specs are read out of the workflow and used VERBATIM, from a directory
+# laid out the way the release job lays it out. Rewriting them to absolute
+# paths first would destroy the only property under test: npm accepts an
+# absolute path either way, and the shorthand collision is a fact about the
+# literal spelling.
+#
+# `--dry-run` needs no credentials and, on a real directory, no registry
+# round-trip either: it packs locally and reports what it would upload. A spec
+# npm reads as a GitHub shorthand fails instead, which is the case being
+# detected. `GIT_TERMINAL_PROMPT=0` keeps that failure from stopping to ask
+# for credentials on a machine that has a terminal.
+#
+# Skipped when npm is absent, so this file stays runnable outside CI.
+if command -v npm > /dev/null 2>&1; then
+  export GIT_TERMINAL_PROMPT=0
+  cp -r "$WORK/out" "$WORK/npm-stage"
+  globs="$(grep -oE '^ *for p in [^;]+' "$WORKFLOW" | sed 's/.*for p in //')"
+  direct="$(grep -oE 'npm publish [^ "$]+' "$WORKFLOW" | awk '{print $3}')"
+  if [ -z "$globs" ] || [ -z "$direct" ]; then
+    check no "found the npm publish invocations in release-plz.yml"
+  fi
+  for spec in $globs $direct; do
+    # Expand the glob where the release job would expand it.
+    entries="$(cd "$WORK" && printf '%s\n' $spec)"
+    for d in $entries; do
+      if ! ( cd "$WORK" && [ -d "$d" ] ); then
+        check no "publish spec $d resolves to a staged directory"
+        continue
+      fi
+      if ( cd "$WORK" && npm publish --dry-run "$d" ) > "$WORK/dry" 2>&1; then
+        check ok "npm reads $d as a directory"
+      else
+        check no "npm reads $d as a directory"
+        tail -4 "$WORK/dry"
+      fi
+    done
+  done
+else
+  echo "skip  npm not on PATH; publish-spec check not run"
 fi
 
 exit "$fail"


### PR DESCRIPTION
The 0.8.11 release published three crates, 18 signed assets, the `.mcpb` and an MCP registry entry — and **no npm packages**. The `publish to npm` job failed, and not for the reason anyone expected.

```
npm error code EALLOWGIT
npm error Fetching packages of type "git" have been disabled
npm error Refusing to fetch "github:npm-stage/doiget-darwin-arm64"
```

`npm publish npm-stage/doiget-darwin-arm64` is two path segments with no leading `./` — exactly npm's `owner/repo` shorthand for a GitHub dependency. npm never opened the directory, and never reached the registry, so we still do not know whether Trusted Publishing is configured. The job is `continue-on-error`, so the release reported green while `CHANGELOG.md`'s entry for it says npm packages ship.

Same failure class as the sha256 glob two lines above it, and found the same way: by a real release, not by a test.

## Why the test suite missed it

`stage-npm.test.sh` verified the staged tree and stopped one step short of the command that consumes it. It now reads the publish specs out of `release-plz.yml` and runs `npm publish --dry-run` on each, **verbatim**, from a directory laid out the way the release job lays it out.

Verbatim is the whole point. My first attempt rebased the specs onto the fixture directory as absolute paths — and **passed against a deliberately broken workflow**, because npm accepts an absolute path either way and the shorthand collision is a fact about the literal spelling. The mutation only fails once the spec is used as written, from the right cwd. Recording that here because a test that normalises away the thing under test is worse than no test.

I also tried pinning `--registry` at a closed port to prove the check is offline. It does not prove that; it just makes npm retry for 71 s per invocation. Dropped — `--dry-run` on a real directory packs locally and needs no credentials.

## Verification

- Fixed workflow: all 5 specs pass, whole file runs in 12 s.
- Mutated workflow (`./` dropped from both invocations): all 5 specs FAIL, exit 1.

## Version

`0.8.12-beta.1`. `next` and `main` are both at `0.8.11` now that the promotion landed, so ADR-0033's gate reads this as a retarget: new base `0.8.12`, cadence reset to `beta.1`. Confirmed locally against `scripts/version-bump-gate.sh`.

## Still open

Whether npm Trusted Publishing is configured on npmjs.com is **unknown** — the job died before authenticating. The next release will find out. Configuring it is still a manual step on npmjs.com.

Refs #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
