### PR TITLE
perf(ci): one test took ten minutes and was being run five times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,29 @@ jobs:
       # so test and clippy exercise an identical feature surface.
       - run: cargo test --workspace --all-targets --no-default-features --features oa-only
 
+  # The five jobs above skip `#[ignore]`d tests, which is where the one
+  # 10-minute test lives. It is a dispatch-loop property that varies with
+  # neither OS nor Cargo feature, so running it in all five spent ~50 minutes
+  # per CI run learning the same thing five times. Once is enough.
+  #
+  # NOT a sixth leg of the `test` matrix: it has to run in PARALLEL with the
+  # others rather than lengthen one of them, and it needs no OS spread.
+  test-slow:
+    name: test (slow)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          cache-bin: false
+      # `--ignored` runs ONLY the ignored tests, so this job is exactly the
+      # slow set and the five broad jobs are exactly everything else. Nothing
+      # is dropped by the split and nothing is run twice.
+      - run: cargo test --workspace --all-targets --no-default-features --features oa-only -- --ignored
+
   test-citation:
     name: test (citation feature)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Changed
 
+- **[ci]** One test was taking ten minutes and being run five times. The five
+  `test` jobs each run the whole workspace suite, and 95% of that suite's time was
+  a single test: `batch_above_window_size_fetches_every_ref`, 627 s out of 663 s,
+  with the next-slowest at 36 s.
+
+  It is not waste. The test fetches `MCP_BATCH_MAX_SIZE + 2` arXiv refs;
+  `SOURCE_RATE_OVERRIDES` puts 3 s between arXiv requests because arXiv's Terms of
+  Use do, and one attempt issues two requests — the Atom feed then the PDF, both
+  paced since #493. So 102 x 2 x 3 s = 612 s, against 609 s measured. The rate
+  limit is a legal safeguard (`RateLimits`' fields are `pub(crate)` precisely so
+  tests cannot weaken it), and it stays exactly as it is.
+
+  What was wasteful was paying it five times, on three operating systems and two
+  feature sets, for a dispatch-loop property that varies with neither. The test is
+  now `#[ignore]`d and a `test (slow)` job runs it once via `--ignored` — exactly
+  one ignored test exists workspace-wide, so the split drops nothing and duplicates
+  nothing. The broad suite went from 627 s to 18 s locally; the slow job runs in
+  parallel rather than lengthening any of the others.
+
+  The test's own comment claimed "~20 s". That was true when it was written
+  (2026-06-16, 200 ms x 102); `2cc32ab` on 2026-08-25 gave arXiv its published 3 s
+  interval and made it 15x slower, and the only symptom was CI minutes. Corrected
+  in place with the arithmetic.
+
+  Not attempted: `tokio::time::pause()`. `http.rs` already records why — wiremock
+  serves over real localhost IO, and paused time auto-advances past reqwest's
+  timeout.
+
+### Changed
+
 - **[dist]** The Claude Code plugin runs `npx -y doiget-cli serve` instead of a bare
   `doiget serve`, so installing it **needs nothing installed beforehand** — npm
   fetches the wrapper and the one matching platform binary on first run. Until now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.4"
