### PR TITLE
feat(cli): the found-nothing fetch says what it consulted (#505 parts 1-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,40 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   answers `initialize` as `doiget 0.8.12` and lists 22 tools, with pure JSON-RPC on
   stdout and zero bytes on stderr.
 
+### Added
+
+- **[cli]** The found-nothing fetch now reports what it consulted. Previously
+  `fetched ... (metadata-only: no OA PDF available)` was byte-identical whether
+  the optional sources were on and had nothing or off and never asked - and it
+  exits 0, so unlike the blocked path there was no `error[...]` block for the
+  #413 trace to hang on. It is the one outcome that reads as a *result*, which is
+  where the silence misleads most: with the default profile that sentence means
+  only "three of eleven sources had nothing" (#505).
+
+  It now prints the same attempt trace the blocked and NOT_FOUND paths already
+  print, plus the command that widens the search - the line to paste, not prose
+  about it:
+
+  ```
+    = suggest: to widen the search:
+        DOIGET_ENABLE_HAL=1 DOIGET_ENABLE_CORE=1 doiget fetch 10.1137/0117004
+  ```
+
+  The variables come from the `Disabled` rows themselves rather than a second
+  registry, so the advice cannot claim a source was skipped when it was
+  consulted, or name a switch the chain does not read.
+
+  A switch that is **already set** is reported as a build problem instead:
+  `resolve_metadata_flag` returns false when the variable is set but the Cargo
+  feature was not compiled in, so the source still reports `Disabled` naming a
+  variable the user set an hour ago. Telling them to set it again would be the
+  same species of unhelpful as the bare `no OA PDF available`.
+
+  Part 3 of #505 - ranking which source is most likely to hold the paper - is
+  deliberately not here. The issue makes the case that a wrong ranking is worse
+  than none because it makes people stop early, and that deserves its own change.
+  #505 stays open for it.
+
 ### Fixed
 
 - **[mcp]** `oa_url` was documented as an OA URL "for the caller to act on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.7"
+version = "0.8.13-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.7"
+version = "0.8.13-beta.8"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.7"
+version = "0.8.13-beta.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.6"
+version = "0.8.13-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.6"
+version = "0.8.13-beta.7"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.6"
+version = "0.8.13-beta.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.7"
+version       = "0.8.13-beta.8"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.7" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.7" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.7" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.8" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.8" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.8" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.6"
+version       = "0.8.13-beta.7"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.6" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.6" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.6" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.7" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.7" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.7" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -596,6 +596,15 @@ fn emit_success_line(ref_: &Ref, outcome: &FetchPaperOutcome) {
                 "fetched {} (metadata-only: no OA PDF available) -> {}",
                 label, outcome.path
             ));
+            // #505: this is the ONLY outcome that reads as a result rather
+            // than an error, which is why it had no trace -- there was no
+            // `error[...]` block to hang one on. It is also the one where the
+            // absence misleads most: the line above is byte-identical whether
+            // the optional sources were on and had nothing, or off and never
+            // asked.
+            for line in not_found_trace_lines(ref_, &outcome.attempts) {
+                print_err(format_args!("{line}"));
+            }
         }
         // Issue #325: publisher PDF was blocked, arXiv preprint auto-fetched.
         PdfLegStatus::PreprintFallback { arxiv_id, .. } => {
@@ -1259,6 +1268,64 @@ fn render_blocked_error(
 /// indication that none of the five had been consulted.
 ///
 /// Pure so the wording is asserted rather than assumed.
+/// The diagnostics for a found-nothing fetch (#505).
+///
+/// `no OA PDF available` means only "the sources that ran had nothing". With
+/// the default profile that is three of eleven, and the sentence does not say
+/// so -- #413 built the trace for exactly this distinction ("we asked and it
+/// had nothing" versus "we never asked") and this was the path it never
+/// reached.
+///
+/// Three blocks: what ran, what did not, and the line to paste.
+fn not_found_trace_lines(ref_: &Ref, attempts: &[SourceAttempt]) -> Vec<String> {
+    let mut out = Vec::new();
+    if attempts.is_empty() {
+        return out;
+    }
+
+    out.push("  = note: no OA copy found. sources this run:".to_string());
+    out.extend(
+        doiget_core::orchestrator::render_attempts(attempts)
+            .lines()
+            .map(|l| format!("  {l}")),
+    );
+
+    // Split the widening advice by whether it can actually be acted on.
+    //
+    // `resolve_metadata_flag` returns false when the variable IS set but the
+    // Cargo feature was not compiled in -- it warns through `tracing` and
+    // moves on, so the source reports `Disabled` naming a variable the user
+    // has already set. Printing "set DOIGET_ENABLE_X" at someone who set it
+    // an hour ago is the same species of unhelpful as the bare
+    // `no OA PDF available` this issue is about, so say which case it is.
+    let (unset, already_set): (Vec<_>, Vec<_>) = doiget_core::orchestrator::widening_env(attempts)
+        .into_iter()
+        .partition(|v| std::env::var_os(v).is_none());
+
+    if !unset.is_empty() {
+        let assignments = unset
+            .iter()
+            .map(|v| format!("{v}=1"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let target = match ref_ {
+            Ref::Arxiv(id) => id.as_str().to_string(),
+            Ref::Doi(doi) => doi.as_str().to_string(),
+        };
+        out.push("  = suggest: to widen the search:".to_string());
+        out.push(format!("      {assignments} doiget fetch {target}"));
+    }
+
+    if !already_set.is_empty() {
+        out.push(format!(
+            "  = note: {} already set, but the source is still off -- this              binary was built without the Cargo feature that provides it.              Widening needs a differently-built binary, not another variable.",
+            already_set.join(", ")
+        ));
+    }
+
+    out
+}
+
 fn blocked_trace_lines(attempts: &[SourceAttempt], message: &str) -> Vec<String> {
     let mut out = Vec::new();
     // A rate limit is the one failure where retrying the same host later is
@@ -2225,6 +2292,93 @@ host = "*.uj.edu.pl"
 
     /// The half of #445 that the #413 trace already answered for
     /// `NotFound`: *did anything else have it?*
+    /// #505: the found-nothing path is the one outcome that reads as a
+    /// result, so its silence is the most misleading. `no OA PDF available`
+    /// is byte-identical whether the optional sources were on and had
+    /// nothing or off and never asked.
+    #[test]
+    fn a_found_nothing_fetch_says_what_it_consulted_and_what_it_did_not() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        let ref_ = Ref::parse("10.1137/0117004").expect("valid doi");
+        let attempts = vec![
+            SourceAttempt::new("unpaywall", AttemptOutcome::NoRecord),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_HAL"],
+                },
+            ),
+        ];
+        let joined = not_found_trace_lines(&ref_, &attempts).join(
+            "
+",
+        );
+
+        assert!(
+            joined.contains("unpaywall") && joined.contains("no record"),
+            "what ran, and what it said:
+{joined}"
+        );
+        assert!(
+            joined.contains("DOIGET_ENABLE_HAL"),
+            "a source never asked must still name its switch:
+{joined}"
+        );
+        // The line to paste, not prose about it.
+        assert!(
+            joined.contains("DOIGET_ENABLE_HAL=1 doiget fetch 10.1137/0117004"),
+            "the widening command must be runnable as printed:
+{joined}"
+        );
+    }
+
+    /// No trace at all when there is nothing to say. An empty attempt list
+    /// means the chain never recorded anything, and inventing a block for it
+    /// would be noise on the one path users see most.
+    #[test]
+    fn no_attempts_means_no_found_nothing_trace() {
+        let ref_ = Ref::parse("10.1137/0117004").expect("valid doi");
+        assert!(not_found_trace_lines(&ref_, &[]).is_empty());
+    }
+
+    /// The advice has to be actionable to be worth printing.
+    ///
+    /// `resolve_metadata_flag` returns false when the variable is SET but the
+    /// Cargo feature was not compiled in, so the source still reports
+    /// `Disabled` naming a variable the user already set. Telling them to set
+    /// it again is the same species of unhelpful as the bare
+    /// `no OA PDF available` this issue is about.
+    #[test]
+    #[serial]
+    fn an_already_set_switch_is_reported_as_a_build_problem_not_a_config_one() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        let _guard = EnvGuard::save("DOIGET_ENABLE_HAL");
+        std::env::set_var("DOIGET_ENABLE_HAL", "1");
+
+        let ref_ = Ref::parse("10.1137/0117004").expect("valid doi");
+        let attempts = vec![SourceAttempt::new(
+            "hal",
+            AttemptOutcome::Disabled {
+                env: &["DOIGET_ENABLE_HAL"],
+            },
+        )];
+        let joined = not_found_trace_lines(&ref_, &attempts).join(
+            "
+",
+        );
+
+        assert!(
+            !joined.contains("doiget fetch 10.1137/0117004"),
+            "must NOT tell them to set what they have already set:
+{joined}"
+        );
+        assert!(
+            joined.contains("built without"),
+            "must name the real blocker, which is the build:
+{joined}"
+        );
+    }
+
     #[test]
     fn a_blocked_leg_reports_which_other_sources_were_consulted() {
         use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4177,6 +4177,48 @@ mod tests {
         assert!(extract_metadata_authors(&json!({"x": 1})).is_empty());
         assert!(extract_metadata_authors(&json!({"authors": []})).is_empty());
     }
+    /// #505: the widening advice is derived from the trace, not from a
+    /// second registry, so it cannot claim a source was skipped when it was
+    /// consulted -- or name a variable the chain does not actually read.
+    #[test]
+    fn widening_env_is_deduped_and_in_chain_order() {
+        let attempts = vec![
+            SourceAttempt::new("crossref", AttemptOutcome::NoRecord),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_HAL"],
+                },
+            ),
+            SourceAttempt::new(
+                "tdm-aps",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_KEY_APS", "DOIGET_AGREE_TDM_APS"],
+                },
+            ),
+            // A second source behind the same switch must not repeat it.
+            SourceAttempt::new(
+                "hal-again",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_HAL"],
+                },
+            ),
+        ];
+        assert_eq!(
+            widening_env(&attempts),
+            vec![
+                "DOIGET_ENABLE_HAL",
+                "DOIGET_KEY_APS",
+                "DOIGET_AGREE_TDM_APS"
+            ],
+            "chain order, de-duplicated, and a consulted source contributes nothing"
+        );
+        // Nothing skipped means nothing to suggest.
+        assert!(
+            widening_env(&[SourceAttempt::new("crossref", AttemptOutcome::NoRecord)]).is_empty()
+        );
+        assert!(widening_env(&[]).is_empty());
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4447,6 +4489,29 @@ pub fn render_attempts(attempts: &[SourceAttempt]) -> String {
         .map(|a| format!("  {:<12} {}", a.source, a.outcome.render()))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Every environment variable the trace says would widen this search, in
+/// first-seen order and de-duplicated.
+///
+/// Built from the `Disabled` rows rather than from a separate registry, so
+/// it cannot drift from what the run actually skipped: a source that was
+/// consulted contributes nothing, and a source that was skipped contributes
+/// exactly the variables its own row already names.
+///
+/// Order is the chain's order, which is the order a user should set them in
+/// (`required_env` documents the same for the multi-variable Tier-3 case).
+#[must_use]
+pub fn widening_env(attempts: &[SourceAttempt]) -> Vec<&'static str> {
+    let mut seen = Vec::new();
+    for a in attempts {
+        for var in a.outcome.required_env().unwrap_or_default() {
+            if !seen.contains(var) {
+                seen.push(*var);
+            }
+        }
+    }
+    seen
 }
 
 /// True when no source in the trace was actually reached.


