### PR TITLE
chore: bootstrap the npm channel, and say plainly that it is not live

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -688,8 +688,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [github-release, sign]
     # Runs for betas too — they publish under the `beta` dist-tag, never
-    # `latest`. ADR-0033's cadence means most tags are betas, so gating this
-    # on stable would leave the npm channel months behind the binaries.
+    # `latest`. Note that has never actually happened: every tag pushed to
+    # this repository so far is stable (38 tags, zero betas), so in practice
+    # every run moves `latest`. Kept because a beta tag is legal under
+    # ADR-0025 and would otherwise silently take `latest`.
+    #
+    # This job cannot CREATE a package. npm Trusted Publishing has no way to
+    # perform a first publish, so the five packages must be bootstrapped once
+    # by hand — `scripts/bootstrap-npm.sh`, runbook in CONTRIBUTING.md. Until
+    # that is done this job fails on authentication however correct it is.
     #
     # `continue-on-error` matches `mcp-registry` / `desktop-extension`: a
     # publish failure must not fail a release whose crates and binaries are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Added
+
+- **[dist]** `scripts/bootstrap-npm.sh`, and the runbook for it in
+  `CONTRIBUTING.md`. The `publish to npm` job authenticates over OIDC and holds no
+  token, which is the right end state and cannot bootstrap itself: **npm Trusted
+  Publishing cannot perform a package's first publish**, because the trusted
+  publisher is configured under a package's Settings and an unpublished package has
+  none. So the five packages have to be created once by hand before the pipeline
+  that was built to publish them can run at all. The script publishes the checked-in
+  `0.0.0` templates under a `placeholder` dist-tag — never `latest`, so
+  `npm install doiget` keeps failing with "No matching version" rather than
+  installing a wrapper with no binary in it — then deprecates them and prints the
+  exact Trusted Publisher fields to enter (#511).
+
 ### Fixed
 
 - **[ci]** **The npm publish failed on the 0.8.11 release**, for a reason no part of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,35 @@ is the binding spec and full runbook. Summary:
   to the fixed commit (the pipeline runs the workflow/scripts *as of the
   tagged tree*). Do not reintroduce a perpetual "release PR".
 
+### npm: the one-time bootstrap
+
+The `publish to npm` job authenticates over OIDC and holds no `NPM_TOKEN`.
+That is the right end state and it cannot bootstrap itself: **npm Trusted
+Publishing cannot perform a package's first publish**, because the trusted
+publisher is configured under a package's Settings and an unpublished package
+has none. v0.8.11 shipped with that job red and the five packages still
+absent from the registry.
+
+Once, by a maintainer with an npm account:
+
+1. `scripts/bootstrap-npm.sh` — dry run. It reads the package list from
+   `scripts/stage-npm.sh`, checks each template is still at the `0.0.0`
+   placeholder, and refuses to proceed if any package already exists.
+2. `npm login`, with 2FA enabled and the GitHub account linked — npm's
+   documented fallback when a 2FA device and its recovery codes are both
+   lost.
+3. `scripts/bootstrap-npm.sh --publish` — publishes the five templates
+   verbatim under the `placeholder` dist-tag, then deprecates them.
+4. On npmjs.com, for **each** of the five: Settings → Trusted Publisher →
+   GitHub Actions, org `QAtlasHub`, repo `doiget`, workflow
+   `release-plz.yml`, allowed action `npm publish`, environment empty.
+5. Revoke the token.
+
+`latest` is deliberately left unset. `npm publish` only moves `latest` when
+the tag is `latest`, so until a real release `npm install doiget` fails with
+"No matching version" — a clean error rather than an install of a wrapper
+with no binary in it.
+
 ## ADR workflow
 
 When proposing a binding decision:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.12-beta.1"
+version = "0.8.12-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.12-beta.1"
+version = "0.8.12-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.12-beta.1"
+version = "0.8.12-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.12-beta.1"
+version       = "0.8.12-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ installers above — they need no compiler.
 
 ### npm / npx — one line in an agent config
 
+> **Not live yet.** The packages do not exist on the registry, so the commands
+> below fail today. See the channel table below for why, and what is left.
+
 ```sh
 npx -y doiget serve          # MCP server, no install step
 npm install -g doiget        # or put `doiget` on PATH
@@ -133,7 +136,11 @@ packages ship from tagged releases, so a very new commit may be ahead of them.
 
 Reads `.claude-plugin/` from this repository's default branch. The plugin's
 `.mcp.json` runs `doiget serve`, so install the binary by one of the routes
-above first.
+above first — the plugin installs nothing itself. That is also why this is a
+self-hosted marketplace rather than a submission to the Anthropic plugin
+directory: a listing whose first run fails for everyone without the binary
+already on PATH is worse than no listing. Once npm is live the plugin can call
+`npx -y doiget serve` and need nothing installed.
 
 ### Channel status
 
@@ -144,10 +151,19 @@ above first.
 | `cargo install doiget-cli` | shipping (needs a C linker) |
 | `.mcpb` Claude Desktop extension | shipping since 0.8.4 |
 | MCP Registry | listed |
-| npm / npx | publishes from the next tagged release |
+| npm / npx | **not live** — needs a one-time bootstrap, see below |
 | Claude Code plugin | self-hosted marketplace, as above |
 | Homebrew tap, `.deb`, Docker | **not built** |
 | Nix | `flake.nix` exists; whether it exposes an installable package rather than a dev shell is unverified |
+
+npm is the one channel whose pipeline is written and whose packages do not
+exist. npm Trusted Publishing cannot perform a package's *first* publish — the
+setting lives under a package's Settings, and there is no Settings page for a
+package that has never been published — so the release job, which carries no
+token by design, cannot create them. `scripts/bootstrap-npm.sh` does the
+once-only placeholder publish that unblocks it; `CONTRIBUTING.md` has the
+runbook. Until then `npm install doiget` fails with "No matching version",
+which is the intended failure: no `latest` is ever pointed at an empty wrapper.
 
 [#247](https://github.com/QAtlasHub/doiget/issues/247) was closed as completed
 while four of its five channels did not exist; the remaining ones are tracked in

--- a/scripts/bootstrap-npm.sh
+++ b/scripts/bootstrap-npm.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# One-time bootstrap of the five npm packages (#511).
+#
+# WHY THIS EXISTS
+#
+# npm Trusted Publishing cannot perform a package's FIRST publish. The trusted
+# publisher setting lives under a package's Settings, and there is no Settings
+# page for a package that does not exist — so the release workflow's pure-OIDC
+# job, which carries no NPM_TOKEN by design, can never create these packages.
+# v0.8.11 released with that job red for a different reason (a path spec npm
+# read as a GitHub shorthand); had that been fixed, it would have failed here
+# instead. The order was simply inverted: OIDC has to be configured before it
+# can be used.
+#
+# The way out is the documented one: publish a placeholder with a token once,
+# configure the trusted publisher against the real package, then never use a
+# token again.
+#
+# WHAT IT PUBLISHES
+#
+# The five templates under `npm/` verbatim, at their checked-in `0.0.0`. The
+# four platform packages carry no `bin` field and no binary, so a 0.0.0 of them
+# is inert. The wrapper's `optionalDependencies` pin `0.0.0`, which resolves to
+# those inert packages.
+#
+# Under `--tag placeholder`, NOT `latest`. `npm publish` only moves `latest`
+# when the tag is `latest`, so after this runs `npm install doiget` fails with
+# "No matching version" rather than installing a wrapper with no binary in it.
+# That is the honest state until a real release: this repo has only ever pushed
+# stable tags (38 tags, zero betas), and the release job publishes betas under
+# `beta`, so `latest` first appears at the next STABLE release.
+#
+# WHAT IT DOES NOT DO
+#
+# No `--provenance`: provenance needs a CI OIDC token, which is exactly what
+# this script exists to make possible. The placeholders are unprovenanced;
+# every real version is provenanced.
+#
+# Usage:
+#   scripts/bootstrap-npm.sh            # dry run: show what would happen
+#   scripts/bootstrap-npm.sh --publish  # actually publish
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$REPO_ROOT/npm"
+PLACEHOLDER_TAG="placeholder"
+
+# Read the package list from the staging script rather than restating it: a
+# fifth platform added there must not be silently skipped here.
+MAP_SOURCE="$REPO_ROOT/scripts/stage-npm.sh"
+PACKAGES="$(grep -oE '^doiget-[a-z0-9-]+:' "$MAP_SOURCE" | tr -d ':' | sort -u || true)"
+if [ -z "$PACKAGES" ]; then
+  echo "error: could not read the package list from $MAP_SOURCE" >&2
+  exit 1
+fi
+# The wrapper goes last: its optionalDependencies pin the platform packages by
+# exact version, so publishing it first leaves a window in which
+# `npm install doiget` resolves nothing to run.
+PACKAGES="$PACKAGES
+doiget"
+
+PUBLISH=0
+case "${1:-}" in
+  --publish) PUBLISH=1 ;;
+  ""|--dry-run) ;;
+  *) echo "usage: $0 [--publish]" >&2; exit 2 ;;
+esac
+
+echo "packages:"
+for p in $PACKAGES; do
+  [ -f "$SRC/$p/package.json" ] || { echo "error: $SRC/$p/package.json is missing" >&2; exit 1; }
+  # Read with grep, not node: `node -p require(...)` is handed an MSYS path
+  # on Windows and cannot resolve it, and reading one field does not justify
+  # a runtime dependency here.
+  v="$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$SRC/$p/package.json" | head -1 | awk -F'"' '{print $4}')"
+  echo "  $p@$v"
+  if [ "$v" != "0.0.0" ]; then
+    echo "error: $p is at $v, not the 0.0.0 placeholder. This script publishes the" >&2
+    echo "       templates verbatim; a stamped version here means it is running" >&2
+    echo "       against a staged tree rather than the repository." >&2
+    exit 1
+  fi
+done
+echo
+
+# Refuse to re-run against packages that already exist. Bootstrapping is
+# once-only, and a second run would publish nothing useful while looking like
+# it had worked.
+existing=0
+for p in $PACKAGES; do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/$p")"
+  if [ "$code" = "200" ]; then
+    echo "already on the registry: $p"
+    existing=$((existing + 1))
+  elif [ "$code" != "404" ]; then
+    echo "error: unexpected HTTP $code for $p — check the registry is reachable" >&2
+    exit 1
+  fi
+done
+if [ "$existing" -gt 0 ]; then
+  echo
+  echo "$existing of these already exist. Bootstrapping is once-only; configure the"
+  echo "trusted publisher on them instead (fields below) rather than re-running."
+  if [ "$PUBLISH" = "1" ]; then
+    exit 1
+  fi
+fi
+
+if [ "$PUBLISH" = "0" ]; then
+  echo
+  echo "DRY RUN. Nothing was published. Re-run with --publish to do it."
+  echo "Before that: npm login, 2FA enabled, and a granular access token with"
+  echo "write access to packages."
+else
+  who="$(npm whoami 2>/dev/null || true)"
+  if [ -z "$who" ]; then
+    echo "error: not logged in to npm. Run 'npm login' first." >&2
+    exit 1
+  fi
+  echo "publishing as: $who"
+  echo
+  for p in $PACKAGES; do
+    echo "--- $p"
+    # `./` is load-bearing: a bare `npm/doiget-linux-x64` matches npm's
+    # `owner/repo` GitHub shorthand and is never read as a directory. That is
+    # the bug that took down the v0.8.11 npm job.
+    npm publish "./npm/$p" --access public --tag "$PLACEHOLDER_TAG"
+  done
+  echo
+  echo "marking the placeholders so nobody installs one by accident:"
+  for p in $PACKAGES; do
+    npm deprecate "$p@0.0.0" \
+      "placeholder published to bootstrap npm trusted publishing; use a real release" || true
+  done
+fi
+
+cat <<EOF
+
+Next, on npmjs.com, for EACH of these packages:
+
+  Settings -> Trusted Publisher -> GitHub Actions
+
+    Organization or user   QAtlasHub
+    Repository             doiget
+    Workflow filename      release-plz.yml
+    Allowed actions        npm publish
+    Environment            (leave empty)
+
+$(for p in $PACKAGES; do echo "  https://www.npmjs.com/package/$p/access"; done)
+
+Then revoke the token used here — the release workflow authenticates over OIDC
+and needs no stored credential.
+
+Note: 'latest' is deliberately unset. It is first written by the next STABLE
+release; betas publish under the 'beta' dist-tag. Until then 'npm install
+doiget' fails cleanly rather than installing an empty wrapper.
+EOF


### PR DESCRIPTION
#544 fixed the path spec that killed the v0.8.11 npm job. Fixing it surfaced the real blocker underneath: **that job could never have worked.**

npm Trusted Publishing cannot perform a package's *first* publish. The trusted publisher is configured under a package's **Settings**, and an unpublished package has no Settings page. The release job holds no `NPM_TOKEN` by design — which is correct — so it cannot create the five packages the whole pipeline exists to publish. The order was inverted from the start: OIDC has to be configured before it can be used.

All five are still absent (measured):

```
doiget                -> HTTP 404
doiget-darwin-arm64   -> HTTP 404
doiget-darwin-x64     -> HTTP 404
doiget-linux-x64      -> HTTP 404
doiget-win32-x64      -> HTTP 404
```

## `scripts/bootstrap-npm.sh`

Once-only, run by hand. Publishes the checked-in `0.0.0` templates verbatim under a `placeholder` dist-tag, deprecates them, and prints the exact Trusted Publisher fields to enter.

- Reads the package list from `stage-npm.sh` rather than restating it, so a fifth platform added there cannot be silently skipped.
- Refuses to run if any package already exists — bootstrapping is once-only, and a second run would publish nothing while looking like it worked.
- Refuses to run against a staged tree (a stamped version where `0.0.0` belongs).
- Publishes the wrapper **last**: its `optionalDependencies` pin the platform packages by exact version.
- `--tag placeholder`, **not** `latest`. `npm publish` only moves `latest` when the tag is `latest`, so `npm install doiget` keeps failing with "No matching version" rather than installing a wrapper with no binary in it. `latest` is first written by a real release.
- No `--provenance`: provenance needs a CI OIDC token, which is the thing this script exists to make possible. The placeholders are unprovenanced; every real version is provenanced.

Dry run against the current tree:

```
packages:
  doiget-darwin-arm64@0.0.0
  doiget-darwin-x64@0.0.0
  doiget-linux-x64@0.0.0
  doiget-win32-x64@0.0.0
  doiget@0.0.0

DRY RUN. Nothing was published.
```

## Two claims corrected

**README said npm works.** The channel table read `publishes from the next tagged release`, and the section showed `npx -y doiget serve` with no caveat. Neither is true. This is exactly the #501 shape the table was *added* to catch — a channel described as shipping that does not exist — so it should not have been written that way. It now says **not live**, with the reason and the pointer to the runbook.

**The npm job's comment says "ADR-0033's cadence means most tags are betas."** Every tag this repository has ever pushed is stable: 38 tags, zero betas, zero beta releases. The comment now says what is true, and why the beta branch is kept anyway (a beta tag is legal under ADR-0025 and would otherwise silently take `latest`).

Also recorded, in the README, why the Claude Code plugin is a self-hosted marketplace rather than a submission to the Anthropic plugin directory: its `.mcp.json` runs `doiget serve` and installs nothing, so a listing would fail first-run for anyone without the binary already on PATH. It becomes submittable once npm is live and the plugin can call `npx -y doiget serve`.

## What souta does after this merges

1. `scripts/bootstrap-npm.sh` (dry run)
2. `npm login` — 2FA on, GitHub account linked, recovery codes saved
3. `scripts/bootstrap-npm.sh --publish`
4. Trusted Publisher on each of the five: org `QAtlasHub`, repo `doiget`, workflow `release-plz.yml`, action `npm publish`, environment empty
5. Revoke the token

Runbook is in `CONTRIBUTING.md` under **Release process → npm: the one-time bootstrap**.

## Verification

`bash -n` clean, dry run correct, all three npm test files pass, `cargo check` clean, `version-bump` gate passes locally (`0.8.12-beta.2` is strict beta+1 over `next`). `site/content/` regenerated.

`version-check` will be red — it is advisory and is red on every beta PR (#525, #530, #537 all the same), because it asks whether *this* version could be tagged and betas have no CHANGELOG section.

Refs #511, #513, #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
