### PR TITLE
docs: four tools shipped undocumented, and nothing compared the table to the router

### DIFF
--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -119,6 +119,45 @@ jobs:
           fi
           echo "LICENSE OK: verbatim SPDX MIT, no trailing prose, ends at SOFTWARE., LF."
 
+      - name: MCP_TOOLS.md lists exactly the tools the router exposes (#553)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `MCP_TOOLS.md` is what an integrator reads to decide what the server
+          # can do, and `docs/INTEGRATION/*.md` points at it. Nothing checked it
+          # against the router, and it had drifted in BOTH directions at once:
+          # four tools shipped with no entry (#553), and one had an entry while
+          # not shipping at all (#552). Neither is visible from inside the other
+          # file.
+          #
+          # rmcp derives a tool's name from its `#[tool]` method name, so the
+          # method list is the router's own truth. Compared against the table
+          # rows, which are the document's.
+          fns="$(grep -oE '^[[:space:]]+(pub )?async fn doiget_[a-z_0-9]+' \
+                 crates/doiget-mcp/src/lib.rs \
+                 | grep -oE 'doiget_[a-z_0-9]+' | sort -u)"
+          rows="$(grep -oE '^\| .doiget_[a-z_0-9]+.' docs/MCP_TOOLS.md \
+                  | grep -oE 'doiget_[a-z_0-9]+' | sort -u)"
+          if [ -z "$fns" ] || [ -z "$rows" ]; then
+            echo "::error::posture-lint mcp-tools: read no tools from the router or no rows from MCP_TOOLS.md — one of the two patterns has stopped matching (#553)"
+            exit 1
+          fi
+          missing="$(comm -23 <(printf '%s\n' "$fns") <(printf '%s\n' "$rows"))"
+          extra="$(comm -13 <(printf '%s\n' "$fns") <(printf '%s\n' "$rows"))"
+          fail=0
+          if [ -n "$missing" ]; then
+            echo "::error::posture-lint mcp-tools: these tools ship but have no row in docs/MCP_TOOLS.md (#553)"
+            printf '  %s\n' $missing
+            fail=1
+          fi
+          if [ -n "$extra" ]; then
+            echo "::error::posture-lint mcp-tools: docs/MCP_TOOLS.md documents these, but the router has no such tool (#552)"
+            printf '  %s\n' $extra
+            fail=1
+          fi
+          [ "$fail" -eq 0 ]
+          echo "MCP_TOOLS.md and the router agree on $(printf '%s\n' "$fns" | wc -l | tr -d ' ') tools"
+
       - name: doiget-cli forwards every doiget-mcp feature (#373 / #516)
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[docs]** Four tools shipped in every release with no entry in `MCP_TOOLS.md`:
+  `doiget_batch_from_bibliography`, `doiget_paper_tex_source`, `doiget_tag` and
+  `doiget_annotate`. That document is what an integrator reads to decide what the
+  server can do, and `docs/INTEGRATION/*.md` points at it, so a tool absent from it
+  is discoverable only by calling `tools/list` and reading JSON Schemas — the work
+  the document exists to save. Two of the four arrived with the tags work (#294) and
+  one with the TeX source work: the tool landed, the reference page did not (#553).
+- **[ci]** `posture-lint` now compares the tool table against the router in **both**
+  directions. Nothing did, and it had drifted both ways at once: four tools with no
+  row (#553) and one row with no tool (#552, the citation graph absent from every
+  release binary). Neither is visible from inside the other file. rmcp derives a
+  tool's name from its `#[tool]` method name, so the method list is the router's own
+  truth; the table rows are the document's. Mutation-checked in both directions —
+  deleting a row and inventing one each fail the check with the right message.
+
 ### Changed
 
 - **[dist]** The Claude Code plugin runs `npx -y doiget-cli serve` instead of a bare

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.2"
+version = "0.8.13-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.2"
+version = "0.8.13-beta.3"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.2"
+version = "0.8.13-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.2"
+version       = "0.8.13-beta.3"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.3" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.3" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.3" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -33,6 +33,10 @@ Additional tools:
 | `doiget_csl_export` | CSL JSON for one or many entries. |
 | `doiget_resolve_citation` | Resolve a free-form bibliographic citation string to ranked DOI candidates. |
 | `doiget_batch_resolve_citations` | Batch resolve bibliographic citation strings to ranked DOI candidates. |
+| `doiget_batch_from_bibliography` | Fetch every OA-resolvable entry in a Zotero / Mendeley CSL-JSON export. |
+| `doiget_paper_tex_source` | Fetch an **arXiv** paper's raw LaTeX source. More reliable than `doiget_paper_text` for papers ar5iv has not processed through LaTeXML. A DOI is not a valid input. |
+| `doiget_tag` | Add or remove tags and collection membership on a stored entry, for local knowledge-base organisation (#294). |
+| `doiget_annotate` | Attach or clear a freeform note on a stored entry (#294). |
 
 ## 2. Naming and convention
 

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -39,6 +39,10 @@ Additional tools:
 | `doiget_csl_export` | CSL JSON for one or many entries. |
 | `doiget_resolve_citation` | Resolve a free-form bibliographic citation string to ranked DOI candidates. |
 | `doiget_batch_resolve_citations` | Batch resolve bibliographic citation strings to ranked DOI candidates. |
+| `doiget_batch_from_bibliography` | Fetch every OA-resolvable entry in a Zotero / Mendeley CSL-JSON export. |
+| `doiget_paper_tex_source` | Fetch an **arXiv** paper's raw LaTeX source. More reliable than `doiget_paper_text` for papers ar5iv has not processed through LaTeXML. A DOI is not a valid input. |
+| `doiget_tag` | Add or remove tags and collection membership on a stored entry, for local knowledge-base organisation (#294). |
+| `doiget_annotate` | Attach or clear a freeform note on a stored entry (#294). |
 
 ## 2. Naming and convention
 


### PR DESCRIPTION
Closes #553.

Four tools ship in every release with no row in `MCP_TOOLS.md`:

- `doiget_batch_from_bibliography`
- `doiget_paper_tex_source`
- `doiget_tag`
- `doiget_annotate`

That document is what an integrator reads to decide what the server can do, and `docs/INTEGRATION/*.md` points at it. A tool missing from it is discoverable only by calling `tools/list` and reading JSON Schemas — the work the document exists to save. Two of the four arrived with the tags work (#294) and one with the TeX source work; the pattern is *the tool landed, the reference page did not*.

Descriptions are lifted from each tool's own `WHEN TO USE:` text rather than written fresh, so the row and the schema say the same thing.

## The check that was missing

Nothing compared the table to the router, and **the drift ran in both directions at once**:

| direction | instance |
|---|---|
| ships, undocumented | these four (#553) |
| documented, does not ship | `doiget_expand_citation_graph` — absent from every release binary (#552) |

Neither is visible from inside the other file, which is why both survived.

rmcp derives a tool's name from its `#[tool]` method name, so the method list is the router's own truth; the table rows are the document's. `posture-lint` now compares the two sets and reports each direction with its own message.

Mutation-checked both ways:

```
delete a row       → CAUGHT ship-but-undocumented: doiget_tag
invent a table row → CAUGHT documented-but-absent: doiget_does_not_exist
current tree       → agree on 22 tools
```

Refs #553, #552, #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
