### PR TITLE
fix: make the npm bootstrap resumable, before it strands the packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[dist]** `scripts/bootstrap-npm.sh` is resumable, runs from any working
+  directory, and no longer gives three pieces of authentication advice at once.
+  The first real run met npm's `403 ... Two-factor authentication or granular
+  access token with bypass 2fa enabled is required to publish packages` — so a
+  second factor is needed **per publish**, which makes a run stopping half way
+  through the NORMAL case rather than the exceptional one. The script refused to
+  start whenever any package already existed, which would have turned one
+  mistyped one-time password into "the remaining packages can never be published
+  by this script". It now skips what is done and publishes what is left, accepts
+  `OTP=` for a non-interactive run, and uses an absolute source path rather than
+  `./npm/<pkg>` relative to the caller's cwd (#511).
+
 - **[ci]** `version-check` was red on **every** PR to `next`, unconditionally.
   ADR-0025 D2-G5 wants a non-empty `## [X.Y.Z]` section for exactly the tagged
   version; D4 says that per-version section is generated and reviewed *at release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   comes from the `cd` rather than from spelling the path out, and the two
   environments agree on where "here" is.
 
+  It also checks for two-factor auth before publishing. npm requires a second
+  factor to publish; with 2FA *disabled* there is no code to ask for, so npm
+  does not prompt — it returns `403 ... Two-factor authentication or granular
+  access token with bypass 2fa enabled is required`, which reads like a
+  permissions problem rather than "this account is not set up yet". That cost
+  two failed runs and a wrong diagnosis about tokens and paths. The script now
+  says which of the four setup steps is missing.
+
 - **[ci]** `version-check` was red on **every** PR to `next`, unconditionally.
   ADR-0025 D2-G5 wants a non-empty `## [X.Y.Z]` section for exactly the tagged
   version; D4 says that per-version section is generated and reviewed *at release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   `OTP=` for a non-interactive run, and uses an absolute source path rather than
   `./npm/<pkg>` relative to the caller's cwd (#511).
 
+  The absolute-path half of that was wrong and is reverted. `$SRC` is a POSIX
+  path under WSL or Git Bash, and the `npm` on PATH may well be the *Windows*
+  npm — which read `/mnt/c/...` as relative and tried to open `C:\mnt\c\...`.
+  The `./` was never the only reason the relative form worked. The script now
+  `cd`s to the repository root and keeps the relative spec, so cwd-independence
+  comes from the `cd` rather than from spelling the path out, and the two
+  environments agree on where "here" is.
+
 - **[ci]** `version-check` was red on **every** PR to `next`, unconditionally.
   ADR-0025 D2-G5 wants a non-empty `## [X.Y.Z]` section for exactly the tagged
   version; D4 says that per-version section is generated and reviewed *at release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,19 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   publisher is configured under a package's Settings and an unpublished package has
   none. So the five packages have to be created once by hand before the pipeline
   that was built to publish them can run at all. The script publishes the checked-in