+version = "0.8.13-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.4"
+version = "0.8.13-beta.5"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.4"
+version = "0.8.13-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.4"
+version       = "0.8.13-beta.5"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.4" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.4" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.4" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.5" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.5" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.5" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/tests/batch_e2e.rs
+++ b/crates/doiget-cli/tests/batch_e2e.rs
@@ -315,6 +315,7 @@ async fn batch_with_malformed_ref_continues_and_returns_err() {
 
 #[tokio::test]
 #[serial]
+#[ignore = "612 s at arXiv's published 3 s/request rate; run by the `test (slow)` CI job via --ignored"]
 async fn batch_above_window_size_fetches_every_ref() {
     // Issue #304: a refs file LARGER than `MCP_BATCH_MAX_SIZE` must no longer
     // abort fetching nothing — every ref is processed across multiple
@@ -323,9 +324,23 @@ async fn batch_above_window_size_fetches_every_ref() {
     // just the windowing arithmetic), so it confirms counters accumulate
     // across windows and the bookends are emitted exactly once.
     //
-    // Slow by construction: `MCP_BATCH_MAX_SIZE + 2` real fetches through the
-    // hard-coded 5-per-second rate cap (~20 s). Kept `#[serial]` so it never
-    // contends with the other batch fixtures.
+    // SLOW BY CONSTRUCTION, and far slower than this comment used to claim.
+    // It said "~20 s", counting only the global 5-per-second cap. Two things
+    // it missed:
+    //
+    //   * `SOURCE_RATE_OVERRIDES` puts 3 s between arXiv requests, because
+    //     arXiv's Terms of Use do (2cc32ab, 2026-08-25 -- after this test was
+    //     written, which is why the estimate was right when it was made);
+    //   * one arXiv attempt issues TWO requests, the Atom feed then the PDF,
+    //     and #493 paced the second one too.
+    //
+    // So the real cost is 102 * 2 * 3 s = 612 s, and CI measured 609 s. That
+    // is not waste -- it is arXiv's published rate, faithfully obeyed -- but
+    // it is a property of the dispatch loop, which varies with neither OS nor
+    // Cargo feature. `#[ignore]` keeps it off the five broad `test` jobs; the
+    // `test (slow)` job runs it once with `--ignored`.
+    //
+    // Kept `#[serial]` so it never contends with the other batch fixtures.
     let server = MockServer::start().await;
     let body = b"%PDF-1.7\n%batch-window-fixture\n".to_vec();
     // One regex mock serves every generated arXiv id rather than mounting one


### PR DESCRIPTION
souta asked whether the tests could be sharded. **They can't usefully** — measuring first showed why, and showed something better.

## Measurement

47 test suites in the workspace. Their times on the last CI run:

```
627.39 s   ← one suite
 36.28 s
  9.35 s
  ...        (the other 44 under 10 s each)
```

That one suite is `tests/batch_e2e.rs`, and inside it one test:

```
15 s   batch_three_arxiv_refs_succeeds_end_to_end
 3 s   batch_with_malformed_ref_continues_and_returns_err
609 s  batch_above_window_size_fetches_every_ref     ← 95% of the suite
```

## Why it is slow, and why that is correct

It fetches `MCP_BATCH_MAX_SIZE + 2` = 102 arXiv refs.

- `SOURCE_RATE_OVERRIDES` puts **3 s between arXiv requests**, because arXiv's Terms of Use do.
- One arXiv attempt issues **two** requests — the Atom feed, then the PDF — and #493 paced the second one too.

```
102 × 2 × 3 s = 612 s      measured: 609 s
```

**This is not waste.** It is arXiv's published rate, faithfully obeyed. `RateLimits`' fields are `pub(crate)` specifically so tests cannot weaken it (`docs/LEGAL.md` §6 safeguard 8), and nothing here touches that.

## What *was* waste

Five jobs each run `cargo test --workspace --all-targets`:

| job | pays 612 s |
|---|---|
| `test (ubuntu-latest)` | ✓ |
| `test (macos-latest)` | ✓ |
| `test (windows-latest)` | ✓ |
| `test (citation feature)` | ✓ |
| `test (tdm features)` | ✓ |

**~50 minutes per CI run, to learn the same thing five times.** The dispatch loop varies with neither OS nor Cargo feature.

## The change

`#[ignore]` on the one test, plus a `test (slow)` job that runs it once with `--ignored`. Verified the split is exact:

```
$ cargo test --workspace --all-targets -- --ignored --list
  batch_above_window_size_fetches_every_ref
$ ... | grep -c ': test$'
1
```

Exactly one ignored test workspace-wide — so the five broad jobs are exactly "everything else", the slow job is exactly "the slow set", and nothing is dropped or run twice. It runs in **parallel** rather than lengthening any other job.

Locally the suite went **627 s → 18 s**.

## Why not sharding

One test is 95% of the suite and it is **sleeping, not computing**. Every shard but one would finish immediately; the last would still take ten minutes, having paid N compiles to get there.

## Why not `tokio::time::pause()`

Already answered in this repo, in `http.rs`:

> Real time: wiremock serves over real localhost IO and tokio `start_paused` is incompatible with that (it auto-advances past reqwest's timeout).

## The stale comment

The test said **"~20 s"**, counting only the global 5-per-second cap. That was true the day it was written — 2026-06-16, 200 ms × 102. Then `2cc32ab` on 2026-08-25, *"fetch arXiv at the rate its Terms of Use publish"*, made it 15× slower. Nobody noticed, because the only symptom is CI minutes. Corrected in place with the arithmetic and both things it had missed.

## Follow-up, not here

The slow job is still ten minutes. Getting it lower means not using arXiv for a test whose subject is the dispatch loop — the same property with DOI refs through default-paced sources would be ~60 s. That trades away the in-batch arXiv two-request path, so it deserves its own issue rather than being smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
