### PR TITLE
fix(mcp): a zero-result search read as "this paper does not exist"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ## [Unreleased]
 
+### Fixed
+
+- **[mcp]** `doiget_paper_search` returning nothing now says whether that is about
+  the query or about the literature. OpenAlex free-text matching degrades sharply
+  past roughly eight terms and returns **nothing** rather than a partial match; a
+  human reading `0 results` shortens the query and retries, but an agent reading
+  `ok: true` with an empty array reads it as a fact about the world and stops. In
+  the session behind #534 that happened eleven times in a row, and a known 1992
+  *Am J Psychiatry* paper was written off as unavailable — until an unrelated
+  three-term query surfaced it immediately.
+
+  A zero-result search is a **success** envelope, so #506's error-disposition work
+  does not reach it and #505's is scoped to the CLI. The envelope now carries a
+  `hint` naming the submitted term count and what to retry with, at the exact point
+  an agent would otherwise conclude absence. Short queries get no hint: a two-term
+  search really may mean the work is not indexed, and hinting on every empty result
+  would train readers to skip it. The tool description says the same thing, so the
+  advice survives an agent that reads schemas but not envelopes (#534).
+
 ### Changed
 
 - **[dist]** The Claude Code plugin runs `npx -y doiget-cli serve` instead of a bare

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.2"
+version = "0.8.13-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.2"
+version = "0.8.13-beta.4"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.2"
+version = "0.8.13-beta.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.2"
+version       = "0.8.13-beta.4"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.2" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.2" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.2" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.4" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.4" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.4" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -1282,7 +1282,8 @@ impl Server {
                        OUTPUTS: { ok: true, scope: \"external\", query, total_results, count, results: [{ doi, openalex_id, arxiv, title, authors, year, venue, abstract, cited_by_count, oa_status, source }] } OR { ok:false, error }.\n\
                        COSTS: 1 OpenAlex request, plus 1 per supplied author/venue/publisher name to resolve.\n\
                        SIDE EFFECTS: Emits Metadata provenance rows. NEVER writes the store. NEVER fetches a PDF.\n\
-                       LIMITS: Tier-1, always-on (no DOIGET_ENABLE_OPENALEX gate). An ambiguous author/venue/publisher name → AMBIGUOUS (candidates listed); no match → NOT_FOUND.",
+                       LIMITS: Tier-1, always-on (no DOIGET_ENABLE_OPENALEX gate). An ambiguous author/venue/publisher name → AMBIGUOUS (candidates listed); no match → NOT_FOUND.\n\
+                       ZERO RESULTS ARE NOT EVIDENCE OF ABSENCE: OpenAlex free-text matching degrades sharply past roughly 8 terms and returns nothing rather than a partial match. On total_results: 0, retry with 3-5 distinctive terms before concluding the work is not indexed; the envelope carries a `hint` saying so.",
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -1398,14 +1399,32 @@ impl Server {
         });
 
         match outcome {
-            Ok(results) => Ok(CallToolResult::structured(json!({
-                "ok": true,
-                "scope": "external",
-                "query": input.query,
-                "total_results": results.total_results,
-                "count": results.results.len(),
-                "results": results.results,
-            }))),
+            Ok(results) => {
+                let mut envelope = json!({
+                    "ok": true,
+                    "scope": "external",
+                    "query": input.query,
+                    "total_results": results.total_results,
+                    "count": results.results.len(),
+                    "results": results.results,
+                });
+                // A zero-result search is a SUCCESS envelope, so #506's work on
+                // error dispositions does not reach it. An agent reads
+                // `ok: true` with an empty array as a fact about the world --
+                // the paper is not indexed -- and stops looking. That happened:
+                // eleven consecutive searches returned 0 for papers a shorter
+                // query then found on the first try (#534).
+                //
+                // The cause is query length, not absence, so the envelope says
+                // so at the exact point an agent would otherwise conclude
+                // absence.
+                if results.results.is_empty() {
+                    if let Some(hint) = zero_result_hint(&input.query) {
+                        envelope["hint"] = json!(hint);
+                    }
+                }
+                Ok(CallToolResult::structured(envelope))
+            }
             // Canonical FetchError -> ErrorCode (AMBIGUOUS / NOT_FOUND /
             // NETWORK_ERROR / …) so an agent can branch on the code.
             Err(e) => Ok(CallToolResult::structured(read_path_error_envelope(
@@ -3999,6 +4018,34 @@ impl ServerHandler for Server {
 /// an unexpanded `${...}` placeholder. A Desktop-Extension config left blank
 /// passes the literal `${user_config.store_root}`, which must never become a
 /// filesystem path (it produced `os error 5` access-denied). See #369.
+/// Advice to attach to a `doiget_paper_search` that matched nothing (#534).
+///
+/// OpenAlex free-text matching degrades sharply as a query lengthens: past
+/// roughly eight terms it returns nothing at all rather than a partial match.
+/// A human reading `0 results` shortens the query and tries again. An agent
+/// reading `ok: true` with an empty array reads it as a fact about the world
+/// and stops -- in the session that produced #534, eleven consecutive searches
+/// returned zero for papers a three-to-five term query then found immediately,
+/// and a known study was written off as unavailable.
+///
+/// Returns `None` for short queries: a zero-result two-term search really may
+/// mean the work is not indexed, and a hint on every empty result would train
+/// readers to skip it.
+fn zero_result_hint(query: &str) -> Option<String> {
+    // Where OpenAlex free-text matching starts failing outright. Not a hard
+    // boundary -- a bound observed from the queries in #534, which is why the
+    // wording says "roughly".
+    const DEGRADES_PAST: usize = 8;
+
+    let terms = query.split_whitespace().count();
+    if terms <= DEGRADES_PAST {
+        return None;
+    }
+    Some(format!(
+        "This query has {terms} terms. OpenAlex free-text matching degrades sharply past roughly {DEGRADES_PAST} and returns nothing rather than a partial match, so zero results here is more likely to be about the query than about the literature. Retry with 3-5 distinctive terms - an author surname, a coined phrase, the distinguishing noun - before concluding the work is not indexed."
+    ))
+}
+
 fn store_root_env_is_usable(value: &str) -> bool {
     let v = value.trim();
     !v.is_empty() && !v.contains("${")
@@ -4179,6 +4226,36 @@ fn capability_profile_to_json(profile: &CapabilityProfile) -> Value {
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// #534: a long query matching nothing is far more likely to be a
+    /// query-length problem than an absent literature, and the agent reading
+    /// the envelope is the one who cannot tell the difference.
+    #[test]
+    fn a_long_zero_result_query_is_told_why_it_may_be_zero() {
+        let q = "lithium refractoriness after discontinuation kindling sensitization course of illness Post";
+        let hint = zero_result_hint(q).expect("10 terms is past the threshold");
+        assert!(hint.contains("10 terms"), "names the count: {hint}");
+        assert!(
+            hint.contains("3-5"),
+            "says what to do instead, not only what went wrong: {hint}"
+        );
+    }
+
+    /// A short query returning nothing may genuinely mean nothing is indexed.
+    /// Hinting on every empty result would teach readers to skip the hint.
+    #[test]
+    fn a_short_zero_result_query_is_left_alone() {
+        assert!(zero_result_hint("depersonalization derealization").is_none());
+        assert!(zero_result_hint("").is_none());
+    }
+
+    /// The threshold counts terms, not characters: one very long term is still
+    /// one term, and "shorten it" is not the advice to give.
+    #[test]
+    fn the_threshold_counts_terms_not_length() {
+        assert!(zero_result_hint(&"a".repeat(400)).is_none());
+        assert!(zero_result_hint("a b c d e f g h i").is_some());
+    }
 
     /// #406: the store-writability probe MUST NOT create anything.
     /// `doiget_health` is annotated `read_only_hint = true`, and the old

--- a/crates/doiget-mcp/tests/paper_search_e2e.rs
+++ b/crates/doiget-mcp/tests/paper_search_e2e.rs
@@ -78,6 +78,127 @@ const SAMPLE_SEARCH: &str = r#"{
     ]
 }"#;
 
+/// #534: an over-long query that matches nothing must not read as "this work
+/// is not indexed". OpenAlex free-text matching degrades sharply past roughly
+/// eight terms and returns nothing rather than a partial match, so the
+/// envelope has to say which of the two happened -- an agent reading
+/// `ok: true` with an empty array cannot tell, and in the session behind #534
+/// it concluded absence eleven times and abandoned a paper a shorter query
+/// then found immediately.
+#[tokio::test]
+#[serial_test::serial]
+async fn an_over_long_zero_result_query_carries_a_hint() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"{ "meta": { "count": 0 }, "results": [] }"#),
+        )
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("utf-8 tempdir")
+        .join("mcp-search-zero.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_OPENALEX_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    // The exact query from the report: ten terms, zero results, real paper.
+    let mut args = serde_json::Map::new();
+    args.insert(
+        "query".to_string(),
+        serde_json::json!(
+            "lithium refractoriness after discontinuation kindling sensitization course of illness Post"
+        ),
+    );
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_paper_search").with_arguments(args))
+        .await?;
+    let s = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_paper_search uses CallToolResult::structured");
+
+    assert_eq!(s["ok"], serde_json::json!(true), "still a success: {s:?}");
+    assert_eq!(s["count"], serde_json::json!(0));
+    let hint = s["hint"].as_str().unwrap_or_default();
+    assert!(
+        hint.contains("10 terms"),
+        "the hint names the term count so the reader can act on it: {s:?}"
+    );
+    assert!(
+        hint.contains("3-5"),
+        "the hint says what to do instead, not only what went wrong: {s:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+/// The counterpart: a short query with no results gets no hint. A two-term
+/// search really may mean the work is not indexed, and a hint on every empty
+/// result would teach readers to skip it.
+#[tokio::test]
+#[serial_test::serial]
+async fn a_short_zero_result_query_carries_no_hint() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"{ "meta": { "count": 0 }, "results": [] }"#),
+        )
+        .mount(&server)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("utf-8 tempdir")
+        .join("mcp-search-short.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_OPENALEX_BASE", &server.uri());
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert(
+        "query".to_string(),
+        serde_json::json!("nonexistent gibberish"),
+    );
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_paper_search").with_arguments(args))
+        .await?;
+    let s = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_paper_search uses CallToolResult::structured");
+
+    assert_eq!(s["count"], serde_json::json!(0));
+    assert!(
+        s.get("hint").is_none() || s["hint"].is_null(),
+        "a short query gets no hint: {s:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn paper_search_returns_external_envelope() -> anyhow::Result<()> {


### PR DESCRIPTION
Closes #534.

OpenAlex free-text matching degrades sharply past roughly eight terms and returns **nothing** rather than a partial match. A human reading `0 results` shortens the query and retries. An agent reading `ok: true` with an empty array reads it as a fact about the world and stops.

From the report — same target, two queries:

```
"lithium refractoriness after discontinuation kindling sensitization course of illness Post"
  → total_results: 0                     (10 terms)

"lithium discontinuation-induced refractoriness preliminary observations"
  → total_results: 1
     Post RM et al., Am J Psychiatry 149:1727 (1992) — the exact paper
```

Eleven consecutive searches in that session returned 0. A known paper was written off as unavailable and the search abandoned, until an unrelated query surfaced it later.

## Why no open issue covered it

A zero-result search is a **success** envelope.

- **#506** — dispositions on the *error* envelope
- **#505** — the found-nothing path, scoped to the **CLI** `fetch`

The gap was success-with-zero-results on the MCP search path.

## What changed

The envelope carries a `hint` when the result set is empty **and** the query is long, naming the submitted term count and what to retry with — placed at the exact point an agent would otherwise conclude absence. The tool description says the same thing, so it also reaches an agent that reads schemas but not envelopes.

**Short queries get nothing.** A two-term search returning zero really may mean the work is not indexed; a hint on every empty result would teach readers to skip the hint.

## Tests

Through the real tool over the existing wiremock harness, not only as a unit — the mock returns `{ "meta": { "count": 0 }, "results": [] }` and the assertions are on the envelope the agent would see:

```
an_over_long_zero_result_query_carries_a_hint ... ok    (the exact 10-term query from the report)
a_short_zero_result_query_carries_no_hint     ... ok
```

Plus three unit tests on the threshold itself, including that it counts **terms, not characters** — one 400-character word is still one term, and "shorten it" is not the advice to give.

Mutation-checked: disabling the guard fails the first e2e and leaves the second passing, which is the right shape rather than both flipping.

## Not in this PR

The issue's lower-priority half — a `fields` / `abstract_max_chars` parameter, and dropping abstracts whose OpenAlex inverted-index reconstruction produced only particles and connectives ("of and in the of a to the with of is not…"). Seven calls in that session exceeded the MCP response budget and spilled to disk, mostly abstracts. Worth its own issue rather than smuggling a schema change in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