-  `0.0.0` templates under a `placeholder` dist-tag — never `latest`, so
-  `npm install doiget` keeps failing with "No matching version" rather than
-  installing a wrapper with no binary in it — then deprecates them and prints the
-  exact Trusted Publisher fields to enter (#511).
+  `0.0.0` templates under a `placeholder` dist-tag, deprecates them, and prints
+  the exact Trusted Publisher fields to enter (#511).
+
+  Two things this entry originally claimed are false, corrected here rather than
+  quietly rewritten. **`--tag placeholder` does not keep `latest` unset**: npm
+  sets `latest` on a package's first publish whatever `--tag` says, measured
+  after the real run as `doiget-linux-x64-> {'placeholder': '0.0.0', 'latest':
+  '0.0.0'}`. So a placeholder is exactly what `npm install <pkg>` resolves to
+  until a release moves `latest`, which makes the deprecation notice the only
+  warning a user gets rather than a nicety. And **the `doiget` wrapper is not
+  published**: npm refuses the name as too similar to the existing `giget`
+  (`403 ... Package name too similar`). The four per-platform packages are
+  published; a naming dispute is open with npm support.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,10 +240,18 @@ Once, by a maintainer with an npm account:
    `release-plz.yml`, allowed action `npm publish`, environment empty.
 5. Revoke the token.
 
-`latest` is deliberately left unset. `npm publish` only moves `latest` when
-the tag is `latest`, so until a real release `npm install doiget` fails with
-"No matching version" — a clean error rather than an install of a wrapper
-with no binary in it.
+**`latest` is not left unset**, contrary to what this section first claimed.
+npm sets `latest` on a package's *first* publish regardless of `--tag`
+(measured: `doiget-linux-x64` came out as
+`{'placeholder': '0.0.0', 'latest': '0.0.0'}`). So the placeholders *are* what
+`npm install <pkg>` resolves to until a real release moves `latest`, and the
+deprecation in step 3 is the only warning a user gets — not a nicety.
+
+The wrapper is the one that matters: nobody installs a platform package
+directly, but `npm install doiget` would land on an empty `0.0.0`. As of
+2026-08-27 the wrapper is not published at all — npm refuses the name `doiget`
+as too similar to the existing `giget`, and a naming dispute is open. The four
+platform packages are published.
 
 ## ADR workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.12-beta.3"
+version = "0.8.12-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.12-beta.3"
+version = "0.8.12-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.12-beta.3"
+version = "0.8.12-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.12-beta.3"
+version       = "0.8.12-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.3" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.3" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.3" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -162,8 +162,12 @@ setting lives under a package's Settings, and there is no Settings page for a
 package that has never been published — so the release job, which carries no
 token by design, cannot create them. `scripts/bootstrap-npm.sh` does the
 once-only placeholder publish that unblocks it; `CONTRIBUTING.md` has the
-runbook. Until then `npm install doiget` fails with "No matching version",
-which is the intended failure: no `latest` is ever pointed at an empty wrapper.
+runbook.
+
+As of 2026-08-27 the four per-platform packages are published as `0.0.0`
+placeholders and **the `doiget` wrapper is not**: npm refuses the name as too
+similar to the existing `giget` package, and a naming dispute is open. Until
+that resolves there is nothing to `npm install`.
 
 [#247](https://github.com/QAtlasHub/doiget/issues/247) was closed as completed
 while four of its five channels did not exist; the remaining ones are tracked in

--- a/scripts/bootstrap-npm.sh
+++ b/scripts/bootstrap-npm.sh
@@ -65,6 +65,10 @@ fi
 PACKAGES="$PACKAGES
 doiget"
 
+# Everything below uses paths relative to the repository root, so stand there.
+# See the note on the `npm publish` call for why relative rather than absolute.
+cd "$REPO_ROOT"
+
 PUBLISH=0
 case "${1:-}" in
   --publish) PUBLISH=1 ;;
@@ -152,12 +156,21 @@ elif [ -n "$TODO" ]; then
   published=""
   for p in $TODO; do
     echo "--- $p"
+    # RELATIVE, from $REPO_ROOT, and both halves matter.
+    #
     # `./` is load-bearing: a bare `npm/doiget-linux-x64` matches npm's
     # `owner/repo` GitHub shorthand and is never read as a directory. That is
-    # the bug that took down the v0.8.11 npm job. `$SRC` rather than a
-    # relative path so this works from any working directory.
+    # the bug that took down the v0.8.11 npm job.
+    #
+    # Relative is load-bearing too. An absolute `$SRC` is a POSIX path under
+    # WSL or Git Bash, and `npm` on PATH may well be the WINDOWS npm, which
+    # reads `/mnt/c/...` as a relative path and opens `C:\mnt\c\...`. A
+    # relative path sidesteps the whole question: WSL translates the working
+    # directory when it launches a Windows binary, so both agree on where
+    # "here" is. cwd-independence comes from the `cd` above, not from
+    # spelling the path out.
     # shellcheck disable=SC2086
-    npm publish "$SRC/$p" --access public --tag "$PLACEHOLDER_TAG" $OTP_ARGS
+    npm publish "./npm/$p" --access public --tag "$PLACEHOLDER_TAG" $OTP_ARGS
     published="$published $p"
   done
   if [ -n "$published" ]; then

--- a/scripts/bootstrap-npm.sh
+++ b/scripts/bootstrap-npm.sh
@@ -146,6 +146,26 @@ elif [ -n "$TODO" ]; then
   fi
   echo
   echo "publishing as: $who"
+  # npm requires a second factor to publish. With 2FA disabled there is no
+  # code to ask for, so npm does not prompt -- it just returns
+  #   403 ... Two-factor authentication or granular access token with bypass
+  #   2fa enabled is required to publish packages
+  # which reads like a permissions problem rather than "your account is not
+  # set up yet". Say so before spending an OTP prompt that will never appear.
+  if npm profile get 2>/dev/null | grep -qi "two-factor auth: disabled"; then
+    echo >&2
+    echo "error: this npm account has two-factor auth disabled, and npm requires" >&2
+    echo "       a second factor to publish. Nothing here can work until it is on." >&2
+    echo >&2
+    echo "  1. npmjs.com -> Account -> Two-Factor Authentication (authenticator" >&2
+    echo "     app). Save the recovery codes." >&2
+    echo "  2. While there, link your GitHub account: it is npm's documented" >&2
+    echo "     fallback if the 2FA device AND the recovery codes are both lost." >&2
+    echo "  3. npm logout && npm login -- the current session token predates" >&2
+    echo "     2FA and is not second-factor verified." >&2
+    echo "  4. Re-run this script." >&2
+    exit 1
+  fi
   # An OTP is accepted for a short window, so one code can cover several
   # calls. Passing it explicitly also lets this run without a TTY.
   OTP_ARGS=""

--- a/scripts/bootstrap-npm.sh
+++ b/scripts/bootstrap-npm.sh
@@ -23,12 +23,18 @@
 # is inert. The wrapper's `optionalDependencies` pin `0.0.0`, which resolves to
 # those inert packages.
 #
-# Under `--tag placeholder`, NOT `latest`. `npm publish` only moves `latest`
-# when the tag is `latest`, so after this runs `npm install doiget` fails with
-# "No matching version" rather than installing a wrapper with no binary in it.
-# That is the honest state until a real release: this repo has only ever pushed
-# stable tags (38 tags, zero betas), and the release job publishes betas under
-# `beta`, so `latest` first appears at the next STABLE release.
+# Under `--tag placeholder`. This does NOT keep `latest` unset -- an earlier
+# version of this comment claimed it did, and the registry disagrees: npm sets
+# `latest` on a package's FIRST publish regardless of `--tag`. Measured after
+# the real run:
+#
+#   doiget-linux-x64  dist-tags: {'placeholder': '0.0.0', 'latest': '0.0.0'}
+#
+# So a placeholder IS what `npm install <pkg>` resolves to until a real release
+# moves `latest`. That is why the deprecation below is not cosmetic: it is the
+# only warning a user gets. It is also why the wrapper matters most -- nobody
+# installs a platform package directly, but `npm install doiget` would have
+# landed on an empty 0.0.0.
 #
 # WHAT IT DOES NOT DO
 #
@@ -173,7 +179,6 @@ elif [ -n "$TODO" ]; then
     OTP_ARGS="--otp=$OTP"
   fi
   echo
-  published=""
   for p in $TODO; do
     echo "--- $p"
     # RELATIVE, from $REPO_ROOT, and both halves matter.
@@ -191,18 +196,29 @@ elif [ -n "$TODO" ]; then
     # spelling the path out.
     # shellcheck disable=SC2086
     npm publish "./npm/$p" --access public --tag "$PLACEHOLDER_TAG" $OTP_ARGS
-    published="$published $p"
   done
-  if [ -n "$published" ]; then
-    echo
-    echo "marking the placeholders so nobody installs one by accident:"
-    for p in $published; do
-      # shellcheck disable=SC2086
-      npm deprecate "$p@0.0.0" \
-        "placeholder published to bootstrap npm trusted publishing; use a real release" \
-        $OTP_ARGS || echo "  (deprecate failed for $p — cosmetic, re-run 'npm deprecate' later)"
-    done
-  fi
+fi
+
+# Deprecate every 0.0.0 on the registry, not only the ones this run published.
+# A run that stops half way leaves the earlier packages undeprecated, and since
+# npm points `latest` at them they are exactly what `npm install` resolves to --
+# the notice is the only warning anyone gets, so it must not depend on the run
+# reaching the end.
+if [ "$PUBLISH" = "1" ]; then
+  echo
+  echo "marking placeholders so nobody installs one by accident:"
+  for p in $PACKAGES; do
+    code="$(curl -s -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/$p")"
+    [ "$code" = "200" ] || continue
+    if curl -s "https://registry.npmjs.org/$p" | grep -q '"deprecated"'; then
+      echo "  already deprecated: $p@0.0.0"
+      continue
+    fi
+    # shellcheck disable=SC2086
+    npm deprecate "$p@0.0.0" \
+      "placeholder published to bootstrap npm trusted publishing; use a real release" \
+      $OTP_ARGS || echo "  (deprecate failed for $p — re-run this script to retry)"
+  done
 fi
 
 cat <<EOF
@@ -222,7 +238,8 @@ $(for p in $PACKAGES; do echo "  https://www.npmjs.com/package/$p/access"; done)
 Then revoke the token used here — the release workflow authenticates over OIDC
 and needs no stored credential.
 
-Note: 'latest' is deliberately unset. It is first written by the next STABLE
-release; betas publish under the 'beta' dist-tag. Until then 'npm install
-doiget' fails cleanly rather than installing an empty wrapper.
+Note: npm sets 'latest' to 0.0.0 on a first publish whatever --tag says, so
+until a real release these placeholders ARE what 'npm install <pkg>' resolves
+to. The deprecation notice is the only thing warning anyone. The next release
+moves 'latest' to a real version.
 EOF

--- a/scripts/bootstrap-npm.sh
+++ b/scripts/bootstrap-npm.sh
@@ -38,7 +38,13 @@
 #
 # Usage:
 #   scripts/bootstrap-npm.sh            # dry run: show what would happen
-#   scripts/bootstrap-npm.sh --publish  # actually publish
+#   scripts/bootstrap-npm.sh --publish  # publish; type the OTP when asked
+#   OTP=123456 scripts/bootstrap-npm.sh --publish   # non-interactive
+#
+# Re-running after a partial run is safe and expected: packages already on the
+# registry are skipped and the rest are published. npm asks for a fresh
+# one-time password per publish, so stopping half way through is the normal
+# case rather than the exceptional one.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -83,55 +89,87 @@ for p in $PACKAGES; do
 done
 echo
 
-# Refuse to re-run against packages that already exist. Bootstrapping is
-# once-only, and a second run would publish nothing useful while looking like
-# it had worked.
+# Work out what is left to do. Publishing five packages is five separate
+# registry calls, and npm demands a fresh one-time password for each when the
+# account has 2FA on — so a run stopping half way through is the NORMAL case,
+# not the exceptional one. An earlier version refused to start whenever any
+# package already existed, which turned one mistyped OTP into "the remaining
+# packages can never be published by this script". Skip what is done, do what
+# is left.
+TODO=""
 existing=0
 for p in $PACKAGES; do
   code="$(curl -s -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/$p")"
