### PR TITLE
fix: chacha20 0.10.1 was yanked from crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [0.8.12] - 2026-08-27
 
+### Security
+
+- **[deps]** `chacha20` 0.10.1 was yanked from crates.io; moved to 0.10.2. Caught by
+  `cargo deny` on the promotion PR, not by anything in this release's own changes —
+  the lock had been fine when the cut was made and the yank landed after it. No
+  RUSTSEC advisory accompanies the yank, so this is a hygiene fix rather than a
+  known-exploitable one, but pinning a yanked version in a release is not something
+  to ship past. Reached through `rand`. The `cargo vet` exemption moved with it,
+  which is required or the next `vet` run goes red.
+
 ### Added
 
 - **[ci]** `scripts/release-version-gate.test.sh` — G5's first test. It runs the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -111,7 +111,7 @@ version = "1.2.61"
 criteria = "safe-to-deploy"
 
 [[exemptions.chacha20]]
-version = "0.10.1"
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]


### PR DESCRIPTION
`cargo deny` on the promotion PR #556:

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
```

0.10.1 is yanked. **0.10.2 was published 2026-08-27 — two days ago, after the cut was made**, so this is not a defect in anything this release changed. The lock was clean when it was written and the yank landed afterwards. Reached through `rand`.

```
0.10.2   yanked=False   2026-08-27
0.10.1   yanked=True    2026-06-24   ← ours
0.10.0   yanked=True    2026-02-07
```

No RUSTSEC advisory accompanies the yank, so this is hygiene rather than a known-exploitable hole. Still not worth shipping past: a released binary pinning a version its author withdrew is a thing you have to explain later, and the release is otherwise ready.

The `cargo vet` exemption moves with it (`supply-chain/config.toml`, 0.10.1 → 0.10.2). Leaving it behind turns the next `vet` run red — the recurring cost of dep bumps in this repo.

## No version bump

`next` carries the clean `0.8.12` from the cut, so ADR-0033's gate would demand `0.8.12-beta.0` and regress it. **`version-bump` is red here for the same reason it is red on the cut itself** — same as #491 and #542 did on the 0.8.11 cut.

## Verified

`cargo check --workspace` clean, and `release-version-gate.sh v0.8.12` still passes G0–G6 with the new lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)