### PR DESCRIPTION
Refs #505 — **parts 1 and 2 of three.** Part 3 (ranking) is deliberately not here; see below. The issue stays open.

## The problem

Two paths, same command, measured in the issue:

| outcome | exit | trace rows |
|---|---|---|
| found but blocked | 3 | 6 |
| **found nothing** | **0** | **0** |

`fetched … (metadata-only: no OA PDF available)` is byte-identical whether the optional sources were on and had nothing or off and never asked. And it exits 0 — so unlike the blocked path there was no `error[…]` block for the #413 trace to hang on. That is precisely why this path, the only one that reads as a **result** rather than a failure, was the one with no diagnostics.

It is also where the silence costs most. With the default profile that sentence means "three of eleven sources had nothing", and it does not say so.

## Part 1 — what was consulted

The `NoOaUrl` arm now emits the same attempt trace the blocked and `NOT_FOUND` paths already emit, via the existing `render_attempts`. No new machinery: `FetchPaperOutcome.attempts` was already populated on this path and simply never read.

## Part 2 — the command that widens it

```
  = suggest: to widen the search:
      DOIGET_ENABLE_HAL=1 doiget fetch 10.1137/0117004
```

The line to paste, not prose about it. `orchestrator::widening_env` derives it **from the `Disabled` rows themselves**, not from a second registry — so it cannot claim a source was skipped when it was consulted, and cannot name a switch the chain does not read. Those rows have carried their own env vars since #470; nothing needed inventing.

