### PR TITLE
fix: every release binary shipped without the citation graph MCP tool

### DIFF
--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -119,6 +119,48 @@ jobs:
           fi
           echo "LICENSE OK: verbatim SPDX MIT, no trailing prose, ends at SOFTWARE., LF."
 
+      - name: doiget-cli forwards every doiget-mcp feature (#373 / #516)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `doiget serve` runs `doiget-mcp` code, and `doiget-mcp` reads its
+          # OWN `cfg!(feature = ...)`. So a `doiget-cli` feature that forwards
+          # only to `doiget-core` leaves the MCP surface behind.
+          #
+          # Not hypothetical: `citation` did exactly this, and the release
+          # binary — built `-p doiget-cli --features oa-only,citation` so the
+          # graph tool would ship (#373) — advertised 21 tools instead of 22,
+          # while `doiget graph` and `capability_profile` both reported the
+          # citation graph as available.
+          #
+          # The whole test matrix missed it. CI builds with `--workspace
+          # --features oa-only,citation`, which enables the feature on
+          # `doiget-mcp` DIRECTLY; only a `-p doiget-cli` build goes through
+          # the forwarding. So this is checked structurally, where the defect
+          # lives, rather than by a feature-flagged test that cannot see it.
+          mcp_features="$(awk '/^\[features\]/{f=1;next} /^\[/{f=0} f && /^[a-z][a-z0-9-]*[[:space:]]*=/{sub(/[[:space:]]*=.*/,""); print}' \
+                          crates/doiget-mcp/Cargo.toml | grep -v '^default$' | sort -u)"
+          if [ -z "$mcp_features" ]; then
+            echo "::error::posture-lint features: read no [features] from crates/doiget-mcp/Cargo.toml"
+            exit 1
+          fi
+          fail=0
+          for f in $mcp_features; do
+            line="$(grep -E "^${f}[[:space:]]*=" crates/doiget-cli/Cargo.toml || true)"
+            if [ -z "$line" ]; then
+              echo "::error::posture-lint features: doiget-mcp has feature '${f}' but doiget-cli has none of that name, so nothing can enable it in a '-p doiget-cli' build"
+              fail=1
+              continue
+            fi
+            if ! printf '%s' "$line" | grep -q "doiget-mcp/${f}"; then
+              echo "::error::posture-lint features: doiget-cli's '${f}' does not forward to doiget-mcp/${f} — 'doiget serve' will behave as if the feature is off (#373)"
+              printf '  %s\n' "$line"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ]
+          echo "doiget-cli forwards every doiget-mcp feature: $(echo "$mcp_features" | tr '\n' ' ')"
+
       - name: npm platform packages cover every release binary (#511)
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   this was found, and `CHANGELOG.md` records that earlier fix — it corrected the
   README and left these behind. A grep would have found them then; nobody ran one
   (#511).
+- **[docs]** `ARCHITECTURE.md`'s diagram said the MCP server exposes **9 tools**. It
+  exposes **22** — `#[tool(` appears 22 times in `doiget-mcp/src/lib.rs`, and
+  `MCP_TOOLS.md` documents 22 names. The count has been wrong since somewhere before
+  0.8.6, which is when the 22-tool safety annotations shipped;
+  `INTEGRATION/claude-code.md` says 22 correctly, so the two docs have been
+  contradicting each other in the same repository.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[mcp]** **Every release binary shipped without `doiget_expand_citation_graph`**,
+  the tool it was built to ship. `Server::new` drops that route on
+  `cfg!(feature = "citation")` *evaluated inside `doiget-mcp`*, and `doiget-cli`'s
+  `citation` feature forwarded only to `doiget-core`. The release build is
+  `-p doiget-cli --no-default-features --features oa-only,citation`, chosen
+  precisely so the graph tool ships (#373) — so `tools/list` advertised 21 tools
+  instead of 22 while `doiget graph` worked and `doiget_capability_profile`
+  reported `citation` as compiled in. An agent reading the profile would look for
+  the tool and not find it. Same shape as this feature's own missing `metadata`
+  implication (#516), one crate over; the `tdm-*` features already forwarded
+  correctly, `citation` alone did not.
+
+  **The test matrix could not see it.** CI's citation job builds
+  `--workspace --features oa-only,citation`, which turns the feature on for
+  `doiget-mcp` *directly*; only a `-p doiget-cli` build exercises the forwarding.
+  So the regression is pinned structurally, in posture-lint: every `doiget-mcp`
+  feature must be forwarded by the `doiget-cli` feature of the same name. Verified
+  by mutation — reverting the fix fails the check.
+
+  Found by running `doiget serve` out of an actually-installed npm package and
+  diffing `tools/list` against `MCP_TOOLS.md`, which is the first time the npm
+  packaging had been exercised with a real binary rather than a fixture.
+
 - **[docs]** Every `cargo install` command in `docs/SOURCES.md` named a crate that
   does not exist. `cargo install doiget` returns 404 from crates.io — the crate is
   `doiget-cli`, which produces the `doiget` binary. That included **all four Tier 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[docs]** Every `cargo install` command in `docs/SOURCES.md` named a crate that
+  does not exist. `cargo install doiget` returns 404 from crates.io — the crate is
+  `doiget-cli`, which produces the `doiget` binary. That included **all four Tier 3
+  install commands**, so the document that answers "how do I enable the institutional
+  TDM connectors" answered it with four commands that fail. Same in
+  `docs/MIGRATION.md` and the site's quick start.
+
+  `README.md` has said `cargo install doiget` does **not** work since the last time
+  this was found, and `CHANGELOG.md` records that earlier fix — it corrected the
+  README and left these behind. A grep would have found them then; nobody ran one
+  (#511).
+
 ### Changed
 
 - **[dist]** **The npm wrapper package is `doiget-cli`, not `doiget`.** npm refuses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.12-beta.7"
+version = "0.8.12-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.12-beta.7"
+version = "0.8.12-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.12-beta.7"
+version = "0.8.12-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.12-beta.5"
+version = "0.8.12-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.12-beta.5"
+version = "0.8.12-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.12-beta.5"
+version = "0.8.12-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.12-beta.7"
+version       = "0.8.12-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.12-beta.5"
+version       = "0.8.12-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.12-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/Cargo.toml
+++ b/crates/doiget-cli/Cargo.toml
@@ -27,7 +27,14 @@ metadata = ["doiget-core/metadata"]
 # CLI-level implication `cfg(feature = "metadata")` is FALSE in a
 # `--features citation` build, so anything gated on `metadata` here
 # silently drops out of the richer build (#516).
-citation = ["metadata", "doiget-core/citation"]
+# The `doiget-mcp/citation` half is what makes the graph tool appear in
+# `tools/list`: `Server::new` trims that route on `cfg!(feature = "citation")`
+# evaluated IN `doiget-mcp`, so forwarding only to `doiget-core` left the
+# release binary — built `--features oa-only,citation` precisely so the tool
+# ships (#373) — advertising 21 tools instead of 22, while `doiget graph` and
+# `capability_profile` both reported the citation graph as available. Same
+# shape as this feature's own `metadata` omission (#516), one crate over.
+citation = ["metadata", "doiget-core/citation", "doiget-mcp/citation"]
 # The `doiget-mcp/*` half matters: `doiget serve` builds its client
 # through the MCP twin of `build_http_client`, so a CLI-only feature
 # would leave the MCP surface without the Tier-3 transport gate (#454).

--- a/crates/doiget-mcp/Cargo.toml
+++ b/crates/doiget-mcp/Cargo.toml
@@ -17,11 +17,20 @@ workspace = true
 
 [features]
 default = []
-# Phase 4 / Slice 15. Enables the `doiget_expand_citation_graph` MCP
-# tool by turning on `doiget-core/citation` (which itself enables
-# `doiget-core/metadata`). Default release binaries (built without
-# `--features citation`) ship without the graph tool; `tools/list`
-# advertises 12 tools instead of 13 in that build.
+# Phase 4 / Slice 15. Enables the `doiget_expand_citation_graph` MCP tool by
+# turning on `doiget-core/citation` (which itself enables
+# `doiget-core/metadata`).
+#
+# Release binaries DO enable it: they are built `--features oa-only,citation`
+# so the graph tool ships (#373). This comment used to say the opposite — that
+# release binaries ship without it, advertising "12 tools instead of 13" — and
+# both halves were wrong: the counts are 21 and 22, and the intent reversed at
+# #373 without this being updated. A stale comment describing the old intent is
+# how the missing `doiget-mcp/citation` forward in `doiget-cli` survived: the
+# behaviour matched the comment, so it looked deliberate.
+#
+# A build WITHOUT this feature still ships 21 tools; the graph route is removed
+# in `Server::new` rather than left to answer NOT_IMPLEMENTED (#379).
 citation = ["doiget-core/citation"]
 
 # Tier 3 — opt-in build only, never published (ADR-0002). doiget-mcp has

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ via the `serve` subcommand. Every fetch passes through a fail-closed provenance 
 flowchart TB
     User[CLI user / Agent host]
     User --> CLI[doiget-cli<br/>fetch / batch / info / serve]
-    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 9 tools]
+    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 22 tools]
     CLI --> Core[doiget-core]
     MCP --> Core
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -12,7 +12,7 @@ machines.
 ### 1. BiblioFetch.jl user trying doiget for the first time
 
 ```sh
-cargo install doiget
+cargo install doiget-cli
 doiget info <DOI of an existing entry>      # should read what BiblioFetch wrote
 ```
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -105,11 +105,11 @@ none.
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+`cargo install doiget-cli` (default) compiles Tier 1 only. The optional source surface
 requires an opt-in build:
 
 ```sh
-cargo install doiget --features metadata
+cargo install doiget-cli --features metadata
 ```
 
 **What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
@@ -128,10 +128,10 @@ download.
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 
 ```sh
-cargo install doiget --features metadata,tdm-springer
-cargo install doiget --features metadata,tdm-aps
-cargo install doiget --features metadata,tdm-elsevier
-cargo install doiget --features metadata,tdm-ieee
+cargo install doiget-cli --features metadata,tdm-springer
+cargo install doiget-cli --features metadata,tdm-aps
+cargo install doiget-cli --features metadata,tdm-elsevier
+cargo install doiget-cli --features metadata,tdm-ieee
 ```
 
 There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).

--- a/site/content/contribute/architecture.md
+++ b/site/content/contribute/architecture.md
@@ -29,7 +29,7 @@ via the `serve` subcommand. Every fetch passes through a fail-closed provenance 
 flowchart TB
     User[CLI user / Agent host]
     User --> CLI[doiget-cli<br/>fetch / batch / info / serve]
-    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 9 tools]
+    CLI --> MCP[doiget-mcp<br/>stdio JSON-RPC, 22 tools]
     CLI --> Core[doiget-core]
     MCP --> Core
 

--- a/site/content/developer/sources.md
+++ b/site/content/developer/sources.md
@@ -111,11 +111,11 @@ none.
 
 ## 3. Default release binaries
 
-`cargo install doiget` (default) compiles Tier 1 only. The optional source surface
+`cargo install doiget-cli` (default) compiles Tier 1 only. The optional source surface
 requires an opt-in build:
 
 ```sh
-cargo install doiget --features metadata
+cargo install doiget-cli --features metadata
 ```
 
 **What `metadata` means (ADR-0040, NORMATIVE).** The feature name predates the sources
@@ -134,10 +134,10 @@ download.
 Tier 3 TDM sources are individually feature-flagged and require user-driven build:
 
 ```sh
-cargo install doiget --features metadata,tdm-springer
-cargo install doiget --features metadata,tdm-aps
-cargo install doiget --features metadata,tdm-elsevier
-cargo install doiget --features metadata,tdm-ieee
+cargo install doiget-cli --features metadata,tdm-springer
+cargo install doiget-cli --features metadata,tdm-aps
+cargo install doiget-cli --features metadata,tdm-elsevier
+cargo install doiget-cli --features metadata,tdm-ieee
 ```
 
 There is no `tdm-all` umbrella feature ([`SCOPE.md`](SCOPE.md) §non-goal 12).

--- a/site/content/use/_index.md
+++ b/site/content/use/_index.md
@@ -21,7 +21,7 @@ sources; institutional TDM access is opt-in at build time per publisher.
 
 ```sh
 # install (after Phase 6 release lands)
-cargo install doiget
+cargo install doiget-cli
 
 # fetch a paper by DOI
 doiget fetch 10.1103/PhysRevLett.130.200601

--- a/site/content/use/migration.md
+++ b/site/content/use/migration.md
@@ -18,7 +18,7 @@ machines.
 ### 1. BiblioFetch.jl user trying doiget for the first time
 
 ```sh
-cargo install doiget
+cargo install doiget-cli
 doiget info <DOI of an existing entry>      # should read what BiblioFetch wrote
 ```
 


### PR DESCRIPTION
> Stacked on #551. Merge that first.

**Every release binary shipped without `doiget_expand_citation_graph`** — the tool it was built to ship.

`Server::new` drops that route on `cfg!(feature = "citation")` evaluated **inside `doiget-mcp`**. `doiget-cli`'s feature forwarded to `doiget-core` and nothing else:

```toml
citation     = ["metadata", "doiget-core/citation"]                       # before
tdm-elsevier = ["doiget-core/tdm-elsevier", "doiget-mcp/tdm-elsevier"]    # already correct
```

The release build is `-p doiget-cli --no-default-features --features oa-only,citation`, chosen precisely so the graph tool ships (#373). Measured on a real release-profile binary, installed through npm:

```
$ npx doiget-cli capabilities
"features": ["oa-only", "metadata", "citation"]

$ npx doiget-cli graph --help
Expand a DOI's citation neighborhood via OpenAlex (BFS, ADR-0010 hard caps)...

$ doiget serve  →  tools/list
21 tools;  doiget_expand_citation_graph present: False
```

So `capability_profile` says the citation graph is available, `doiget graph` works, and the MCP tool for it is absent. An agent reading the profile goes looking for a tool that is not there — and `MCP_TOOLS.md` documents it.

After the one-line fix: **22 tools, present: True**, stdout still pure JSON-RPC, stderr 0 bytes.

## Why it survived

`doiget-mcp/Cargo.toml` said, in a comment:

> Default release binaries (built without `--features citation`) ship without the graph tool; `tools/list` advertises 12 tools instead of 13 in that build.

Written before #373 reversed the intent, never updated. **The behaviour matched the comment, so it read as deliberate.** Both numbers were stale too — it is 21 and 22. `release-plz.yml` says the opposite in its own comment, so two files in this repo have been contradicting each other about whether the tool ships.

## Why no test caught it, and what pins it now

CI's citation job builds `--workspace --features oa-only,citation`. With `--workspace`, cargo enables the feature on **`doiget-mcp` directly** — the forwarding is bypassed. Only a `-p doiget-cli` build exercises it, and the only `-p doiget-cli` build is the release.

A feature-flagged test therefore *cannot* see this defect. So it is pinned structurally, in posture-lint: **every `doiget-mcp` feature must be forwarded by the `doiget-cli` feature of the same name.** That is a check of the thing that was actually wrong, not a proxy for it.

Mutation-verified:

```
(fixed)     mcp features: citation tdm-aps tdm-elsevier tdm-ieee tdm-springer → ALL FORWARDED
(reverted)  CAUGHT: citation not forwarded → lint exits nonzero
```

## Provenance

Found by running `doiget serve` from an **actually installed npm package** and diffing `tools/list` against `MCP_TOOLS.md`. That was the first time the npm packaging had been exercised with a real binary rather than a `printf 'fake'` fixture — which is why I wanted to do it before the release that first publishes to npm.

The same diff turned up two documentation gaps, filed separately rather than mixed in here: 4 shipped tools with no entry in `MCP_TOOLS.md` (`doiget_annotate`, `doiget_batch_from_bibliography`, `doiget_paper_tex_source`, `doiget_tag`).

Refs #373, #516, #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