-  if [ "$code" = "200" ]; then
-    echo "already on the registry: $p"
-    existing=$((existing + 1))
-  elif [ "$code" != "404" ]; then
-    echo "error: unexpected HTTP $code for $p — check the registry is reachable" >&2
-    exit 1
-  fi
+  case "$code" in
+    200)
+      echo "already on the registry, skipping: $p"
+      existing=$((existing + 1))
+      ;;
+    404)
+      TODO="$TODO
+$p"
+      ;;
+    *)
+      echo "error: unexpected HTTP $code for $p — check the registry is reachable" >&2
+      exit 1
+      ;;
+  esac
 done
-if [ "$existing" -gt 0 ]; then
+TODO="$(printf '%s' "$TODO" | sed '/^$/d')"
+if [ -z "$TODO" ]; then
   echo
-  echo "$existing of these already exist. Bootstrapping is once-only; configure the"
-  echo "trusted publisher on them instead (fields below) rather than re-running."
-  if [ "$PUBLISH" = "1" ]; then
-    exit 1
-  fi
+  echo "All $existing packages are published. Nothing left to bootstrap —"
+  echo "configure the trusted publisher on them (fields below)."
 fi
 
 if [ "$PUBLISH" = "0" ]; then
   echo
   echo "DRY RUN. Nothing was published. Re-run with --publish to do it."
