### PR TITLE
docs: every cargo install command in SOURCES.md named a crate that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   this was found, and `CHANGELOG.md` records that earlier fix — it corrected the
   README and left these behind. A grep would have found them then; nobody ran one
   (#511).
+- **[docs]** `ARCHITECTURE.md`'s diagram said the MCP server exposes **9 tools**. It
+  exposes **22** — `#[tool(` appears 22 times in `doiget-mcp/src/lib.rs`, and
+  `MCP_TOOLS.md` documents 22 names. The count has been wrong since somewhere before
+  0.8.6, which is when the 22-tool safety annotations shipped;
+  `INTEGRATION/claude-code.md` says 22 correctly, so the two docs have been
+  contradicting each other in the same repository.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[docs]** Every `cargo install` command in `docs/SOURCES.md` named a crate that
+  does not exist. `cargo install doiget` returns 404 from crates.io — the crate is
+  `doiget-cli`, which produces the `doiget` binary. That included **all four Tier 3
+  install commands**, so the document that answers "how do I enable the institutional
+  TDM connectors" answered it with four commands that fail. Same in
+  `docs/MIGRATION.md` and the site's quick start.
+
+  `README.md` has said `cargo install doiget` does **not** work since the last time
+  this was found, and `CHANGELOG.md` records that earlier fix — it corrected the
+  README and left these behind. A grep would have found them then; nobody ran one
+  (#511).
+
 ### Changed
 
 - **[dist]** **The npm wrapper package is `doiget-cli`, not `doiget`.** npm refuses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.12-beta.5"
+version = "0.8.12-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.12-beta.5"
+version = "0.8.12-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.12-beta.5"
+version = "0.8.12-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.12-beta.5"
+version       = "0.8.12-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ via the `serve` subcommand. Every fetch passes through a fail-closed provenance 
 flowchart TB
     User[CLI user / Agent host]
     User --> CLI[doiget-cli<br/>fetch / batch / info / serve]
-    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 9 tools]
+    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 22 tools]
     CLI --> Core[doiget-core]
     MCP --> Core
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -12,7 +12,7 @@ machines.
 ### 1. BiblioFetch.jl user trying doiget for the first time
 
 ```sh
-cargo install doiget
+cargo install doiget-cli
 doiget info <DOI of an existing entry>      # should read what BiblioFetch wrote
 ```
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -105,11 +105,11 @@ none.
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+`cargo install doiget-cli` (default) compiles Tier 1 only. The optional source surface
 requires an opt-in build:
 
 ```sh
-cargo install doiget --features metadata
+cargo install doiget-cli --features metadata
 ```
 
 **What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
@@ -128,10 +128,10 @@ download.
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 
 ```sh
-cargo install doiget --features metadata,tdm-springer
-cargo install doiget --features metadata,tdm-aps
-cargo install doiget --features metadata,tdm-elsevier
-cargo install doiget --features metadata,tdm-ieee
+cargo install doiget-cli --features metadata,tdm-springer
+cargo install doiget-cli --features metadata,tdm-aps
+cargo install doiget-cli --features metadata,tdm-elsevier
+cargo install doiget-cli --features metadata,tdm-ieee
 ```
 
 There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).

--- a/site/content/contribute/architecture.md
+++ b/site/content/contribute/architecture.md
@@ -29,7 +29,7 @@ via the `serve` subcommand. Every fetch passes through a fail-closed provenance 
 flowchart TB
     User[CLI user / Agent host]
     User --> CLI[doiget-cli<br/>fetch / batch / info / serve]
-    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 9 tools]
+    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 22 tools]
     CLI --> Core[doiget-core]
     MCP --> Core
 

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -111,11 +111,11 @@ none.
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+`cargo install doiget-cli` (default) compiles Tier 1 only. The optional source surface
 requires an opt-in build:
 
 ```sh
-cargo install doiget --features metadata
+cargo install doiget-cli --features metadata
 ```
 
 **What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
@@ -134,10 +134,10 @@ download.
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 
 ```sh
-cargo install doiget --features metadata,tdm-springer
-cargo install doiget --features metadata,tdm-aps
-cargo install doiget --features metadata,tdm-elsevier
-cargo install doiget --features metadata,tdm-ieee
+cargo install doiget-cli --features metadata,tdm-springer
+cargo install doiget-cli --features metadata,tdm-aps
+cargo install doiget-cli --features metadata,tdm-elsevier
+cargo install doiget-cli --features metadata,tdm-ieee
 ```
 
 There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).

--- a/site/content/use/_index.md
+++ b/site/content/use/_index.md
@@ -21,7 +21,7 @@ sources; institutional TDM access is opt-in at build time per publisher.
 
 ```sh
 # install (after Phase 6 release lands)
-cargo install doiget
+cargo install doiget-cli
 
 # fetch a paper by DOI
 doiget fetch 10.1103/PhysRevLett.130.200601

--- a/site/content/use/migration.md
+++ b/site/content/use/migration.md
@@ -18,7 +18,7 @@ machines.
 ### 1. BiblioFetch.jl user trying doiget for the first time
 
 ```sh
-cargo install doiget
+cargo install doiget-cli
 doiget info <DOI of an existing entry>      # should read what BiblioFetch wrote
 ```
 


### PR DESCRIPTION
`cargo install doiget` returns **404 from crates.io**. The crate is `doiget-cli`; it produces the `doiget` binary.

That included **all four Tier 3 install commands** in `docs/SOURCES.md` — so the document whose job is to answer *"how do I enable the institutional TDM connectors"* answered it with four commands that fail:

```sh
cargo install doiget --features metadata,tdm-springer   # 404
cargo install doiget --features metadata,tdm-aps        # 404
cargo install doiget --features metadata,tdm-elsevier   # 404
cargo install doiget --features metadata,tdm-ieee       # 404
```

Eight occurrences across `docs/SOURCES.md`, `docs/MIGRATION.md` and the site quick start.

## This was already known

`README.md:94` says, in as many words:

> The published crate is **`doiget-cli`** (it produces the `doiget` binary). `cargo install doiget` does **not** work — there is no crate by that bare name

And `CHANGELOG.md:1083` records the earlier fix that put that sentence there: *"Corrected the install command `cargo install doiget` → …"*.

So it was found once, corrected in the README, and left standing everywhere else. A `grep -rn "cargo install doiget"` would have caught the rest the same day. The README's warning being *correct* is what let the wrong commands survive — anyone checking the README came away satisfied.

Found while answering "what is Tier 3 again", which meant reading the page that tells you how to get it.

## Note

`README.md:94` still contains the string `cargo install doiget` — deliberately, as the warning quoted above. The `site/content/` files are regenerated by `scripts/sync_docs_to_site.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
