### PR TITLE
fix(fetch): a DOI resolver is addressing, not a content host (#533)

### DIFF
--- a/.github/workflows/posture-lint.yml
+++ b/.github/workflows/posture-lint.yml
@@ -305,6 +305,31 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
 
+      - name: Host adjudication uses `permits`, never `matches` (#533)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `SourceAllowlist::matches` answers "is this host on the list".
+          # `SourceAllowlist::permits` answers "may we go here", which is what
+          # every gate is actually asking -- and it is the one that treats a
+          # DOI resolver as addressing rather than as a content host.
+          #
+          # #533 was a gate that asked the first question and acted on the
+          # answer: a gold-OA cc-by paper was refused at `doi.org`, one hop
+          # before the publisher whose host was already allowlisted. There
+          # were FIVE such gates and only one of them was ever walked end to
+          # end, which is #462's point exactly ("every 'unreachable source'
+          # bug passed its unit tests").
+          #
+          # The discriminator: adjudication passes a host VARIABLE
+          # (`.matches(&host)`); list-membership assertions in tests pass a
+          # LITERAL (`.matches("doaj.org")`). So a `.matches(&` anywhere is a
+          # gate that should be a `permits`.
+          if grep -rn --include='*.rs' '\.matches(&' crates/ ; then
+            echo "::error::posture-lint: host adjudication must call permits(), not matches() - see http::is_transparent_resolver (#533)"
+            exit 1
+          fi
+
       - name: No outbound-network APIs in unit / integration tests
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,38 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[fetch]** A gold-OA, cc-by paper was refused at `doi.org`, one hop before the
+  publisher whose host was already on the allowlist. Unpaywall reports
+  `best_oa_location.url` for `10.1002/pcn5.205` as literally
+  `https://doi.org/10.1002/pcn5.205`, with no `url_for_pdf` - the normal shape for
+  publisher-hosted gold OA - so the first host doiget touched on the fetch leg was
+  the DOI resolver, and it was adjudicated as though it were where the bytes come
+  from (#533).
+
+  The remediation the denial emitted was worse than the refusal: it advised adding
+  `doi.org` to `[[network.additional_hosts]]`. That does not widen the trusted
+  surface toward one publisher. It removes the bound entirely, because every DOI in
+  existence resolves through it, and an agent following the advice would get its
+  PDF while silently losing the invariant the allowlist exists to hold (ADR-0027).
+
+  A closed set of resolver hosts - `doi.org`, `dx.doi.org`, `hdl.handle.net`, each
+  measured issuing a single 302 straight to the publisher - is now **transparent**:
+  followed, but never allowlisted, never named as remediation, never counted as the
+  source of the content. Matching is exact, not the usual suffix-glob, because
+  `*.doi.org` would sweep in `www.doi.org` (the DOI Foundation's website, not a
+  resolver) and `evil-doi.org` is what an attacker registers. The host that actually
+  serves the response is adjudicated exactly as before. See ADR-0053.
+
+  This does **not** manufacture access. `10.1002/pcn5.205` now reaches Wiley and
+  meets Wiley's own cookie wall; it fails honestly at the publisher instead of
+  dishonestly at the addressing layer.
+
+  There were **five** gates asking this question and only one had ever been walked
+  end to end - #462's point exactly. They now share one predicate,
+  `SourceAllowlist::permits`, and a posture-lint step fails any gate that calls
+  `matches` on a host variable, so a sixth cannot be added without the fifth's
+  lesson.
+
 - **[mcp]** `doiget_paper_search` returning nothing now says whether that is about
   the query or about the literature. OpenAlex free-text matching degrades sharply
   past roughly eight terms and returns **nothing** rather than a partial match; a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.5"
+version = "0.8.13-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.5"
+version = "0.8.13-beta.6"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.5"
+version = "0.8.13-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.5"
+version       = "0.8.13-beta.6"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.5" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.5" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.5" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.6" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.6" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.6" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -239,7 +239,7 @@ const TRANSPARENT_RESOLVER_HOSTS: &[&str] = &["doi.org", "dx.doi.org", "hdl.hand
 
 /// Whether `host` is a DOI resolver rather than a content host (#533).
 ///
-/// Exact match against [`TRANSPARENT_RESOLVER_HOSTS`], deliberately without
+/// Exact match against `TRANSPARENT_RESOLVER_HOSTS`, deliberately without
 /// wildcard support: `evil-doi.org`, `doi.org.evil.test` and `www.doi.org`
 /// are all NOT resolvers, and the first two are what an attacker would
 /// register.
@@ -1764,10 +1764,10 @@ mod tests {
 
     /// Exact hosts, no wildcards. `*.doi.org` would sweep in `www.doi.org`,
     /// which is the DOI Foundation's website and not a resolver, plus
-    /// whatever else is ever stood up there; and the look-alikes below are
+    /// whatever else is ever stood up there; and the impostor hosts below are
     /// precisely what an attacker registers.
     #[test]
-    fn resolver_lookalikes_are_not_transparent() {
+    fn resolver_impostor_hosts_are_not_transparent() {
         for host in [
             "doi.org",
             "dx.doi.org",

--- a/crates/doiget-core/src/http.rs
+++ b/crates/doiget-core/src/http.rs
@@ -173,6 +173,80 @@ impl SourceAllowlist {
             .iter()
             .any(|pat| host_matches_pattern(&host_lc, pat))
     }
+
+    /// Returns `true` if a request to `host` may proceed under this
+    /// allowlist: either it is on the list, or it is a transparent DOI
+    /// resolver ([`is_transparent_resolver`]).
+    ///
+    /// **This, not [`matches`](Self::matches), is what an adjudication site
+    /// calls.** `matches` answers "is this host on the list", which is a
+    /// question about the list; `permits` answers "may we go here", which is
+    /// the question every gate is actually asking. Keeping them separate
+    /// means the resolver set is not silently reported as part of any
+    /// source's `expected_hosts`.
+    ///
+    /// The four adjudication sites (the pre-fetch OA-URL check in
+    /// `orchestrator`, the two redirect-policy closures, and `probe`) all
+    /// route through here so they cannot disagree -- #533 was found because
+    /// only one of them was ever walked end to end.
+    #[must_use]
+    pub fn permits(&self, host: &str) -> bool {
+        is_transparent_resolver(host) || self.matches(host)
+    }
+}
+
+/// Hosts that are addressing, not hosting.
+///
+/// `doi.org` is the indirection layer every DOI passes through, and
+/// Unpaywall routinely reports it AS the OA location: for the gold cc-by
+/// paper in #533, `best_oa_location.url` is literally
+/// `https://doi.org/10.1002/pcn5.205` with no `url_for_pdf`. Adjudicating
+/// that hop as if it were a content host had two consequences, both wrong:
+///
+///   * the chain was refused at the FIRST hop, before it ever reached the
+///     publisher -- whose host, `*.wiley.com`, was already on the list; and
+///   * the denial's remediation told the user to allowlist `doi.org`, which
+///     does not widen the trusted surface toward one publisher. It removes
+///     the bound entirely, because every DOI in existence resolves through
+///     it. An agent following that advice would get the PDF and silently
+///     lose the invariant the allowlist exists to hold (ADR-0027).
+///
+/// These hosts are therefore FOLLOWED but never allowlisted, never named as
+/// remediation, and never counted as the source of the content. The host
+/// that actually serves the bytes is adjudicated exactly as before, so this
+/// is transparent to the invariant rather than an exception to it.
+///
+/// # Why a closed set and not "the terminal host"
+///
+/// #533's first suggestion was to adjudicate only the final host of a
+/// chain. That is a bigger change than it looks: it would let a chain
+/// traverse ANY host so long as it ended somewhere allowed, and every hop
+/// still sees the request. A named, closed set of resolvers keeps the bound.
+///
+/// # Why exact hosts and no wildcards
+///
+/// `*.doi.org` would sweep in `www.doi.org`, which is the DOI Foundation's
+/// website, not a resolver -- and any other subdomain the Foundation ever
+/// stands up. Each entry here is a host measured to 302 straight to the
+/// publisher (2026-08-30, `10.1002/pcn5.205`):
+///
+/// | host | what it is |
+/// |---|---|
+/// | `doi.org` | the canonical DOI resolver |
+/// | `dx.doi.org` | its long-standing alias, still in live metadata |
+/// | `hdl.handle.net` | the Handle System resolver `doi.org` proxies |
+const TRANSPARENT_RESOLVER_HOSTS: &[&str] = &["doi.org", "dx.doi.org", "hdl.handle.net"];
+
+/// Whether `host` is a DOI resolver rather than a content host (#533).
+///
+/// Exact match against [`TRANSPARENT_RESOLVER_HOSTS`], deliberately without
+/// wildcard support: `evil-doi.org`, `doi.org.evil.test` and `www.doi.org`
+/// are all NOT resolvers, and the first two are what an attacker would
+/// register.
+#[must_use]
+pub fn is_transparent_resolver(host: &str) -> bool {
+    let host_lc = host.to_ascii_lowercase();
+    TRANSPARENT_RESOLVER_HOSTS.contains(&host_lc.as_str())
 }
 
 /// Returns `true` if `host` (already lowercased) matches `pattern` per
@@ -955,7 +1029,7 @@ impl HttpClient {
             .ok_or_else(|| HttpError::UnknownSource {
                 source_key: source.to_string(),
             })?;
-        if !allow.matches(&host) {
+        if !allow.permits(&host) {
             return Err(HttpError::RedirectDenied {
                 source_key: source.to_string(),
                 host,
@@ -1271,7 +1345,7 @@ fn build_client_allow_http(allowlist: SourceAllowlist) -> Result<Client, reqwest
                 });
             }
         };
-        if !allowlist_for_closure.matches(&host) {
+        if !allowlist_for_closure.permits(&host) {
             return attempt.error(HttpError::RedirectDenied {
                 source_key: allowlist_for_closure.source.clone(),
                 host,
@@ -1467,7 +1541,7 @@ fn build_client(allowlist: SourceAllowlist, ua: &str) -> Result<Client, reqwest:
                 });
             }
         };
-        if !allowlist_for_closure.matches(&host) {
+        if !allowlist_for_closure.permits(&host) {
             return attempt.error(HttpError::RedirectDenied {
                 source_key: allowlist_for_closure.source.clone(),
                 host,
@@ -1647,6 +1721,93 @@ mod tests {
     /// wildcard does not match an apex, and the redirect that motivated
     /// #405 (10.1109/access.2024.3495502, IEEE Access gold OA) targeted the
     /// bare apex.
+    /// #533, reproduced against the REAL allowlist rather than a fixture.
+    ///
+    /// Harada & Kato 2024 is gold OA, cc-by, and Unpaywall's
+    /// `best_oa_location.url` for it is literally `https://doi.org/10.1002/
+    /// pcn5.205` with no `url_for_pdf` (verified against the live API,
+    /// 2026-08-30). The chain was refused at that first hop -- while
+    /// `*.wiley.com`, where it lands, was already on the list.
+    #[test]
+    fn a_doi_resolver_hop_is_permitted_without_being_allowlisted() {
+        let lists = oa_publisher_allowlist();
+        let oa = lists
+            .iter()
+            .find(|a| a.source == "oa-publisher")
+            .expect("oa-publisher entry");
+
+        // The two questions stay distinct: a resolver is permitted, but it is
+        // NOT on the list and must never be reported as if it were.
+        assert!(oa.permits("doi.org"), "the hop the report was refused at");
+        assert!(
+            !oa.matches("doi.org"),
+            "a resolver must not be ON the allowlist -- `expected_hosts` is \
+             shown to the user as what to trust, and doi.org is every DOI"
+        );
+        assert!(
+            !oa.redirect_hosts.iter().any(|h| h.contains("doi.org")),
+            "and it must not leak into the expected-host list: {:?}",
+            oa.redirect_hosts
+        );
+
+        // The host the chain actually lands on was trusted all along. This is
+        // what makes the refusal a layer error rather than a missing entry.
+        assert!(
+            oa.permits("onlinelibrary.wiley.com"),
+            "the publisher was already covered by *.wiley.com: {:?}",
+            oa.redirect_hosts
+        );
+
+        // And the gate still gates.
+        assert!(!oa.permits("evil.example.com"));
+    }
+
+    /// Exact hosts, no wildcards. `*.doi.org` would sweep in `www.doi.org`,
+    /// which is the DOI Foundation's website and not a resolver, plus
+    /// whatever else is ever stood up there; and the look-alikes below are
+    /// precisely what an attacker registers.
+    #[test]
+    fn resolver_lookalikes_are_not_transparent() {
+        for host in [
+            "doi.org",
+            "dx.doi.org",
+            "hdl.handle.net",
+            "DOI.ORG",
+            "Dx.Doi.Org",
+        ] {
+            assert!(is_transparent_resolver(host), "{host} is a resolver");
+        }
+        for host in [
+            "www.doi.org",
+            "doi.org.evil.test",
+            "evil-doi.org",
+            "notdoi.org",
+            "a.doi.org",
+            "handle.net",
+            "",
+        ] {
+            assert!(!is_transparent_resolver(host), "{host} is NOT a resolver");
+        }
+    }
+
+    /// Transparency is a property of the resolver, not of one source: a
+    /// resolver hop is addressing wherever it appears.
+    #[test]
+    fn every_tier_1_source_treats_a_resolver_hop_as_addressing() {
+        for a in tier_1_allowlist() {
+            assert!(
+                a.permits("doi.org"),
+                "source {} refuses the addressing layer",
+                a.source
+            );
+            assert!(
+                !a.matches("doi.org"),
+                "source {} lists a resolver as a content host",
+                a.source
+            );
+        }
+    }
+
     #[test]
     fn doaj_is_on_the_default_oa_publisher_allowlist() {
         let lists = oa_publisher_allowlist();
@@ -2323,7 +2484,10 @@ mod tests {
                     });
                 }
             };
-            if !allowlist_for_closure.matches(&h) {
+            // `permits`, mirroring production: this closure is a local copy
+            // of `build_client`'s policy, and a copy that adjudicates
+            // differently tests something that does not ship (#533).
+            if !allowlist_for_closure.permits(&h) {
                 return attempt.error(HttpError::RedirectDenied {
                     source_key: allowlist_for_closure.source.clone(),
                     host: h,

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -2290,7 +2290,10 @@ async fn try_fetch_oa_pdf(
             .host_str()
             .map(|h| h.to_ascii_lowercase())
             .unwrap_or_default();
-        if !allowlist.matches(&host) {
+        // `permits`, not `matches`: a DOI resolver is addressing, not a
+        // content host, and Unpaywall routinely reports `doi.org` AS the OA
+        // location (#533). See `http::is_transparent_resolver`.
+        if !allowlist.permits(&host) {
             let e = HttpError::RedirectDenied {
                 source_key: SOURCE.to_string(),
                 host: host.clone(),

--- a/docs/DECISIONS/0053-doi-resolvers-are-addressing.md
+++ b/docs/DECISIONS/0053-doi-resolvers-are-addressing.md
@@ -1,0 +1,102 @@
+# 0053 - A DOI resolver is addressing, not hosting
+
+- **Date:** 2026-08-30
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0027](0027-redirect-allowlist-society-hosts.md) — answers a layer question 0027 never had to ask, and [0039](0039-publisher-hosts-stay-off-allowlist.md), which decided the adjacent case the other way for the same reason
+- **Source:** #533 (a gold-OA cc-by paper refused at `doi.org`, one hop before an already-allowlisted publisher)
+
+## Context
+
+`doiget fetch 10.1002/pcn5.205` — Harada & Kato 2024, **gold OA, cc-by** — was
+refused:
+
+```
+redirect target doi.org not in allowlist for source oa-publisher
+```
+
+with a remediation offering `doi.org` and `*.doi.org` as hosts to add.
+
+This is not an incomplete list. It is a gate applied at the wrong layer.
+
+Unpaywall reports `best_oa_location.url` for this work as literally
+`https://doi.org/10.1002/pcn5.205`, with no `url_for_pdf` (verified against the
+live API, 2026-08-30). That is not unusual — it is the normal shape for
+publisher-hosted gold OA. So the very first host doiget touches on the fetch leg
+is the DOI resolver, and it was being adjudicated as though it were the place
+the bytes come from. The chain was refused before it ever reached
+`onlinelibrary.wiley.com`, whose `*.wiley.com` was already on the list.
+
+The offered remediation is worse than the refusal. ADR-0027 justifies the
+built-in list as *bounded* registrable-domain wildcards for established
+publishers and repositories, and the list contains exactly that — no resolvers.
+Adding `doi.org` would not widen the trusted surface toward one publisher. It
+would remove the bound entirely, because **every DOI in existence resolves
+through it**. An agent following that advice gets its PDF and silently loses the
+invariant the allowlist exists to hold.
+
+ADR-0039 refused to add IEEE/ACM/SIAM/AMS to `oa-publisher` because those are
+content hosts and the ADR would not widen the content surface. The same
+principle decides this case the opposite way, and for the same reason: a
+resolver is not a content host at all, so making it followable widens nothing.
+
+Three recent bugs share this shape — #503 (europe-pmc refused on a flag before
+consulting the URL list), #516 (a Tier-2 gate keyed on the wrong feature), and
+this one. #462 names why they survive review: *"every 'unreachable source' bug
+passed its unit tests."* The allowlist matcher here is correct in isolation; the
+defect only appears once `unpaywall → doi.org → wiley` is actually walked.
+
+## Decision
+
+**A closed set of DOI resolver hosts is transparent to host adjudication.** They
+are followed, but never allowlisted, never named as remediation, and never
+counted as the source of the content.
+
+```
+doi.org          the canonical DOI resolver
+dx.doi.org       its long-standing alias, still present in live metadata
+hdl.handle.net   the Handle System resolver doi.org proxies
+```
+
+Each was measured issuing a single 302 straight to the publisher (2026-08-30,
+`10.1002/pcn5.205`).
+
+Three constraints on that set:
+
+1. **Exact hosts, no wildcards.** `*.doi.org` would sweep in `www.doi.org` —
+   the DOI Foundation's website, not a resolver — and anything else ever stood
+   up there. `evil-doi.org` and `doi.org.evil.test` are what an attacker
+   registers.
+2. **The host that serves the bytes is adjudicated exactly as before.** This is
+   transparent to the ADR-0027 invariant, not an exception to it.
+3. **One predicate, not five gates.** `SourceAllowlist::permits` is what every
+   adjudication site calls; `matches` remains the narrower "is this host on the
+   list" used to build and assert the lists themselves. A resolver is therefore
+   never reported inside any source's `expected_hosts`.
+
+### Rejected: adjudicate only the terminal host
+
+#533's first suggestion. It is a larger change than it appears: a chain could
+traverse *any* host so long as it ended somewhere allowed, and every hop still
+observes the request. A named, closed set keeps the bound while fixing the
+reported class.
+
+### Rejected: allowlist `doi.org`
+
+The remediation the tool was emitting. Mechanically effective, semantically
+wrong, and it deletes the invariant — see Context.
+
+## Consequences
+
+- Publisher-hosted gold OA whose Unpaywall location is a `doi.org` URL is
+  reachable. This is a whole class, not one paper.
+- No new content host is trusted. The set contains no host that serves papers.
+- A denial now names the host the user would actually have to trust, because a
+  resolver hop can no longer produce one.
+- **This does not promise a PDF.** `10.1002/pcn5.205` reaches Wiley and then
+  meets Wiley's own cookie wall (`/action/cookieAbsent`). That is a publisher
+  posture question — ADR-0039's territory — and it fails honestly at the
+  publisher rather than dishonestly at the addressing layer. The fix removes a
+  wrong refusal; it does not manufacture access.
+- A posture-lint step fails any adjudication site that calls `matches` on a host
+  variable, so the fifth gate cannot be added without the fourth's lesson.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -69,6 +69,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0050 | credentials.toml carries the key; the agreement stays in the environment | Accepted | `feat/509-credentials-file` | #509 |
 | 0051 | Contributions carry a relicensable grant, recorded as a commit sign-off | Accepted | `chore/cla-relicensing-grant` | - |
 | 0052 | Crossref `link[]` is programme-scoped, so the fetch path does not carry it | Accepted | `feat/517-publisher-candidate` | #517 |
+| 0053 | A DOI resolver is addressing, not hosting | Accepted | `fix/533-resolver-hop-is-addressing` | #533 |
 
 ## Conventions
 

--- a/docs/REDIRECT_ALLOWLIST.md
+++ b/docs/REDIRECT_ALLOWLIST.md
@@ -74,6 +74,42 @@ redirect_hosts = [
 
 The exact list of entries is given in §3.
 
+### 2.4 Transparent DOI resolvers (NORMATIVE)
+
+A small, closed set of hosts is **addressing, not hosting**, and is exempt from
+the rule in §2.2:
+
+| host | what it is |
+|---|---|
+| `doi.org` | the canonical DOI resolver |
+| `dx.doi.org` | its long-standing alias, still present in live metadata |
+| `hdl.handle.net` | the Handle System resolver `doi.org` proxies |
+
+These are **followed** but MUST NOT be added to any source's entry, MUST NOT
+appear in a denial's `expected` list, and MUST NOT be offered as remediation.
+The host that actually serves the response is adjudicated exactly as it would be
+otherwise, so this is transparent to §1's invariant rather than an exception to
+it.
+
+Matching is **exact**, not the §2.2 suffix-glob. `*.doi.org` would sweep in
+`www.doi.org`, which is the DOI Foundation's website and not a resolver;
+`evil-doi.org` and `doi.org.evil.test` are what an attacker registers.
+
+**Why this rule exists.** Unpaywall routinely reports a `doi.org` URL as
+`best_oa_location.url` for publisher-hosted gold OA — for `10.1002/pcn5.205` it
+is the *only* location, with no `url_for_pdf`. Adjudicating that first hop as a
+content host refused a cc-by paper one hop before the publisher that was already
+on the list, and the denial then advised adding `doi.org`, which does not widen
+the trusted surface toward one publisher: it removes the bound entirely, because
+every DOI resolves through it. See [ADR-0053](DECISIONS/0053-doi-resolvers-are-addressing.md)
+and #533.
+
+**Enforced by:** `http::is_transparent_resolver`, reached through
+`SourceAllowlist::permits` — the predicate every adjudication site calls.
+`SourceAllowlist::matches` remains the narrower "is this host on the list"
+question and is used only to build and assert the lists. A posture-lint step
+fails any gate that calls `matches` on a host variable.
+
 ## 3. Tier 1 entries
 
 The entries below are the binding redirect-host allowlist for the Tier 1

--- a/site/content/developer/redirect-allowlist.md
+++ b/site/content/developer/redirect-allowlist.md
@@ -80,6 +80,42 @@ redirect_hosts = [
 
 The exact list of entries is given in §3.
 
+### 2.4 Transparent DOI resolvers (NORMATIVE)
+
+A small, closed set of hosts is **addressing, not hosting**, and is exempt from
+the rule in §2.2:
+
+| host | what it is |
+|---|---|
+| `doi.org` | the canonical DOI resolver |
+| `dx.doi.org` | its long-standing alias, still present in live metadata |
+| `hdl.handle.net` | the Handle System resolver `doi.org` proxies |
+
+These are **followed** but MUST NOT be added to any source's entry, MUST NOT
+appear in a denial's `expected` list, and MUST NOT be offered as remediation.
+The host that actually serves the response is adjudicated exactly as it would be
+otherwise, so this is transparent to §1's invariant rather than an exception to
+it.
+
+Matching is **exact**, not the §2.2 suffix-glob. `*.doi.org` would sweep in
+`www.doi.org`, which is the DOI Foundation's website and not a resolver;
+`evil-doi.org` and `doi.org.evil.test` are what an attacker registers.
+
+**Why this rule exists.** Unpaywall routinely reports a `doi.org` URL as
+`best_oa_location.url` for publisher-hosted gold OA — for `10.1002/pcn5.205` it
+is the *only* location, with no `url_for_pdf`. Adjudicating that first hop as a
+content host refused a cc-by paper one hop before the publisher that was already
+on the list, and the denial then advised adding `doi.org`, which does not widen
+the trusted surface toward one publisher: it removes the bound entirely, because
+every DOI resolves through it. See [ADR-0053](DECISIONS/0053-doi-resolvers-are-addressing.md)
+and #533.
+
+**Enforced by:** `http::is_transparent_resolver`, reached through
+`SourceAllowlist::permits` — the predicate every adjudication site calls.
+`SourceAllowlist::matches` remains the narrower "is this host on the list"
+question and is used only to build and assert the lists. A posture-lint step
+fails any gate that calls `matches` on a host variable.
+
 ## 3. Tier 1 entries
 
 The entries below are the binding redirect-host allowlist for the Tier 1


### PR DESCRIPTION
Closes #533.

## The problem

`doiget fetch 10.1002/pcn5.205` — Harada & Kato 2024, **gold OA, cc-by** — is refused:

```
redirect target doi.org not in allowlist for source oa-publisher
```

…and the denial offers `doi.org` / `*.doi.org` as hosts to add.

This is not a missing entry. It is a gate applied at the wrong layer.

I verified the premise against the live API rather than assuming it:

```
$ curl -s "https://api.unpaywall.org/v2/10.1002/pcn5.205?email=…"
is_oa       : True
oa_status   : gold
license     : cc-by
url         : https://doi.org/10.1002/pcn5.205
url_for_pdf : None
host_type   : publisher
```

Unpaywall's OA location for this work **is** a `doi.org` URL, with no `url_for_pdf`. That is the normal shape for publisher-hosted gold OA, not an edge case — so the first host the fetch leg touches is the DOI resolver, and it was adjudicated as if it were where the bytes come from. The chain died one hop before `onlinelibrary.wiley.com`, whose `*.wiley.com` was **already on the list**.

```
$ curl -sIL https://doi.org/10.1002/pcn5.205
302 → https://onlinelibrary.wiley.com/doi/10.1002/pcn5.205
```

## Why the offered remediation was worse than the refusal

Adding `doi.org` to `[[network.additional_hosts]]` does not widen the trusted surface toward one publisher. It removes the bound entirely, because **every DOI in existence resolves through it**. An agent following that advice gets its PDF and silently loses the invariant ADR-0027 exists to hold.

## The fix

A closed set is **transparent** to host adjudication — followed, but never allowlisted, never named as remediation, never counted as the source of the content:

| host | what it is |
|---|---|
| `doi.org` | the canonical DOI resolver |
| `dx.doi.org` | its long-standing alias, still in live metadata |
| `hdl.handle.net` | the Handle System resolver `doi.org` proxies |

Each measured issuing a single 302 straight to the publisher (2026-08-30). The host that actually serves the response is adjudicated exactly as before, so this is transparent to the invariant rather than an exception to it.

**Exact match, no wildcards.** `*.doi.org` would sweep in `www.doi.org` — the DOI Foundation's website, not a resolver — and `evil-doi.org` / `doi.org.evil.test` are what an attacker registers.

### Rejected: adjudicate only the terminal host

#533's first suggestion, and a larger change than it looks: a chain could traverse *any* host so long as it ended somewhere allowed, and every hop still observes the request. A named, closed set fixes the reported class while keeping the bound.

### Consistent with ADR-0039

ADR-0039 refused to add IEEE/ACM/SIAM/AMS because those are content hosts. The same principle decides this case the other way, for the same reason: a resolver is not a content host at all, so making it followable widens nothing. ADR-0053 records it.

## What this does not do

**It does not manufacture access.** `10.1002/pcn5.205` now reaches Wiley and meets Wiley's own cookie wall (`/action/cookieAbsent`) — publisher-posture territory, ADR-0039's. The fix removes a wrong refusal; it does not promise the PDF. Stated in the ADR and the CHANGELOG too, so nobody reads this as a capability claim.

## Five gates, one predicate

The bug was in a gate — and there were **five** asking the same question:

1. the pre-fetch OA-URL check in `orchestrator` (the one that fired here)
2. the production redirect-policy closure
3. the `allow_http` test-client closure
4. `probe`
5. **a test-local copy of the production redirect policy**, which had already drifted into testing something that does not ship

I found #5 only by grepping after fixing the first four. That is #462's point verbatim: *"every 'unreachable source' bug passed its unit tests."*

All five now call `SourceAllowlist::permits`. `matches` stays the narrower "is this host on the list", used only to build and assert the lists — which is what keeps a resolver out of any source's `expected_hosts`. A **posture-lint step** fails any gate that calls `matches` on a host variable (the discriminator: gates pass a variable, list assertions pass a literal). Mutation-checked: reverting one gate makes the lint fail with the file and line.

## Tests

Against the **real production allowlists**, not fixtures:

- `permits("doi.org")` — the hop the report died on — while `matches("doi.org")` is false and `doi.org` appears nowhere in `redirect_hosts`. The two questions stay distinct, which is what stops it leaking into `expected`.
- `permits("onlinelibrary.wiley.com")` — trusted all along. This is what makes it a layer error rather than a missing entry.
- `permits("evil.example.com")` is still false.
- Look-alikes: `www.doi.org`, `doi.org.evil.test`, `evil-doi.org`, `notdoi.org`, `a.doi.org`, `handle.net`, `""` are all rejected; `DOI.ORG` / `Dx.Doi.Org` accepted (case-insensitive).
- Every Tier-1 source treats a resolver hop as addressing — transparency is a property of the resolver, not of one source.

**Coverage limit, stated plainly:** the transparent set is real hostnames, so a wiremock chain cannot exercise the closure end to end without outbound network, which the posture lint forbids. The tests therefore pin the predicate the production gates call, and the lint pins that they all call it. A full `unpaywall → doi.org → wiley` walk stays a manual check — which is exactly how this bug was found, and why #462 is still open.

Local: fmt, clippy `-D warnings`, full workspace suite (47 suites, 0 failures), `version-bump-gate.sh`.