-  echo "Before that: npm login, 2FA enabled, and a granular access token with"
-  echo "write access to packages."
-else
+  echo
+  echo "npm requires a second factor for every publish. Two ways:"
+  echo "  * run this in an INTERACTIVE terminal and type the OTP when npm asks"
+  echo "    (once per package, so five times, plus the deprecations);"
+  echo "  * or set OTP=123456 for a single code that covers the whole run, if"
+  echo "    your authenticator's window is long enough."
+  echo "A granular access token with 'bypass 2FA' also works and is what npm's"
+  echo "own 403 suggests, but npm is restricting those for direct publishing —"
+  echo "and the point of this bootstrap is to stop needing tokens at all."
+elif [ -n "$TODO" ]; then
   who="$(npm whoami 2>/dev/null || true)"
   if [ -z "$who" ]; then
     echo "error: not logged in to npm. Run 'npm login' first." >&2
     exit 1
   fi
-  echo "publishing as: $who"
   echo
-  for p in $PACKAGES; do
+  echo "publishing as: $who"
+  # An OTP is accepted for a short window, so one code can cover several
+  # calls. Passing it explicitly also lets this run without a TTY.
+  OTP_ARGS=""
+  if [ -n "${OTP:-}" ]; then
+    OTP_ARGS="--otp=$OTP"
+  fi
+  echo
+  published=""
+  for p in $TODO; do
     echo "--- $p"
     # `./` is load-bearing: a bare `npm/doiget-linux-x64` matches npm's
     # `owner/repo` GitHub shorthand and is never read as a directory. That is
