### PR TITLE
fix(mcp): oa_url was documented as actionable and was always null (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,6 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   serves over real localhost IO, and paused time auto-advances past reqwest's
   timeout.
 
-### Changed
-
 - **[dist]** The Claude Code plugin runs `npx -y doiget-cli serve` instead of a bare
   `doiget serve`, so installing it **needs nothing installed beforehand** — npm
   fetches the wrapper and the one matching platform binary on first run. Until now
@@ -56,6 +54,42 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   stdout and zero bytes on stderr.
 
 ### Fixed
+
+- **[mcp]** `oa_url` was documented as an OA URL "for the caller to act on
+  separately" and was, in practice, `null` for every DOI. The DOI path is
+  Crossref-first on the rationale that Crossref's `message.link[]` supplied an
+  OA URL without a second request - but #517 measured twelve live `link[]`
+  entries and eight captured fixtures and found **not one** general-purpose
+  entry: every one was scoped to a licensed programme (Similarity Check, TDM,
+  syndication). The extractor refuses all of them, correctly, which left the
+  field permanently empty while its documentation told agents to act on it. An
+  agent reading `oa_url: null` had no way to tell it from "this work has no free
+  copy" (#539).
+
+  A caller that wants a real OA location now passes `include_oa_location: true`
+  to `doiget_metadata_only` or `doiget_resolve_paper`, which consults Unpaywall.
+  It is off by default: the default path stays one round-trip, and nobody pays
+  for a location they will not use. No guarantee is weakened - Unpaywall is a
+  metadata source, and the URL is still reported and never followed.
+
+  With the flag set, `oa_status` says which answer you got: `"closed"` means the
+  lookup completed and there is no OA location; `null` means the lookup did not
+  complete. A failed Unpaywall call therefore leaves **both** fields null rather
+  than inventing a status, because asserting `"closed"` on the strength of a 500
+  would recreate the exact ambiguity being fixed. The Crossref metadata is still
+  returned; an optional extra failing does not sink the resolve. This mirrors
+  the `oa_status` + `pdf.status` pairing `doiget_fetch_paper` already uses.
+
+  The resolver cache keys on the options as well as the ref, so a default entry
+  is never served to a caller that asked for the location. The key is a
+  subdirectory rather than a `.oa` filename suffix: `Ref::safekey` keeps `.`, so
+  a suffix would make the DOI `10.1234/foo.oa` and the opt-in entry for
+  `10.1234/foo` collide on one file. That collision was written, then caught by
+  the test that now guards it.
+
+  `doiget-core` gains `MetadataOnlyOptions` and `*_with_options` variants of
+  `metadata_only`, `resolve_only` and `metadata_only_to_store`; the existing
+  three delegate with defaults, so nothing downstream breaks.
 
 - **[mcp]** `doiget_paper_search` returning nothing now says whether that is about
   the query or about the literature. OpenAlex free-text matching degrades sharply

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.5"
+version = "0.8.13-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.5"
+version = "0.8.13-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.5"
+version = "0.8.13-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.5"
+version       = "0.8.13-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -142,6 +142,79 @@ pub async fn metadata_only(
     profile: &CapabilityProfile,
     ctx: &FetchContext,
 ) -> Result<MetadataOnlyOutcome, FetchError> {
+    metadata_only_with_options(ref_, profile, ctx, MetadataOnlyOptions::default()).await
+}
+
+/// What a metadata-only resolve may spend beyond its single round-trip.
+///
+/// One knob, and it exists because #517 removed the reason there was none.
+/// The DOI path is Crossref-first, and its rationale was that Crossref's
+/// `message.link[]` supplied an OA URL for free. Measurement showed every
+/// entry is programme-scoped, so `extract_crossref_publisher_url`
+/// correctly returns `None` for every DOI -- leaving `oa_url` permanently
+/// null while `docs/MCP_TOOLS.md` s11 told callers to act on it (#539).
+///
+/// Crossref-first is still the right default: it resolves nearly every DOI
+/// in one request. What was wrong was promising a field it cannot fill. So
+/// the caller says whether it wants the second request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MetadataOnlyOptions {
+    /// Consult Unpaywall for a real OA location, filling `oa_url`,
+    /// `oa_status` and `license` from its record.
+    ///
+    /// Costs one extra request against Unpaywall. Unpaywall is a metadata
+    /// source, so this does not weaken the "never fetches a PDF, never
+    /// touches a publisher" guarantee: the URL is still reported and never
+    /// followed.
+    ///
+    /// Off by default. A caller that wants metadata should not pay for a
+    /// location it will not use.
+    ///
+    /// # Reading the result
+    ///
+    /// With this set, the `oa_status`/`oa_url` pair says which of three
+    /// things happened:
+    ///
+    /// | `oa_status` | `oa_url` | meaning |
+    /// |---|---|---|
+    /// | `"closed"` | `None` | asked; this work has no OA location |
+    /// | `"gold"`, `"green"`, ... | `Some` | asked; here it is |
+    /// | `None` | `None` | the lookup did not complete |
+    ///
+    /// The third row is why a failed Unpaywall call leaves *both* fields
+    /// `None` rather than filling in a plausible-looking `oa_status`: a
+    /// caller that paid for a lookup has to be able to tell "no OA location
+    /// exists" from "I could not find out", and that distinction is the
+    /// whole of #539.
+    pub include_oa_location: bool,
+}
+
+impl MetadataOnlyOptions {
+    /// Ask for the OA location (or not).
+    ///
+    /// A builder rather than a struct literal because the struct is
+    /// `#[non_exhaustive]`: a future option must not be a breaking change
+    /// for `doiget-mcp`, `doiget-cli`, or anyone else downstream.
+    #[must_use]
+    pub const fn with_oa_location(mut self, include: bool) -> Self {
+        self.include_oa_location = include;
+        self
+    }
+}
+
+/// [`metadata_only`], with the caller choosing what it is willing to spend.
+///
+/// # Errors
+///
+/// As [`metadata_only`]. A failure of the *optional* OA-location lookup is
+/// not an error here: see [`MetadataOnlyOptions`].
+pub async fn metadata_only_with_options(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    opts: MetadataOnlyOptions,
+) -> Result<MetadataOnlyOutcome, FetchError> {
     // Resolver cache (docs/CACHE.md): on a hit within TTL, return the
     // cached outcome without touching the network — this is what lets
     // `doiget verify` avoid upstream rate limits across repeated runs.
@@ -158,14 +231,18 @@ pub async fn metadata_only(
         ctx.cache_root.as_deref()
     };
 
+    // Keyed by the options, not just the ref: an entry written by a default
+    // resolve carries `oa_url: None`, and handing that to a caller that asked
+    // for the location would answer a question it did not ask. See
+    // `resolver_cache::cache_file_with_options`.
     if let Some(root) = cache_root {
-        if let Some(cached) = crate::resolver_cache::read(root, ref_) {
+        if let Some(cached) = crate::resolver_cache::read_with_options(root, ref_, opts) {
             return Ok(cached);
         }
     }
 
     let outcome = match ref_ {
-        Ref::Doi(doi) => metadata_only_doi(doi, ref_, profile, ctx).await?,
+        Ref::Doi(doi) => metadata_only_doi(doi, ref_, profile, ctx, opts).await?,
         Ref::Arxiv(id) => {
             let arxiv = arxiv_source_from_env();
             let metadata = arxiv.fetch_metadata_only(id, ctx).await?;
@@ -185,7 +262,7 @@ pub async fn metadata_only(
 
     // Best-effort cache write (never fails the resolve).
     if let Some(root) = cache_root {
-        crate::resolver_cache::write(root, ref_, &outcome);
+        crate::resolver_cache::write_with_options(root, ref_, &outcome, opts);
     }
     Ok(outcome)
 }
@@ -249,13 +326,27 @@ pub async fn resolve_only(
     profile: &CapabilityProfile,
     ctx: &FetchContext,
 ) -> Result<MetadataOnlyOutcome, FetchError> {
-    // Delegating to the PURE `metadata_only` is the contract-correct
-    // implementation, not a placeholder: `metadata_only` never writes
+    resolve_only_with_options(ref_, profile, ctx, MetadataOnlyOptions::default()).await
+}
+
+/// [`resolve_only`], with the caller choosing what it is willing to spend.
+///
+/// # Errors
+///
+/// As [`resolve_only`].
+pub async fn resolve_only_with_options(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    opts: MetadataOnlyOptions,
+) -> Result<MetadataOnlyOutcome, FetchError> {
+    // Delegating to the PURE `metadata_only_with_options` is the
+    // contract-correct implementation, not a placeholder: it never writes
     // to the store (the persisting path is the separate
     // `metadata_only_to_store`, which this function does not call), so
     // `resolve_only`'s "no store mutation" guarantee holds structurally
     // and cannot regress (#139).
-    metadata_only(ref_, profile, ctx).await
+    metadata_only_with_options(ref_, profile, ctx, opts).await
 }
 
 /// Resolve a [`Ref`] to metadata **and persist the metadata TOML to the
@@ -290,7 +381,24 @@ pub async fn metadata_only_to_store(
     ctx: &FetchContext,
     store: &dyn Store,
 ) -> Result<MetadataOnlyOutcome, FetchError> {
-    let outcome = metadata_only(ref_, profile, ctx).await?;
+    metadata_only_to_store_with_options(ref_, profile, ctx, store, MetadataOnlyOptions::default())
+        .await
+}
+
+/// [`metadata_only_to_store`], with the caller choosing what it is willing
+/// to spend.
+///
+/// # Errors
+///
+/// As [`metadata_only_to_store`].
+pub async fn metadata_only_to_store_with_options(
+    ref_: &Ref,
+    profile: &CapabilityProfile,
+    ctx: &FetchContext,
+    store: &dyn Store,
+    opts: MetadataOnlyOptions,
+) -> Result<MetadataOnlyOutcome, FetchError> {
+    let outcome = metadata_only_with_options(ref_, profile, ctx, opts).await?;
     let safekey = ref_.safekey();
     let metadata = build_metadata_only_metadata(ref_, &outcome);
     // `pdf_src = None` => writes `<root>/.metadata/<safekey>.toml` and
@@ -688,37 +796,81 @@ fn unpaywall_source_from_env(contact: &str) -> UnpaywallSource {
     UnpaywallSource::new(contact.to_string())
 }
 
-/// DOI branch — Crossref first, with Unpaywall as a fallback when
-/// Crossref fails. Crossref's `message.link[]` array (when present)
-/// supplies the OA URL hint without making a publisher request.
+/// DOI branch: Crossref first, with Unpaywall as a fallback when Crossref
+/// fails, and as an *addition* when the caller asked for an OA location.
+///
+/// This doc used to say Crossref's `message.link[]` "supplies the OA URL
+/// hint without making a publisher request". It does not, and #517 is why:
+/// measured across twelve live `link[]` entries and eight captured
+/// fixtures, every one was programme-scoped, so
+/// [`extract_crossref_publisher_url`] correctly refuses all of them.
+/// Crossref-first is still the right default -- one request resolves nearly
+/// every DOI -- but the free OA hint that sentence promised never existed
+/// (#539).
 async fn metadata_only_doi(
     _doi: &Doi,
     ref_: &Ref,
     profile: &CapabilityProfile,
     ctx: &FetchContext,
+    opts: MetadataOnlyOptions,
 ) -> Result<MetadataOnlyOutcome, FetchError> {
     let contact = resolve_contact_email();
     let crossref = crossref_source_from_env(&contact);
     match crossref.fetch(ref_, profile, ctx).await {
         Ok(res) => {
             let metadata = res.metadata_json.unwrap_or(Value::Null);
-            let oa_url = extract_crossref_publisher_url(&metadata);
-            // Pure resolver — no store write here (see `metadata_only`
+            // `None` for every DOI in practice -- see the fn doc and #517.
+            // Kept because it is the gate that stops a Similarity Check URL
+            // being handed out under the name `oa_url`.
+            let mut oa_url = extract_crossref_publisher_url(&metadata);
+            // Crossref reports neither an OA status nor a license; both
+            // channels are Unpaywall's. They stay `None` unless the caller
+            // asked us to go and look.
+            let mut oa_status = None;
+            let mut license = None;
+
+            if opts.include_oa_location {
+                let unpaywall = unpaywall_source_from_env(&contact);
+                match unpaywall.fetch(ref_, profile, ctx).await {
+                    Ok(uw) => {
+                        let uw_metadata = uw.metadata_json.unwrap_or(Value::Null);
+                        oa_url = extract_unpaywall_oa_url(&uw_metadata);
+                        oa_status = extract_unpaywall_oa_status(&uw_metadata);
+                        license = if uw.license == "unknown" {
+                            None
+                        } else {
+                            Some(uw.license)
+                        };
+                    }
+                    Err(e) => {
+                        // Deliberately NOT an error, and deliberately
+                        // leaving `oa_status` as `None`. The caller still
+                        // gets the Crossref metadata it also asked for, and
+                        // a null `oa_status` is what distinguishes "could
+                        // not find out" from a completed lookup reporting
+                        // `"closed"`. Inventing a status here would
+                        // recreate the exact ambiguity this option exists
+                        // to remove (#539).
+                        tracing::debug!(
+                            error = %e,
+                            "metadata_only: OA location lookup failed; leaving oa_status null to say so"
+                        );
+                    }
+                }
+            }
+
+            // `metadata` stays Crossref's and `source` says so: the OA
+            // lookup adds three fields, it does not change whose record
+            // this is.
+            //
+            // Pure resolver -- no store write here (see `metadata_only`
             // doc); persistence is `metadata_only_to_store`'s job.
             Ok(MetadataOnlyOutcome {
                 source: crossref.name().to_string(),
                 resolver_profile: crossref.name().to_string(),
-                // Crossref does not surface a license directly; the
-                // license channel for DOI metadata is Unpaywall's
-                // `best_oa_location.license`. Leave `None` here; the
-                // agent can call `unpaywall` (or a follow-up slice's
-                // chained orchestrator) if it needs a license string.
-                license: None,
+                license,
                 oa_url,
-                // Crossref does not report OA status; "not determined".
-                // (The metadata path is Crossref-first and only consults
-                // Unpaywall on a Crossref failure — see the fallback arm.)
-                oa_status: None,
+                oa_status,
                 metadata,
             })
         }

--- a/crates/doiget-core/src/resolver_cache.rs
+++ b/crates/doiget-core/src/resolver_cache.rs
@@ -23,7 +23,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::orchestrator::MetadataOnlyOutcome;
+use crate::orchestrator::{MetadataOnlyOptions, MetadataOnlyOutcome};
 use crate::{Ref, RESOLVER_CACHE_TTL_DAYS};
 
 /// Current cache-entry schema version (CACHE.md §2).
@@ -46,9 +46,41 @@ struct CacheEntry {
 /// `<cache_root>/resolver/<safekey>.toml`.
 #[must_use]
 pub fn cache_file(cache_root: &Utf8Path, ref_: &Ref) -> Utf8PathBuf {
-    cache_root
-        .join("resolver")
-        .join(format!("{}.toml", ref_.safekey().as_str()))
+    cache_file_with_options(cache_root, ref_, MetadataOnlyOptions::default())
+}
+
+/// [`cache_file`], keyed by the options as well as the ref.
+///
+/// A default resolve and an `include_oa_location` resolve ask different
+/// questions of the network and get different answers, so they cannot share
+/// an entry. Serving a default entry to an opt-in caller would answer with
+/// `oa_url: None` -- indistinguishable from "Unpaywall was asked and this
+/// work has no OA location", which is the one thing the caller paid a
+/// request to find out.
+///
+/// The other direction is just as wrong: reading the opt-in entry and
+/// re-fetching whenever `oa_url` is `None` would re-fetch forever for
+/// exactly the closed-access works one asks about repeatedly.
+///
+/// So: two entries, separated by a SUBDIRECTORY rather than a filename
+/// suffix. A `<safekey>.oa.toml` suffix would collide -- [`Ref::safekey`]
+/// keeps `.` (it is in the allowed set), so the DOI `10.1234/foo.oa`
+/// resolved by default and the DOI `10.1234/foo` resolved with the flag
+/// would both want `doi_10.1234_foo.oa.toml`. A safekey can never contain a
+/// path separator (`/` is replaced with `_`), so a subdirectory cannot.
+#[must_use]
+pub fn cache_file_with_options(
+    cache_root: &Utf8Path,
+    ref_: &Ref,
+    opts: MetadataOnlyOptions,
+) -> Utf8PathBuf {
+    let dir = cache_root.join("resolver");
+    let dir = if opts.include_oa_location {
+        dir.join("oa")
+    } else {
+        dir
+    };
+    dir.join(format!("{}.toml", ref_.safekey().as_str()))
 }
 
 /// Read a cached outcome for `ref_` if present and still within its TTL.
@@ -62,7 +94,19 @@ pub fn read_at(
     ref_: &Ref,
     now: DateTime<Utc>,
 ) -> Option<MetadataOnlyOutcome> {
-    let path = cache_file(cache_root, ref_);
+    read_at_with_options(cache_root, ref_, now, MetadataOnlyOptions::default())
+}
+
+/// [`read_at`], reading the entry keyed by `opts`. See
+/// [`cache_file_with_options`] for why the options are part of the key.
+#[must_use]
+pub fn read_at_with_options(
+    cache_root: &Utf8Path,
+    ref_: &Ref,
+    now: DateTime<Utc>,
+    opts: MetadataOnlyOptions,
+) -> Option<MetadataOnlyOutcome> {
+    let path = cache_file_with_options(cache_root, ref_, opts);
     let text = std::fs::read_to_string(&path).ok()?;
     let entry: CacheEntry = toml::from_str(&text).ok()?;
     let fetched: DateTime<Utc> = DateTime::parse_from_rfc3339(&entry.fetched_at)
@@ -81,6 +125,16 @@ pub fn read(cache_root: &Utf8Path, ref_: &Ref) -> Option<MetadataOnlyOutcome> {
     read_at(cache_root, ref_, Utc::now())
 }
 
+/// [`read`], reading the entry keyed by `opts`.
+#[must_use]
+pub fn read_with_options(
+    cache_root: &Utf8Path,
+    ref_: &Ref,
+    opts: MetadataOnlyOptions,
+) -> Option<MetadataOnlyOutcome> {
+    read_at_with_options(cache_root, ref_, Utc::now(), opts)
+}
+
 /// Write `outcome` to the cache for `ref_`. Best-effort: returns `false`
 /// (after a `tracing::debug!`) on any I/O or serialization failure rather
 /// than propagating, since a cache write must never fail a resolve.
@@ -89,6 +143,23 @@ pub fn write_at(
     ref_: &Ref,
     outcome: &MetadataOnlyOutcome,
     now: DateTime<Utc>,
+) -> bool {
+    write_at_with_options(
+        cache_root,
+        ref_,
+        outcome,
+        now,
+        MetadataOnlyOptions::default(),
+    )
+}
+
+/// [`write_at`], writing the entry keyed by `opts`.
+pub fn write_at_with_options(
+    cache_root: &Utf8Path,
+    ref_: &Ref,
+    outcome: &MetadataOnlyOutcome,
+    now: DateTime<Utc>,
+    opts: MetadataOnlyOptions,
 ) -> bool {
     let response = match serde_json::to_string(outcome) {
         Ok(s) => s,
@@ -111,7 +182,7 @@ pub fn write_at(
             return false;
         }
     };
-    let path = cache_file(cache_root, ref_);
+    let path = cache_file_with_options(cache_root, ref_, opts);
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
             tracing::debug!(error = %e, dir = %parent, "resolver cache: mkdir failed; skipping write");
@@ -128,6 +199,16 @@ pub fn write_at(
 /// Write using the current wall clock. See [`write_at`].
 pub fn write(cache_root: &Utf8Path, ref_: &Ref, outcome: &MetadataOnlyOutcome) -> bool {
     write_at(cache_root, ref_, outcome, Utc::now())
+}
+
+/// [`write()`], writing the entry keyed by `opts`.
+pub fn write_with_options(
+    cache_root: &Utf8Path,
+    ref_: &Ref,
+    outcome: &MetadataOnlyOutcome,
+    opts: MetadataOnlyOptions,
+) -> bool {
+    write_at_with_options(cache_root, ref_, outcome, Utc::now(), opts)
 }
 
 #[cfg(test)]
@@ -157,6 +238,64 @@ mod tests {
         let got = read_at(root, &r, now).expect("cache hit");
         assert_eq!(got.source, "crossref");
         assert_eq!(got.metadata["DOI"], "10.1234/x");
+    }
+
+    /// #539: the options are part of the key, not just the request.
+    ///
+    /// A default resolve caches `oa_url: None` because it never asked. Serving
+    /// that entry to a caller who DID ask would answer the one question it
+    /// paid a round-trip for, with a value that means something else.
+    #[test]
+    fn an_opt_in_read_does_not_hit_the_default_entry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = Utf8Path::from_path(dir.path()).unwrap();
+        let r = Ref::parse("10.1234/x").unwrap();
+        let now = Utc::now();
+        let with_oa = MetadataOnlyOptions::default().with_oa_location(true);
+
+        assert!(write_at(root, &r, &outcome(), now));
+        assert!(
+            read_at_with_options(root, &r, now, with_oa).is_none(),
+            "the default entry must not satisfy an opt-in read"
+        );
+        // ... and the converse, so a warm opt-in cache does not start
+        // answering default calls with a field they did not ask for.
+        let dir2 = tempfile::TempDir::new().unwrap();
+        let root2 = Utf8Path::from_path(dir2.path()).unwrap();
+        assert!(write_at_with_options(root2, &r, &outcome(), now, with_oa));
+        assert!(read_at(root2, &r, now).is_none());
+        assert!(read_at_with_options(root2, &r, now, with_oa).is_some());
+    }
+
+    /// The first version of this used a `<safekey>.oa.toml` SUFFIX, which
+    /// collides: [`Ref::safekey`] keeps `.` (it is in the allowed character
+    /// set), so the DOI `10.1234/foo.oa` resolved by default and the DOI
+    /// `10.1234/foo` resolved with the flag both wanted
+    /// `doi_10.1234_foo.oa.toml` -- one silently serving the other's answer.
+    /// A subdirectory cannot collide, because a safekey can never contain a
+    /// path separator.
+    #[test]
+    fn a_dot_oa_doi_cannot_collide_with_an_opt_in_entry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = Utf8Path::from_path(dir.path()).unwrap();
+        let plain = Ref::parse("10.1234/foo").unwrap();
+        let dotted = Ref::parse("10.1234/foo.oa").unwrap();
+
+        // Guard the premise: if safekey ever starts escaping `.`, this test
+        // is no longer testing what it says it is.
+        assert!(
+            dotted.safekey().as_str().ends_with(".oa"),
+            "premise: safekey keeps '.', so a '.oa' suffix is reachable"
+        );
+
+        assert_ne!(
+            cache_file_with_options(root, &dotted, MetadataOnlyOptions::default()),
+            cache_file_with_options(
+                root,
+                &plain,
+                MetadataOnlyOptions::default().with_oa_location(true)
+            ),
+        );
     }
 
     #[test]

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -52,8 +52,8 @@ use doiget_core::http::{
 };
 use doiget_core::orchestrator::{
     batch_fetch as core_batch_fetch, batch_fetch_plans, fetch_paper as core_fetch_paper,
-    metadata_only_to_store, resolve_only as core_resolve_only, FetchPaperOutcome,
-    MetadataOnlyOutcome, PdfLegStatus,
+    metadata_only_to_store_with_options, resolve_only_with_options as core_resolve_only,
+    FetchPaperOutcome, MetadataOnlyOptions, MetadataOnlyOutcome, PdfLegStatus,
 };
 use doiget_core::provenance::{Capability, LogEvent, LogResult, ProvenanceLog, RowInput};
 use doiget_core::rate_limiter::RateLimiter;
@@ -248,11 +248,11 @@ impl Server {
     /// [`FetchPlan`]: doiget_core::dry_run::FetchPlan
     #[tool(
         description = "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\n\
-                       INPUTS: ref (DOI or arXiv id), dry_run (optional bool).\n\
-                       OUTPUTS: { ok: true, ref, source, license?, oa_url, metadata } OR { ok: true, dry_run: true, ref, plan, rate_limit_budget } OR { ok:false, error }.\n\
-                       COSTS: 1-2 s metadata round-trip (or 0 when dry_run).\n\
+                       INPUTS: ref (DOI or arXiv id), dry_run (optional bool), include_oa_location (optional bool).\n\
+                       OUTPUTS: { ok: true, ref, source, license?, oa_url, oa_status, metadata } OR { ok: true, dry_run: true, ref, plan, rate_limit_budget } OR { ok:false, error }.\n\
+                       COSTS: 1-2 s metadata round-trip (or 0 when dry_run; roughly doubled when include_oa_location).\n\
                        SIDE EFFECTS: Appends a 'metadata-only' provenance row (unless dry_run). Writes the metadata TOML to the store. Never fetches PDF.\n\
-                       LIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed.",
+                       LIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed. oa_url is null unless include_oa_location is set: Crossref alone cannot supply one, because its link[] entries are scoped to a licensed programme (Similarity Check / TDM / syndication) rather than being general-purpose. A null oa_url is therefore NOT evidence that the work is closed. With include_oa_location set, oa_status says which answer you got: closed means the lookup completed and found no OA location, null means the lookup did not complete.",
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -368,7 +368,9 @@ impl Server {
             )));
         }
 
-        let outcome = metadata_only_to_store(&ref_, &self.profile, &ctx, &store).await;
+        let opts = MetadataOnlyOptions::default().with_oa_location(input.include_oa_location);
+        let outcome =
+            metadata_only_to_store_with_options(&ref_, &self.profile, &ctx, &store, opts).await;
 
         // SessionEnd bookend. Best-effort: if this append fails we still
         // surface the orchestrator's outcome (a fresh log error here
@@ -434,11 +436,11 @@ impl Server {
     /// `doiget_metadata_only` with `dry_run: true` instead.
     #[tool(
         description = "WHEN TO USE: User wants metadata for a DOI / arXiv id with no local persistence (audit log row only).\n\
-                       INPUTS: ref (DOI or arXiv id).\n\
-                       OUTPUTS: { ok: true, ref, source, resolver_profile, license?, oa_url, metadata, schema_version } OR { ok:false, ref, error }.\n\
-                       COSTS: 1-2 s metadata round-trip.\n\
+                       INPUTS: ref (DOI or arXiv id), include_oa_location (optional bool).\n\
+                       OUTPUTS: { ok: true, ref, source, resolver_profile, license?, oa_url, oa_status, metadata, schema_version } OR { ok:false, ref, error }.\n\
+                       COSTS: 1-2 s metadata round-trip (roughly doubled when include_oa_location).\n\
                        SIDE EFFECTS: Appends one provenance row per consulted resolver. NEVER writes a metadata TOML to the store. NEVER fetches PDF.\n\
-                       LIMITS: Subject to the same rate cap as metadata_only (5/sec). The OA URL is reported but never followed. dry_run is not supported; use metadata_only with dry_run for a preview.",
+                       LIMITS: Subject to the same rate cap as metadata_only (5/sec). The OA URL is reported but never followed. oa_url is null unless include_oa_location is set: Crossref alone cannot supply one, because its link[] entries are scoped to a licensed programme (Similarity Check / TDM / syndication) rather than being general-purpose. A null oa_url is therefore NOT evidence that the work is closed. With include_oa_location set, oa_status says which answer you got: closed means the lookup completed and found no OA location, null means the lookup did not complete. dry_run is not supported; use metadata_only with dry_run for a preview.",
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -501,7 +503,8 @@ impl Server {
             )));
         }
 
-        let outcome = core_resolve_only(&ref_, &self.profile, &ctx).await;
+        let opts = MetadataOnlyOptions::default().with_oa_location(input.include_oa_location);
+        let outcome = core_resolve_only(&ref_, &self.profile, &ctx, opts).await;
 
         // SessionEnd bookend. Best-effort.
         let session_ok = outcome.is_ok();
@@ -2577,6 +2580,25 @@ pub struct MetadataOnlyInput {
     /// either omit the field or pass `false`.
     #[serde(default)]
     pub dry_run: bool,
+    /// Consult Unpaywall for a real OA location, filling `oa_url`,
+    /// `oa_status` and `license`. Costs one extra metadata round-trip.
+    ///
+    /// Defaults to `false`, and when it is `false` `oa_url` is ALWAYS
+    /// `null`: the default path is Crossref-only, and Crossref's `link[]`
+    /// is a programme-scoped channel (Similarity Check, TDM, syndication),
+    /// never a general-purpose OA URL (#517). Before #539 the field was
+    /// advertised without that caveat, so an agent could read a permanent
+    /// `null` as "this work has no OA location".
+    ///
+    /// Set it and `oa_status` tells you which answer you got: `"closed"`
+    /// means the lookup completed and there is no OA location, while
+    /// `null` means the lookup itself did not complete.
+    ///
+    /// Plain `bool` rather than `Option<bool>` for the same reason as
+    /// `dry_run`: a wire `null` should be rejected at deserialize time
+    /// rather than silently meaning "no".
+    #[serde(default)]
+    pub include_oa_location: bool,
 }
 
 /// JSON-schema-derived input for the `doiget_resolve_paper` MCP tool.
@@ -2596,6 +2618,25 @@ pub struct ResolvePaperInput {
     #[serde(rename = "ref")]
     #[schemars(rename = "ref")]
     pub ref_: String,
+    /// Consult Unpaywall for a real OA location, filling `oa_url`,
+    /// `oa_status` and `license`. Costs one extra metadata round-trip.
+    ///
+    /// Defaults to `false`, and when it is `false` `oa_url` is ALWAYS
+    /// `null`: the default path is Crossref-only, and Crossref's `link[]`
+    /// is a programme-scoped channel (Similarity Check, TDM, syndication),
+    /// never a general-purpose OA URL (#517). Before #539 the field was
+    /// advertised without that caveat, so an agent could read a permanent
+    /// `null` as "this work has no OA location".
+    ///
+    /// Set it and `oa_status` tells you which answer you got: `"closed"`
+    /// means the lookup completed and there is no OA location, while
+    /// `null` means the lookup itself did not complete.
+    ///
+    /// Plain `bool` rather than `Option<bool>` for the same reason as
+    /// `dry_run`: a wire `null` should be rejected at deserialize time
+    /// rather than silently meaning "no".
+    #[serde(default)]
+    pub include_oa_location: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/doiget-mcp/tests/resolve_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_paper_e2e.rs
@@ -469,7 +469,7 @@ async fn resolve_paper_with_include_oa_location_returns_a_real_oa_url() -> anyho
     let td = tempfile::TempDir::new().expect("tempdir");
     let log_path = camino::Utf8Path::from_path(td.path())
         .expect("tempdir is utf-8")
-        .join("mcp-resolve-optin.jsonl");
+        .join("mcp-resolve-opt-in.jsonl");
 
     let env = EnvGuard::new(ENV_KEYS);
     env.set("DOIGET_CROSSREF_BASE", &crossref.uri());

--- a/crates/doiget-mcp/tests/resolve_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_paper_e2e.rs
@@ -357,6 +357,263 @@ async fn doiget_resolve_paper_doi_crossref_happy_path_returns_metadata_envelope(
 }
 
 // ---------------------------------------------------------------------------
+// 3b. #539 — the OA location is opt-in, and its absence is legible
+// ---------------------------------------------------------------------------
+
+/// A REALISTIC Crossref response. `SAMPLE_CROSSREF_RESPONSE` above carries
+/// `intended-application: "unspecified"`, which the #517 measurement found in
+/// **zero** of twelve live `link[]` entries and zero of eight captured
+/// fixtures -- it exercises the accept arm of the gate, but it is not what
+/// Crossref actually returns. This one is: a Similarity Check link, correctly
+/// refused, leaving `oa_url` null. That is the #539 condition.
+const REALISTIC_CROSSREF_RESPONSE: &str = r#"{"status":"ok","message":{"title":["Example Paper"],"link":[{"URL":"https://publisher.example.org/similarity/10.1234/example.pdf","content-type":"application/pdf","intended-application":"similarity-checking"}]}}"#;
+
+const SAMPLE_UNPAYWALL_RESPONSE: &str = r#"{"doi":"10.1234/example","is_oa":true,"oa_status":"gold","best_oa_location":{"url_for_pdf":"https://repository.example.org/free.pdf","url":"https://repository.example.org/landing","license":"cc-by"}}"#;
+
+/// Default: one request, and `oa_url` is null because Crossref alone cannot
+/// supply one. The Unpaywall mock is mounted with `.expect(0)`, so if the
+/// default path ever starts paying for a second round-trip this test fails on
+/// `MockServer` drop rather than silently doubling everyone's cost.
+#[tokio::test]
+#[serial_test::serial]
+async fn resolve_paper_does_not_consult_unpaywall_by_default() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let crossref = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/example"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(REALISTIC_CROSSREF_RESPONSE))
+        .mount(&crossref)
+        .await;
+
+    let unpaywall = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_UNPAYWALL_RESPONSE))
+        .expect(0)
+        .mount(&unpaywall)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-resolve-default.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_CROSSREF_BASE", &crossref.uri());
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", unpaywall.uri()));
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
+    env.set(
+        "DOIGET_STORE_ROOT",
+        td.path().to_str().expect("utf-8 tempdir"),
+    );
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_resolve_paper uses CallToolResult::structured");
+
+    assert_eq!(structured["ok"], serde_json::json!(true), "{structured:?}");
+    assert_eq!(
+        structured["oa_url"],
+        serde_json::Value::Null,
+        "a similarity-checking link is not an OA URL (#517): {structured:?}"
+    );
+    assert_eq!(
+        structured["oa_status"],
+        serde_json::Value::Null,
+        "nothing was consulted, so nothing is known: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    // Verifies the `.expect(0)`.
+    drop(unpaywall);
+    drop(td);
+    Ok(())
+}
+
+/// Opt in and the field is filled from Unpaywall's `best_oa_location` -- the
+/// URL, the status, and the license, which the Crossref-only path also leaves
+/// null.
+#[tokio::test]
+#[serial_test::serial]
+async fn resolve_paper_with_include_oa_location_returns_a_real_oa_url() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let crossref = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/example"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(REALISTIC_CROSSREF_RESPONSE))
+        .mount(&crossref)
+        .await;
+
+    let unpaywall = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SAMPLE_UNPAYWALL_RESPONSE))
+        .mount(&unpaywall)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-resolve-optin.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_CROSSREF_BASE", &crossref.uri());
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", unpaywall.uri()));
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
+    env.set(
+        "DOIGET_STORE_ROOT",
+        td.path().to_str().expect("utf-8 tempdir"),
+    );
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    args.insert("include_oa_location".to_string(), serde_json::json!(true));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_resolve_paper uses CallToolResult::structured");
+
+    assert_eq!(structured["ok"], serde_json::json!(true), "{structured:?}");
+    assert_eq!(
+        structured["oa_url"],
+        serde_json::json!("https://repository.example.org/free.pdf"),
+        "{structured:?}"
+    );
+    assert_eq!(structured["oa_status"], serde_json::json!("gold"));
+    assert_eq!(structured["license"], serde_json::json!("cc-by"));
+    // The record is still Crossref's; the lookup adds fields, it does not
+    // change whose metadata this is.
+    assert_eq!(structured["source"], serde_json::json!("crossref"));
+    assert_eq!(
+        structured["metadata"]["title"],
+        serde_json::json!(["Example Paper"])
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    drop(td);
+    Ok(())
+}
+
+/// The case #539 is really about. A caller that paid for a lookup must be
+/// able to tell "this work has no OA location" from "I could not find out".
+/// Unpaywall is down here, so BOTH fields stay null -- and a null `oa_status`
+/// is precisely what says the lookup did not complete, because a lookup that
+/// completes on a closed work reports `oa_status: "closed"`.
+///
+/// The call still succeeds: the Crossref metadata the caller also asked for
+/// is good, and failing the whole resolve over an optional extra would be a
+/// worse answer than an honest partial one.
+#[tokio::test]
+#[serial_test::serial]
+async fn resolve_paper_leaves_oa_status_null_when_the_lookup_fails() -> anyhow::Result<()> {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let crossref = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/works/10.1234/example"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(REALISTIC_CROSSREF_RESPONSE))
+        .mount(&crossref)
+        .await;
+
+    let unpaywall = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(500))
+        // Without this the test would also pass against a build that ignored
+        // `include_oa_location` and never called Unpaywall at all: "both
+        // fields null" is what that produces too.
+        //
+        // A RANGE, not `== 1`: a 5xx is retried by the transport (measured:
+        // four attempts), and the retry policy is not this feature's contract
+        // to freeze.
+        .expect(1..)
+        .mount(&unpaywall)
+        .await;
+
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let log_path = camino::Utf8Path::from_path(td.path())
+        .expect("tempdir is utf-8")
+        .join("mcp-resolve-degraded.jsonl");
+
+    let env = EnvGuard::new(ENV_KEYS);
+    env.set("DOIGET_CROSSREF_BASE", &crossref.uri());
+    env.set("DOIGET_UNPAYWALL_BASE", &format!("{}/v2", unpaywall.uri()));
+    env.set("DOIGET_LOG_PATH", log_path.as_str());
+    env.set("DOIGET_CONTACT_EMAIL", "test@example.org");
+    env.set(
+        "DOIGET_STORE_ROOT",
+        td.path().to_str().expect("utf-8 tempdir"),
+    );
+
+    let (client, server_handle) = boot_in_memory_server().await?;
+
+    let mut args = serde_json::Map::new();
+    args.insert("ref".to_string(), serde_json::json!("10.1234/example"));
+    args.insert("include_oa_location".to_string(), serde_json::json!(true));
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("doiget_resolve_paper").with_arguments(args))
+        .await?;
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("doiget_resolve_paper uses CallToolResult::structured");
+
+    assert_eq!(
+        structured["ok"],
+        serde_json::json!(true),
+        "an optional extra failing must not sink the resolve: {structured:?}"
+    );
+    assert_eq!(
+        structured["metadata"]["title"],
+        serde_json::json!(["Example Paper"]),
+        "the metadata the caller also asked for is still there: {structured:?}"
+    );
+    assert_eq!(structured["oa_url"], serde_json::Value::Null);
+    assert_eq!(
+        structured["oa_status"],
+        serde_json::Value::Null,
+        "a null oa_status is the signal that the lookup did not complete; \
+         inventing 'closed' here would assert the work is paywalled on the \
+         strength of a 500: {structured:?}"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    drop(env);
+    // Verifies the `.expect(1)`.
+    drop(unpaywall);
+    drop(td);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // 4. dry_run field rejection
 // ---------------------------------------------------------------------------
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -283,10 +283,43 @@ metadata. It **MUST NOT** trigger a publisher-side PDF fetch, even when the
 metadata source returns an OA URL. The OA URL, when known, is surfaced in the
 response as `oa_url` (string) for the caller to act on separately.
 
+### `oa_url` is opt-in (#539)
+
+By default `oa_url` is **always `null`**, and callers MUST NOT read that as
+"this work has no OA location".
+
+The DOI path is Crossref-first, on the rationale that Crossref's
+`message.link[]` supplied an OA URL without a second request. It does not:
+measured across twelve live entries and eight captured fixtures, every one
+carried an `intended-application` scoping it to a licensed programme
+(Similarity Check, TDM, syndication) rather than being general-purpose, and
+following one outside that programme would be taking a licensed route
+without the licence. So the extractor refuses all of them, correctly, and the
+field it was meant to fill stays empty (ADR-0052, #517).
+
+A caller that wants a real OA location passes `include_oa_location: true`,
+which consults Unpaywall. That costs one extra metadata round-trip; it does
+NOT weaken any guarantee above, because Unpaywall is a metadata source and
+the URL is still reported and never followed.
+
+With the flag set, the `oa_status`/`oa_url` pair says which answer you got:
+
+| `oa_status` | `oa_url` | meaning |
+|---|---|---|
+| `"closed"` | `null` | the lookup completed; this work has no OA location |
+| `"gold"`, `"green"`, `"hybrid"`, `"bronze"` | string | the lookup completed; here it is |
+| `null` | `null` | the lookup did not complete |
+
+A failed Unpaywall call is NOT an error: the Crossref metadata the caller also
+asked for is still returned, and the null `oa_status` is what distinguishes
+"could not find out" from a completed lookup reporting `"closed"`. This
+mirrors the `oa_status` + `pdf.status` pairing already used by
+`doiget_fetch_paper` (§4).
+
 ```jsonc
 {
   "name": "doiget_metadata_only",
-  "description": "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\nINPUTS: ref (DOI or arXiv id), dry_run (optional bool).\nOUTPUTS: { ok: true, ref, source, license?, oa_url:string|null, metadata } or { ok:false, error }.\nCOSTS: 1-2 s metadata round-trip. No publisher fetch.\nSIDE EFFECTS: Appends a provenance row tagged 'metadata-only' (unless dry_run). Writes the metadata TOML to the store.\nLIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed.",
+  "description": "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\nINPUTS: ref (DOI or arXiv id), dry_run (optional bool), include_oa_location (optional bool).\nOUTPUTS: { ok: true, ref, source, license?, oa_url:string|null, oa_status:string|null, metadata } or { ok:false, error }.\nCOSTS: 1-2 s metadata round-trip (roughly doubled when include_oa_location). No publisher fetch.\nSIDE EFFECTS: Appends a provenance row tagged 'metadata-only' (unless dry_run). Writes the metadata TOML to the store.\nLIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed. oa_url is null unless include_oa_location is set.",
   "inputSchema": {
     "type": "object",
     "required": ["ref"],
@@ -297,7 +330,8 @@ response as `oa_url` (string) for the caller to act on separately.
         "maxLength": 256,
         "pattern": "^(10\\.\\d{4,9}/[A-Za-z0-9._/()-]+|arXiv:\\d{4}\\.\\d{4,5}|\\d{4}\\.\\d{4,5})$"
       },
-      "dry_run": { "type": "boolean", "default": false }
+      "dry_run": { "type": "boolean", "default": false },
+      "include_oa_location": { "type": "boolean", "default": false }
     },
     "additionalProperties": false
   }
@@ -316,7 +350,11 @@ type MetadataOnlyResult =
       // Currently equal to `source` verbatim.
       resolver_profile: string,
       license: string,
+      // Null unless `include_oa_location` was set - see above. A null here is
+      // NOT evidence that the work has no OA location.
       oa_url: string | null,
+      // gold / green / hybrid / bronze / closed, or null when not determined.
+      oa_status: string | null,
       metadata: object,
       schema_version: string,
     }

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -289,10 +289,43 @@ metadata. It **MUST NOT** trigger a publisher-side PDF fetch, even when the
 metadata source returns an OA URL. The OA URL, when known, is surfaced in the
 response as `oa_url` (string) for the caller to act on separately.
 
+### `oa_url` is opt-in (#539)
+
+By default `oa_url` is **always `null`**, and callers MUST NOT read that as
+"this work has no OA location".
+
+The DOI path is Crossref-first, on the rationale that Crossref's
+`message.link[]` supplied an OA URL without a second request. It does not:
+measured across twelve live entries and eight captured fixtures, every one
+carried an `intended-application` scoping it to a licensed programme
+(Similarity Check, TDM, syndication) rather than being general-purpose, and
+following one outside that programme would be taking a licensed route
+without the licence. So the extractor refuses all of them, correctly, and the
+field it was meant to fill stays empty (ADR-0052, #517).
+
+A caller that wants a real OA location passes `include_oa_location: true`,
+which consults Unpaywall. That costs one extra metadata round-trip; it does
+NOT weaken any guarantee above, because Unpaywall is a metadata source and
+the URL is still reported and never followed.
+
+With the flag set, the `oa_status`/`oa_url` pair says which answer you got:
+
+| `oa_status` | `oa_url` | meaning |
+|---|---|---|
+| `"closed"` | `null` | the lookup completed; this work has no OA location |
+| `"gold"`, `"green"`, `"hybrid"`, `"bronze"` | string | the lookup completed; here it is |
+| `null` | `null` | the lookup did not complete |
+
+A failed Unpaywall call is NOT an error: the Crossref metadata the caller also
+asked for is still returned, and the null `oa_status` is what distinguishes
+"could not find out" from a completed lookup reporting `"closed"`. This
+mirrors the `oa_status` + `pdf.status` pairing already used by
+`doiget_fetch_paper` (§4).
+
 ```jsonc
 {
   "name": "doiget_metadata_only",
-  "description": "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\nINPUTS: ref (DOI or arXiv id), dry_run (optional bool).\nOUTPUTS: { ok: true, ref, source, license?, oa_url:string|null, metadata } or { ok:false, error }.\nCOSTS: 1-2 s metadata round-trip. No publisher fetch.\nSIDE EFFECTS: Appends a provenance row tagged 'metadata-only' (unless dry_run). Writes the metadata TOML to the store.\nLIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed.",
+  "description": "WHEN TO USE: User wants metadata for a DOI / arXiv id without paying for or being noticed by a PDF download.\nINPUTS: ref (DOI or arXiv id), dry_run (optional bool), include_oa_location (optional bool).\nOUTPUTS: { ok: true, ref, source, license?, oa_url:string|null, oa_status:string|null, metadata } or { ok:false, error }.\nCOSTS: 1-2 s metadata round-trip (roughly doubled when include_oa_location). No publisher fetch.\nSIDE EFFECTS: Appends a provenance row tagged 'metadata-only' (unless dry_run). Writes the metadata TOML to the store.\nLIMITS: Subject to the same rate cap as fetch_paper (5/sec). The OA URL is reported but never followed. oa_url is null unless include_oa_location is set.",
   "inputSchema": {
     "type": "object",
     "required": ["ref"],
@@ -303,7 +336,8 @@ response as `oa_url` (string) for the caller to act on separately.
         "maxLength": 256,
         "pattern": "^(10\\.\\d{4,9}/[A-Za-z0-9._/()-]+|arXiv:\\d{4}\\.\\d{4,5}|\\d{4}\\.\\d{4,5})$"
       },
-      "dry_run": { "type": "boolean", "default": false }
+      "dry_run": { "type": "boolean", "default": false },
+      "include_oa_location": { "type": "boolean", "default": false }
     },
     "additionalProperties": false
   }
@@ -322,7 +356,11 @@ type MetadataOnlyResult =
       // Currently equal to `source` verbatim.
       resolver_profile: string,
       license: string,
+      // Null unless `include_oa_location` was set - see above. A null here is
+      // NOT evidence that the work has no OA location.
       oa_url: string | null,
+      // gold / green / hybrid / bronze / closed, or null when not determined.
+      oa_status: string | null,
       metadata: object,
       schema_version: string,
     }


### PR DESCRIPTION
Closes #539.

## The problem

`doiget_metadata_only` and `doiget_resolve_paper` advertise `oa_url` as an OA URL "for the caller to act on separately" (`docs/MCP_TOOLS.md` §11). It is `null` for **every DOI**.

The DOI path is Crossref-first, on the stated rationale that Crossref's `message.link[]` "supplies the OA URL hint without making a publisher request". #517 measured that claim: twelve live `link[]` entries across SIAM, IEEE, AMS, ACM, Springer Nature and the Royal Society, plus the eight captured fixtures — **not one** was general-purpose. Every entry was scoped to a licensed programme (Similarity Check, TDM, syndication), and following one outside that programme would be taking a licensed route without the licence.

So `extract_crossref_publisher_url` refuses all of them, correctly. The rationale for Crossref-first is fine — one request resolves nearly every DOI. What was wrong was continuing to promise a field it cannot fill.

An agent reading `oa_url: null` has no way to distinguish it from "this work has no free copy".

## The fix

`include_oa_location: true` consults Unpaywall. **Off by default**: the default path stays one round-trip, and nobody pays for a location they will not use. No guarantee is weakened — Unpaywall is a metadata source, and the URL is still reported and never followed.

With the flag set, `oa_status` says which answer you got:

| `oa_status` | `oa_url` | meaning |
|---|---|---|
| `"closed"` | `null` | the lookup completed; this work has no OA location |
| `"gold"`, `"green"`, … | string | the lookup completed; here it is |
| `null` | `null` | the lookup did not complete |

A failed Unpaywall call leaves **both** fields null rather than inventing a status. Asserting `"closed"` on the strength of a 500 would recreate the exact ambiguity being fixed. The call still succeeds — the Crossref metadata the caller also asked for is good, and an optional extra failing should not sink the resolve.

This is not a new convention: `doiget_fetch_paper` already pairs `oa_status` with `pdf.status` for the same reason, so an agent can tell a paywalled work from one it could not reach.

## The cache key, and a bug I wrote

The resolver cache keyed on the safekey alone, so a default entry would have been served to a caller that asked for the location — answering the one question it paid a round-trip for, with a value that means something else. The options are now part of the key.

The **first** version used a `<safekey>.oa.toml` filename suffix, with a comment explaining it was safe because `Ref::safekey` percent-encodes `.`. **It does not** — `lib.rs:623` lists `.` in the allowed set. So the DOI `10.1234/foo.oa` resolved by default and `10.1234/foo` resolved with the flag both wanted `doi_10.1234_foo.oa.toml`. Checking the claim instead of trusting it caught this; it is now a subdirectory, which cannot collide because a safekey can never contain a path separator.

`a_dot_oa_doi_cannot_collide_with_an_opt_in_entry` guards it. Reverting to the suffix fails that test and nothing else — verified.

## API

`doiget-core` gains `MetadataOnlyOptions` and `_with_options` variants of `metadata_only`, `resolve_only` and `metadata_only_to_store`. The existing three delegate with defaults, so nothing downstream breaks — this is additive on a semver-strict crate. The options type is `#[non_exhaustive]` with a `with_oa_location` builder, so a future knob is not a breaking change either.

## Tests

Three at the MCP boundary over wiremock, using a **realistic** Crossref fixture. The existing `SAMPLE_CROSSREF_RESPONSE` carries `intended-application: "unspecified"`, which the #517 measurement found in zero of twenty entries — it exercises the gate's accept arm but is not what Crossref returns. The new fixture is a Similarity Check link, correctly refused, which is the actual #539 condition.

- **default** — `oa_url` and `oa_status` both null, and Unpaywall is mounted with `.expect(0)`, so a regression that starts paying for a second round-trip fails on server drop rather than silently doubling everyone's cost.
- **opt-in** — `oa_url`, `oa_status` and `license` all filled from `best_oa_location`; `source` stays `crossref`, because the lookup adds fields rather than changing whose record it is.
- **degraded** — Unpaywall 500s: still `ok: true` with the Crossref metadata, both OA fields null. Mounted `.expect(1..)` so the test cannot pass against a build that ignores the flag entirely — "both fields null" is what that produces too. A range rather than `== 1` because a 5xx is retried by the transport (measured: four attempts), and the retry policy is not this feature's contract to freeze.

Plus two `resolver_cache` unit tests for the key.

**Mutation-checked** both ways: ignoring the flag fails the two opt-in tests and leaves the default one passing; restoring the suffix key fails only the collision test.

## Notes

- Finding the fixture bug was itself an instance of the problem: the first opt-in test failed with two nulls, indistinguishable in the envelope from a network failure. It was a missing `is_oa` field, which `UnpaywallWork` requires.
- Also folds a duplicate `### Changed` heading inside the Unreleased CHANGELOG section (a merge artefact).
- `cargo doc -D warnings` caught two intra-doc link errors in the new comments (a public doc linking a private item; `write` ambiguous with the macro). Both fixed.

Local: fmt, clippy `-D warnings`, full workspace suite, both rustdoc surfaces, `version-bump-gate.sh`.