### The advice has to be actionable to be worth printing

`resolve_metadata_flag` returns `false` when the variable **is set** but the Cargo feature was not compiled in. It warns through `tracing` — which nobody sees — and the source still reports `Disabled`, naming a variable the user set an hour ago.

Printing "set `DOIGET_ENABLE_X`" at that user would be the same species of unhelpful as the bare `no OA PDF available` this issue is about. So the two cases are split, and the already-set one names the real blocker:

```
  = note: DOIGET_ENABLE_HAL already set, but the source is still off — this
    binary was built without the Cargo feature that provides it. Widening needs
    a differently-built binary, not another variable.
```

## Part 3 — not in this PR, on purpose

The issue makes the case itself: *"a ranking that is wrong is worse than no ranking, because it makes people stop early"*, so it must be an ordering of the full list, never a shortlist, and must name the signal it ranked on — with item 1 (OpenAlex `locations`, a lookup) marked as categorically different from items 2+ (heuristics over metadata). That is a design worth its own change and its own review, not a rider on a diagnostics PR. #505 stays open for it.

## Tests

- The trace names both what ran (`unpaywall` / `no record`) and what did not (`DOIGET_ENABLE_HAL`).
- The widening command is asserted **runnable as printed** — `DOIGET_ENABLE_HAL=1 doiget fetch 10.1137/0117004` — not merely that the variable appears somewhere.
- With the variable already set: no command is printed, and the message names the build.
- Empty attempts produce no block at all, so the common path gains no noise.
- `widening_env` dedupes, preserves chain order, and a consulted source contributes nothing.

**One test caught during review.** `widening_env_is_deduped_and_in_chain_order` first landed in `mod attempt_denial_tests`, which is feature-gated — it compiled and silently did not run (`0 passed; 471 filtered out`). Moved into `mod tests`, where it does. Worth flagging given #462's theme.

Local: fmt, clippy `-D warnings`, full workspace suite (47 suites, 0 failures), rustdoc `-D warnings`, `version-bump-gate.sh`.