-    # the bug that took down the v0.8.11 npm job.
-    npm publish "./npm/$p" --access public --tag "$PLACEHOLDER_TAG"
+    # the bug that took down the v0.8.11 npm job. `$SRC` rather than a
+    # relative path so this works from any working directory.
+    # shellcheck disable=SC2086
+    npm publish "$SRC/$p" --access public --tag "$PLACEHOLDER_TAG" $OTP_ARGS
+    published="$published $p"
   done
-  echo
-  echo "marking the placeholders so nobody installs one by accident:"
-  for p in $PACKAGES; do
-    npm deprecate "$p@0.0.0" \
-      "placeholder published to bootstrap npm trusted publishing; use a real release" || true
-  done
+  if [ -n "$published" ]; then
+    echo
+    echo "marking the placeholders so nobody installs one by accident:"
+    for p in $published; do
+      # shellcheck disable=SC2086
+      npm deprecate "$p@0.0.0" \
+        "placeholder published to bootstrap npm trusted publishing; use a real release" \
+        $OTP_ARGS || echo "  (deprecate failed for $p — cosmetic, re-run 'npm deprecate' later)"
+    done
+  fi
 fi
 
 cat <<EOF


### PR DESCRIPTION
The first real bootstrap run hit npm's second-factor requirement:

```
403 Forbidden - PUT https://registry.npmjs.org/doiget-darwin-arm64
Two-factor authentication or granular access token with bypass 2fa enabled
is required to publish packages.
```

A second factor is required **per publish**. Five packages is five registry calls plus five deprecations, each wanting a fresh one-time password — which makes a run that stops half way through the **normal** case, not the exceptional one.

## The defect that mattered

The script refused to start whenever any package already existed. That guard was written for "do not bootstrap twice", and it is correct for that. Combined with per-call OTP it meant **one mistyped code would leave the remaining packages with no way to be published by this script at all** — you would be reduced to running `npm publish` by hand for whatever was left, which is exactly the error-prone thing the script exists to prevent.

It now skips what is already on the registry and publishes what is left. That is what "once-only" should have meant.

Caught before it bit: nothing was published in the failed run, so the registry is still clean.

## Also

- **`OTP=123456`** for a non-interactive run. npm accepts one code for a short window, so a single code can cover several calls; if it expires part way, re-running is now safe.
- Publish from `$SRC/<pkg>` rather than `./npm/<pkg>`, so the script works from any working directory. The `./` was there to dodge npm's `owner/repo` GitHub shorthand — an absolute path dodges it too, without silently depending on the caller standing in the repo root.
- The dry run said *"npm login, 2FA enabled, and a granular access token with write access to packages"* — three different auth schemes in one sentence, and wrong about all of them. It now says what npm actually demands, and notes that the bypass-2FA token npm's own 403 suggests is being restricted for direct publishing, and that not needing tokens is the entire point of this bootstrap.
- Deprecation failures no longer abort: the packages are published by then, and a missing deprecation is cosmetic.

## Verification

`bash -n` clean. Dry run correct from the repo root and from an unrelated cwd. `version-bump` gate passes locally (`0.8.12-beta.4`).

Refs #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
