### PR TITLE
fix: the npm publish job published the wrapper twice

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -793,7 +793,19 @@ jobs:
           # `EALLOWGIT: Refusing to fetch "github:npm-stage/doiget-darwin-arm64"`
           # and the job died before reaching the registry at all. A path spec
           # has to look like a path.
-          for p in ./npm-stage/doiget-*; do
-            npm publish "$p" --provenance --access public --tag "$DIST_TAG"
+          # The platform list comes from `stage-npm.sh`'s MAP, not from a
+          # `doiget-*` glob. The glob used to be safe because the wrapper was
+          # named `doiget`; renaming it to `doiget-cli` made the glob match it
+          # too, so v0.8.12 published the wrapper inside the loop AND again on
+          # the line below -- `npm error You cannot publish over the previously
+          # published versions: 0.8.12`, after everything had in fact shipped.
+          # It also sorted first, so the wrapper went out ahead of the packages
+          # it pins: exactly the window the paragraph above warns about.
+          #
+          # Reading the MAP cannot drift the same way. It lists platform
+          # packages only, so the wrapper is excluded by construction rather
+          # than by a name test somebody has to remember to update.
+          for pkg in $(grep -oE '^doiget-[a-z0-9-]+:' scripts/stage-npm.sh | tr -d ':' | sort -u); do
+            npm publish "./npm-stage/$pkg" --provenance --access public --tag "$DIST_TAG"
           done
           npm publish ./npm-stage/doiget-cli --provenance --access public --tag "$DIST_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[ci]** The npm publish job published the wrapper **twice** and failed on the
+  second attempt: `npm error You cannot publish over the previously published
+  versions: 0.8.12`. The loop globbed `./npm-stage/doiget-*`, which was safe while
+  the wrapper was named `doiget` and stopped being safe the moment it was renamed
+  to `doiget-cli` — that name starts with `doiget-` too. So the wrapper went out
+  inside the loop and again on the explicit line after it. It also sorts before
+  `doiget-darwin-*`, so it published ahead of the packages its
+  `optionalDependencies` pin: the exact window the comment above that loop warns
+  about.
+
+  Everything had already shipped by then, which is the worst shape a failure can
+  take — a red job on a complete release. The 0.8.12 npm packages are correct and
+  live; only the job's exit status was wrong.
+
+  The loop now reads the platform list from `stage-npm.sh`'s MAP, which lists
+  platform packages only, so the wrapper is excluded by construction rather than by
+  a name test somebody has to remember. `stage-npm.test.sh` bans the glob outright
+  and asserts no package is published twice; mutation-checked in both directions.
+
+  Worth recording: the identical trap was spotted in `posture-lint`'s
+  `find -name 'doiget-*'` and excluded there, in the very PR that did the rename
+  (#549). One of the two `doiget-*` patterns got the fix (#511).
+
 ## [0.8.12] - 2026-08-27
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.12"
+version = "0.8.13-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.12"
+version = "0.8.13-beta.1"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.12"
+version = "0.8.13-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.12"
+version       = "0.8.13-beta.1"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.12" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.12" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.12" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.1" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.1" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.1" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/npm/doiget-cli/test/stage-npm.test.sh
+++ b/npm/doiget-cli/test/stage-npm.test.sh
@@ -142,12 +142,46 @@ fi
 if command -v npm > /dev/null 2>&1; then
   export GIT_TERMINAL_PROMPT=0
   cp -r "$WORK/out" "$WORK/npm-stage"
-  globs="$(grep -oE '^ *for p in [^;]+' "$WORKFLOW" | sed 's/.*for p in //')"
+  # A `npm-stage/doiget-*` glob is banned outright. It matches the WRAPPER --
+  # `doiget-cli` starts with `doiget-` too -- so the wrapper is published
+  # inside the loop and again on the explicit line after it. v0.8.12's release
+  # job died on `You cannot publish over the previously published versions:
+  # 0.8.12`, after everything had already shipped: red job, complete release.
+  # It also sorted first, so the wrapper went out ahead of the packages its
+  # optionalDependencies pin.
+  #
+  # This is checked as a shape, not as a duplicate count, because the glob is
+  # the thing that is wrong. The same trap was spotted and excluded in
+  # posture-lint's `find -name doiget-*` in the very PR that renamed the
+  # wrapper, and missed here.
+  if grep -qE 'npm-stage/doiget-\*' "$WORKFLOW"; then
+    check no "the publish step does not glob npm-stage/doiget-*"
+    grep -nE 'npm-stage/doiget-\*' "$WORKFLOW" | sed 's/^/  /'
+  else
+    check ok "the publish step does not glob npm-stage/doiget-*"
+  fi
+
+  # The platform list the loop actually iterates, from the same source it reads.
+  looped="$(grep -oE '^doiget-[a-z0-9-]+:' "$ROOT/scripts/stage-npm.sh" | tr -d ':' | sort -u | sed 's#^#./npm-stage/#')"
   direct="$(grep -oE 'npm publish [^ "$]+' "$WORKFLOW" | awk '{print $3}')"
-  if [ -z "$globs" ] || [ -z "$direct" ]; then
+  if [ -z "$looped" ] || [ -z "$direct" ]; then
     check no "found the npm publish invocations in release-plz.yml"
   fi
-  for spec in $globs $direct; do
+
+  all_specs="$(printf '%s
+%s
+' "$looped" "$direct" | sed '/^$/d' | sed 's#^\./##')"
+  dupes="$(printf '%s
+' "$all_specs" | sort | uniq -d)"
+  if [ -n "$dupes" ]; then
+    check no "no package is published twice"
+    printf '  duplicated: %s
+' "$dupes"
+  else
+    check ok "no package is published twice"
+  fi
+
+  for spec in $looped $direct; do
     # Expand the glob where the release job would expand it.
     entries="$(cd "$WORK" && printf '%s\n' $spec)"
     for d in $entries; do


### PR DESCRIPTION
v0.8.12's release job ended red:

```
npm error You cannot publish over the previously published versions: 0.8.12
```

**Everything had already shipped.** All five packages are live at 0.8.12 and `npx doiget-cli --version` answers `doiget 0.8.12` from the real registry. Only the job's exit status was wrong — the worst shape a failure takes, because anyone reading the status concludes npm did not publish.

## Cause

The loop globbed `./npm-stage/doiget-*`. Safe while the wrapper was named `doiget`; unsafe the moment it became **`doiget-cli`**, which starts with `doiget-` too. So the wrapper published inside the loop and again on the explicit line after it.

It also sorts before `doiget-darwin-*`, so it went out **ahead of the packages its `optionalDependencies` pin** — the exact window the comment directly above that loop warns about.

## Fix

The loop reads the platform list from `stage-npm.sh`'s MAP. That list contains platform packages only, so the wrapper is excluded **by construction** rather than by a name test somebody has to remember to update — the same technique `bootstrap-npm.sh` already uses.

## Test

`stage-npm.test.sh` bans the glob outright. The glob is the thing that is wrong, so it is checked as a shape rather than as a duplicate count — a duplicate-count check alone went green under mutation, because the mutated loop no longer matched the pattern the check was reading. It also asserts separately that no package appears twice.

```
fixed:   ok    the publish step does not glob npm-stage/doiget-*
mutated: FAIL  the publish step does not glob npm-stage/doiget-*
```

## Worth recording

**The identical trap was caught in `posture-lint`'s `find -name 'doiget-*'` and excluded there — in the same PR that did the rename (#549).** Two `doiget-*` patterns needed the same fix. One got it.

Refs #511
