### PR TITLE
feat: the Claude Code plugin no longer requires doiget to be installed first

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "doiget",
   "metadata": {
     "description": "The doiget marketplace — one plugin: an OA-first paper fetcher for DOIs and arXiv IDs.",
-    "version": "0.8.11"
+    "version": "0.8.12"
   },
   "owner": {
     "name": "QAtlasHub",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "doiget",
   "description": "Turn DOIs and arXiv IDs into local PDFs and structured metadata via official Open-Access APIs. Never bypasses paywalls.",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "Sota Shimozono",
     "url": "https://github.com/QAtlasHub/doiget"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,10 @@
 {
   "mcpServers": {
     "doiget": {
-      "command": "doiget",
+      "command": "npx",
       "args": [
+        "-y",
+        "doiget-cli",
         "serve"
       ]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Changed
+
+- **[dist]** The Claude Code plugin runs `npx -y doiget-cli serve` instead of a bare
+  `doiget serve`, so installing it **needs nothing installed beforehand** — npm
+  fetches the wrapper and the one matching platform binary on first run. Until now
+  the plugin only worked for people who had already installed doiget some other
+  way, which is why it was kept as a self-hosted marketplace rather than submitted
+  to the Anthropic plugin directory: a listing whose first run fails for everyone
+  without the binary on PATH is worse than no listing. That objection is gone, so
+  the directory submission is now viable (#513).
+
+  Verified by launching it: `npx -y doiget-cli serve` from the real registry
+  answers `initialize` as `doiget 0.8.12` and lists 22 tools, with pure JSON-RPC on
+  stdout and zero bytes on stderr.
+
+### Fixed
+
+- **[dist]** `.claude-plugin/plugin.json` and `marketplace.json` said **0.8.11**
+  while the repository was two releases ahead. Nothing stamps them — no script, no
+  workflow references either file — so they drift silently, and `/plugin
+  marketplace add` reads the default branch, meaning users saw the stale number.
+  Set to 0.8.12, the last released version (#513).
+- **[docs]** Two more references the `doiget` → `doiget-cli` rename left behind:
+  `README.md`'s plugin paragraph promised `npx -y doiget serve`, and the 0.8.11
+  release notes lead with two npm commands that were never valid — the wrapper is
+  not called `doiget`, and that release's npm publish failed outright, so nothing
+  was on the registry to install. The 0.8.11 entry is annotated rather than
+  rewritten (#511).
+
 ### Fixed
 
 - **[ci]** The npm publish job published the wrapper **twice** and failed on the
@@ -247,6 +276,12 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   supply-chain shape a reviewer is trained to reject. Published by the release
   workflow over npm Trusted Publishing (OIDC, no long-lived token), after verifying
   each binary against the release's own `.sha256` (#511).
+
+  **Neither command in this entry was ever valid.** The npm publish failed on this
+  release (see the `[ci]` entry below), so nothing was on the registry; and the
+  wrapper is `doiget-cli`, not `doiget` — npm refuses the bare name as too similar
+  to the unrelated `giget`. The channel first went live at 0.8.12. Left in place
+  rather than rewritten, with this note, because the failure is the point.
 - **[dist]** **Claude Code plugin.** `/plugin marketplace add QAtlasHub/doiget` then
   `/plugin install doiget@doiget`. Self-hosted, so it needs approval from nobody;
   both manifests pass `claude plugin validate` (#513).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.1"
+version = "0.8.13-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.1"
+version = "0.8.13-beta.2"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.1"
+version = "0.8.13-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.1"
+version       = "0.8.13-beta.2"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.1" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.1" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.1" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.2" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.2" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.2" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ packages ship from tagged releases, so a very new commit may be ahead of them.
 ```
 
 Reads `.claude-plugin/` from this repository's default branch. The plugin's
-`.mcp.json` runs `doiget serve`, so install the binary by one of the routes
-above first — the plugin installs nothing itself. That is also why this is a
-self-hosted marketplace rather than a submission to the Anthropic plugin
-directory: a listing whose first run fails for everyone without the binary
-already on PATH is worse than no listing. Once npm is live the plugin can call
-`npx -y doiget serve` and need nothing installed.
+`.mcp.json` runs `npx -y doiget-cli serve`, so it needs **nothing installed
+beforehand** — npm fetches the wrapper and the one matching platform binary on
+first run. Until this it ran a bare `doiget`, which meant the plugin worked
+only for people who had already installed doiget some other way; that is why it
+was self-hosted rather than submitted to the Anthropic plugin directory, and
+why it is now submittable.
 
 ### Channel status
 


### PR DESCRIPTION
`.mcp.json` ran a bare `doiget serve`, so installing the plugin did **nothing** for anyone who had not already installed doiget by some other route — which is most people finding it through a plugin marketplace.

```diff
-{ "command": "doiget",  "args": ["serve"] }
+{ "command": "npx", "args": ["-y", "doiget-cli", "serve"] }
```

That was the stated reason for keeping this a self-hosted marketplace rather than submitting to the Anthropic plugin directory — *a listing whose first run fails for everyone without the binary on PATH is worse than no listing*. **The objection is gone**, so the submission is viable. That is #513's remaining half.

## Verified by launching it, not by reading it

```
$ npx -y doiget-cli serve  <  (initialize, initialized, tools/list)
exit=0   stderr=0B
  initialize -> {'name': 'doiget', 'version': '0.8.12'}
  tools: 22
```

From the real registry. Pure JSON-RPC on stdout, zero bytes on stderr — the stdout-purity invariant holds through the npx shim. The 22 also independently confirms #552's citation-graph fix shipped in 0.8.12.

## Two things this turned up

**The plugin manifests said 0.8.11** while the repository was two releases ahead. Nothing stamps them — neither `plugin.json` nor `marketplace.json` is referenced by any script or workflow, so they drift silently. `/plugin marketplace add` reads the default branch, so that stale number is what users saw. Set to 0.8.12, the last released version.

**Two more references the `doiget` → `doiget-cli` rename left behind.** README's plugin paragraph promised `npx -y doiget serve`. And the 0.8.11 release notes lead with `npx -y doiget serve` / `npm i -g doiget`, *neither of which was ever valid* — the wrapper is not called `doiget`, and that release's npm publish failed outright, so there was nothing on the registry to install either way. The 0.8.11 entry is annotated rather than rewritten; that failure is the point of the surrounding text.

That makes **three** places the rename missed. The same trap was caught and excluded in `posture-lint`'s `find -name 'doiget-*'` inside the rename PR itself (#549); the release workflow's publish glob (#558) and these two were not.

## After this

The directory submission is souta's — `platform.claude.com/plugins/submit`, the route for individual authors (the claude.ai path needs a Team/Enterprise org). PRs to `anthropics/claude-plugins-community` are closed automatically; the form is the only door.

Refs #513, #511
