### PR TITLE
fix(core): an access refusal was decided by substring, so rewording one reclassified it (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,33 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[core]** An access refusal was classified by reading an error message back.
+  A source saying "I found it and cannot give it to you" returned
+  `FetchError::SourceSchema` with an explanatory hint, and the orchestrator
+  decided what the trace row said by substring-matching that hint for
+  `not open access` / `openAccess` / `no retrievable PDF`. Match and the row
+  read *"found, not open access"*; miss and it read *"failed"* - which tells an
+  operator the source broke rather than that the paper is not free there (#538).
+
+  It had already fired. #503 reworded Europe PMC's refusal for good reasons, the
+  hint fell out of the predicate, and every Europe PMC refusal silently became
+  `Failed`. Nothing in the source said the wording was load-bearing, and `hal`
+  matched on `openAccess` - a JSON **field name**, not prose anyone chose.
+
+  Sources now return `FetchError::NotRetrievable { source_key, detail }` and the
+  classifier matches the variant. `is_access_refusal` is gone. The compiler
+  found a second exhaustive match the substring approach had no way to flag.
+
+  It collapses to the **existing** `NO_OA_AVAILABLE` rather than adding a wire
+  code: "found it, no free copy" is what that already means, so the closed set
+  in `docs/ERRORS.md` §3 does not widen. Its §2 description does - it said
+  "Tier 1 sources reported no OA URL" and now also covers an optional source
+  holding the record with nothing retrievable. See ADR-0054.
+
+  Side effect worth naming: `SourceSchema` collapses to `INTERNAL_ERROR`, so
+  until now a paper simply not being free at one repository could be reported as
+  a bug in doiget. It no longer is.
+
 - **[fetch]** A gold-OA, cc-by paper was refused at `doi.org`, one hop before the
   publisher whose host was already on the allowlist. Unpaywall reports
   `best_oa_location.url` for `10.1002/pcn5.205` as literally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.8"
+version = "0.8.13-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.8"
+version = "0.8.13-beta.9"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.8"
+version = "0.8.13-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.8"
+version       = "0.8.13-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.9" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.9" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.9" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -4541,15 +4541,15 @@ pub fn nothing_was_consulted(attempts: &[SourceAttempt]) -> bool {
 fn classify_attempt(e: &FetchError) -> AttemptOutcome {
     match e {
         FetchError::NotFound { .. } => AttemptOutcome::NoRecord,
-        // Sources signal "found it, cannot give it to you" through
-        // SourceSchema with an explicit hint (OpenAIRE access rights,
-        // Europe PMC isOpenAccess, HAL openAccess_bool). The hint is
-        // carried verbatim so the reason survives into the message.
-        FetchError::SourceSchema { hint } if is_access_refusal(hint) => {
-            AttemptOutcome::NotOpenAccess {
-                detail: hint.clone(),
-            }
-        }
+        // A source saying "found it, cannot give it to you" says so in the
+        // type now (#538). This used to be `SourceSchema` plus a substring
+        // search over the hint, which meant the phrasing of an error message
+        // decided how the row rendered -- and #503 reworded one and silently
+        // turned every Europe PMC refusal into `Failed`. The detail is still
+        // carried verbatim, because the reason is for a reader, not a match.
+        FetchError::NotRetrievable { detail, .. } => AttemptOutcome::NotOpenAccess {
+            detail: detail.clone(),
+        },
         // A policy refusal before the untyped fallback (#470). The
         // conversion already exists and yields exactly the reason /
         // attempted / expected / hop_index that `remediation::for_denial`
@@ -4745,38 +4745,6 @@ mod attempt_denial_tests {
             "row: {row}"
         );
     }
-}
-
-/// Whether a `SourceSchema` hint describes an access refusal rather than a
-/// malformed response.
-///
-/// The coupling is prose: a source says why it refused in free text and
-/// this reads the text back. That is fragile, and #503 is the proof — it
-/// reworded Europe PMC's refusal from "not open access" to "advertises no
-/// retrievable PDF" and the row silently reclassified from
-/// `NotOpenAccess` to `Failed`, which reads to an operator as "the source
-/// broke" rather than "the source has it and cannot give it to us".
-///
-/// It is caught rather than prevented: `an_access_refusal_is_recorded_
-/// distinctly_from_a_miss` drives the real chain, so any source whose
-/// wording drifts out of this predicate fails there. A typed refusal on
-/// `FetchError` would prevent it instead, at the cost of widening the
-/// closed error set in `docs/ERRORS.md` §3.
-#[cfg(any(
-    feature = "metadata",
-    feature = "tdm-elsevier",
-    feature = "tdm-aps",
-    feature = "tdm-springer",
-    feature = "tdm-ieee"
-))]
-fn is_access_refusal(hint: &str) -> bool {
-    hint.contains("not open access")
-        || hint.contains("openAccess")
-        // #503: Europe PMC refuses on "nothing retrievable is
-        // advertised", which is a strictly narrower claim than "outside
-        // the OA subset" and is still an access refusal, not a schema
-        // failure.
-        || hint.contains("no retrievable PDF")
 }
 
 /// Run the optional resolution chain and record one [`SourceAttempt`] per
@@ -5485,8 +5453,10 @@ mod chain_tests {
     ///
     /// This record carries no `fullTextUrlList` at all, so after #503 it is
     /// refused for the narrower reason and must still classify as
-    /// `NotOpenAccess` — see `is_access_refusal`, whose coupling to the
-    /// wording this test is the only thing guarding.
+    /// `NotOpenAccess`. Until #538 this test was the only thing guarding
+    /// that, because classification read the wording back out of the hint;
+    /// the refusal is a `FetchError::NotRetrievable` now, so the compiler
+    /// guards it and this asserts the behaviour rather than the phrasing.
     #[tokio::test]
     #[serial_test::serial]
     async fn an_access_refusal_is_recorded_distinctly_from_a_miss() {

--- a/crates/doiget-core/src/source.rs
+++ b/crates/doiget-core/src/source.rs
@@ -136,6 +136,35 @@ pub enum FetchError {
     /// source receives a borrowed string from upstream and re-validates).
     #[error("invalid ref: {0}")]
     InvalidRef(#[from] RefParseError),
+    /// A source found the record and **cannot supply a copy** — an access
+    /// refusal, not a failure.
+    ///
+    /// The distinction is the whole point: "the source has it and cannot
+    /// give it to us" and "the source broke" lead an operator to different
+    /// conclusions, and only the second is a bug to chase.
+    ///
+    /// This exists as a variant because it used to be a *substring search*.
+    /// A refusal was [`Self::SourceSchema`] with an explanatory hint, and
+    /// `orchestrator::is_access_refusal` read the hint back looking for
+    /// "not open access" / "openAccess" / "no retrievable PDF". #503
+    /// reworded Europe PMC's refusal for good reasons, the hint fell out of
+    /// that list, and every Europe PMC refusal silently became
+    /// `AttemptOutcome::Failed`. Nothing in the source said the wording was
+    /// load-bearing, and `hal` matched on `openAccess` — a JSON *field
+    /// name*, not prose anyone chose (#538).
+    ///
+    /// Collapses to [`crate::ErrorCode::NoOaAvailable`], which is an
+    /// EXISTING wire code: "found it, no free copy" is exactly what that
+    /// means, so the closed set in `docs/ERRORS.md` §3 does not widen. See
+    /// ADR-0054.
+    #[error("{source_key} has the record but no retrievable copy: {detail}")]
+    NotRetrievable {
+        /// Which source refused.
+        source_key: String,
+        /// Why, in the source's own terms — the flags or codes a reader
+        /// checks next. Displayed, never parsed: that is the point.
+        detail: String,
+    },
     /// Source-side schema mismatch (unexpected JSON shape, missing
     /// required field). Surfaces to [`crate::ErrorCode::InternalError`]
     /// at the public boundary.
@@ -234,6 +263,9 @@ impl From<&FetchError> for crate::ErrorCode {
             FetchError::Http(_) => crate::ErrorCode::NetworkError,
             FetchError::Log(_) => crate::ErrorCode::LogError,
             FetchError::InvalidRef(_) => crate::ErrorCode::InvalidRef,
+            // An access refusal is not an internal error. Before #538 it
+            // was reported as one, because it travelled as `SourceSchema`.
+            FetchError::NotRetrievable { .. } => crate::ErrorCode::NoOaAvailable,
             FetchError::SourceSchema { .. } => crate::ErrorCode::InternalError,
             // Slice 2: a too-large batch is a request-shape failure, so
             // collapse to `INVALID_REF` (closest closed-set fit). The
@@ -282,6 +314,12 @@ impl From<&FetchError> for Option<crate::DenialContext> {
             // `TooManyRefs` is a request-shape failure, not a denial —
             // adding it to the None arm keeps the mapping table consistent.)
             FetchError::NoOaAvailable
+            // #538: a source refusing because the work is not open there is
+            // NOT a denial in the ADR-0023 sense. Nothing was withheld by
+            // policy, so there is no capability to grant and no allowlist to
+            // widen -- a `DenialContext` would send a reader after a
+            // configuration change that does not exist.
+            | FetchError::NotRetrievable { .. }
             | FetchError::NotFound { .. }
             | FetchError::Ambiguous { .. }
             | FetchError::Log(_)

--- a/crates/doiget-core/src/sources/europepmc.rs
+++ b/crates/doiget-core/src/sources/europepmc.rs
@@ -186,9 +186,10 @@ impl Source for EuropePmcSource {
         // one line before the code written to find them. The flags stay
         // in the refusal because they are what a reader checks next.
         if open_access_pdf_url(record).is_none() {
-            return Err(FetchError::SourceSchema {
-                hint: format!(
-                    "europepmc record advertises no retrievable PDF: no \
+            return Err(FetchError::NotRetrievable {
+                source_key: "europepmc".to_string(),
+                detail: format!(
+                    "no \
                      fullTextUrlList entry has documentStyle = pdf with \
                      availabilityCode F or OA (isOpenAccess = {}, inEPMC = {})",
                     flag(record, "isOpenAccess").unwrap_or("absent"),
@@ -489,19 +490,32 @@ mod tests {
             .await
             .expect_err("a non-OA record must be refused, not returned");
         let msg = err.to_string();
+        // #538: the CATEGORY, not "some schema error". `SourceSchema`
+        // collapses to INTERNAL_ERROR at the boundary, which said the source
+        // broke; a refusal is `NoOaAvailable`, which says the work is not
+        // free here.
         assert!(
-            matches!(err, FetchError::SourceSchema { .. }),
-            "got {err:?}"
+            matches!(err, FetchError::NotRetrievable { .. }),
+            "an access refusal is its own variant, not a schema failure: {err:?}"
+        );
+        assert_eq!(
+            crate::ErrorCode::from(&err),
+            crate::ErrorCode::NoOaAvailable,
+            "and it must not surface as an internal error: {err:?}"
         );
         assert!(
             msg.contains("isOpenAccess = N") && msg.contains("inEPMC = Y"),
             "the refusal must say WHY, naming both flags; got: {msg}"
         );
+        // #503's point survives, but it is no longer asserted through the
+        // wording. That the refusal is about RETRIEVABILITY rather than
+        // subset membership is now carried by the variant -- checked above --
+        // and by the criterion the detail names. Asserting the old phrase
+        // "no retrievable PDF" would rebuild in the test exactly the
+        // prose-coupling #538 removed from the classifier.
         assert!(
-            msg.contains("no retrievable PDF"),
-            "the refusal must be about retrievability, not subset membership \
-             — the two are distinguishable and #503 was the case where they \
-             differ; got: {msg}"
+            msg.contains("documentStyle = pdf") && msg.contains("availabilityCode"),
+            "the refusal must name the criterion it applied, which is              per-entry retrievability and not the isOpenAccess subset;              got: {msg}"
         );
     }
 

--- a/crates/doiget-core/src/sources/hal.rs
+++ b/crates/doiget-core/src/sources/hal.rs
@@ -176,8 +176,9 @@ impl Source for HalSource {
             .and_then(serde_json::Value::as_bool)
             != Some(true)
         {
-            return Err(FetchError::SourceSchema {
-                hint: "hal deposit is not open access (openAccess_bool != true)".to_string(),
+            return Err(FetchError::NotRetrievable {
+                source_key: "hal".to_string(),
+                detail: "deposit is not open access (openAccess_bool != true)".to_string(),
             });
         }
 
@@ -425,9 +426,18 @@ mod tests {
             .fetch(&ref_, &profile(true), &ctx)
             .await
             .expect_err("closed deposits must not be returned");
+        // #538: the CATEGORY, not "some schema error". `SourceSchema`
+        // collapses to INTERNAL_ERROR at the boundary, which said the source
+        // broke; a refusal is `NoOaAvailable`, which says the work is not
+        // free here.
         assert!(
-            matches!(err, FetchError::SourceSchema { .. }),
-            "got {err:?}"
+            matches!(err, FetchError::NotRetrievable { .. }),
+            "an access refusal is its own variant, not a schema failure: {err:?}"
+        );
+        assert_eq!(
+            crate::ErrorCode::from(&err),
+            crate::ErrorCode::NoOaAvailable,
+            "and it must not surface as an internal error: {err:?}"
         );
     }
 

--- a/crates/doiget-core/src/sources/openaire.rs
+++ b/crates/doiget-core/src/sources/openaire.rs
@@ -173,9 +173,10 @@ impl Source for OpenAireSource {
         })?;
 
         if !is_open_access(record) {
-            return Err(FetchError::SourceSchema {
-                hint: format!(
-                    "openaire record is not open access (bestAccessRight.code = {})",
+            return Err(FetchError::NotRetrievable {
+                source_key: "openaire".to_string(),
+                detail: format!(
+                    "record is not open access (bestAccessRight.code = {})",
                     access_right_code(record).unwrap_or("absent")
                 ),
             });
@@ -426,9 +427,18 @@ mod tests {
             .fetch(&ref_, &profile(true), &ctx)
             .await
             .expect_err("restricted records must not be returned");
+        // #538: the CATEGORY, not "some schema error". `SourceSchema`
+        // collapses to INTERNAL_ERROR at the boundary, which said the source
+        // broke; a refusal is `NoOaAvailable`, which says the work is not
+        // free here.
         assert!(
-            matches!(err, FetchError::SourceSchema { .. }),
-            "got {err:?}"
+            matches!(err, FetchError::NotRetrievable { .. }),
+            "an access refusal is its own variant, not a schema failure: {err:?}"
+        );
+        assert_eq!(
+            crate::ErrorCode::from(&err),
+            crate::ErrorCode::NoOaAvailable,
+            "and it must not surface as an internal error: {err:?}"
         );
     }
 

--- a/docs/DECISIONS/0054-access-refusal-is-a-type.md
+++ b/docs/DECISIONS/0054-access-refusal-is-a-type.md
@@ -1,0 +1,96 @@
+# 0054 - An access refusal is a type, and it collapses to `NO_OA_AVAILABLE`
+
+- **Date:** 2026-08-30
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0014](0014-docs-class-system.md) — this is the ADR that document requires for the `docs/ERRORS.md` §2 change below
+- **Source:** #538 (an access refusal was classified by substring, so rewording one silently reclassified the row)
+
+## Context
+
+A source signalling *"I found it and cannot give it to you"* returned
+`FetchError::SourceSchema { hint }` with an explanatory string, and
+`classify_attempt` decided what the trace row said by **reading that string
+back**:
+
+```rust
+fn is_access_refusal(hint: &str) -> bool {
+    hint.contains("not open access")
+        || hint.contains("openAccess")
+        || hint.contains("no retrievable PDF")
+}
+```
+
+Match → `AttemptOutcome::NotOpenAccess`, *"consulted: found, not open access"*.
+Miss → `AttemptOutcome::Failed`, *"consulted: failed"*. Those are different
+claims to an operator: **the source has it and will not give it to us** versus
+**the source broke**, and only the second is a bug to chase.
+
+It had already fired. #503 reworded Europe PMC's refusal from *"is indexed but
+not open access"* to *"advertises no retrievable PDF"* — correctly, because the
+gate moved from OA-subset membership to per-entry retrievability — the hint fell
+out of the predicate, and every Europe PMC refusal became `Failed`. Nothing in
+`europepmc.rs` said the wording was load-bearing. `hal` matched on the substring
+`openAccess`, which comes from a JSON **field name**, not prose anyone chose.
+
+It was also latent for every future source: an author had no way to learn that
+the phrasing of an error message decides how the row renders.
+
+There is a second defect underneath. `SourceSchema` collapses to
+`ErrorCode::InternalError`, so whenever such a refusal reached the boundary it
+was reported as *a bug in doiget* — for the ordinary situation of a paper not
+being free at one repository.
+
+## Decision
+
+**1. The refusal is a variant.**
+
+```rust
+FetchError::NotRetrievable { source_key: String, detail: String }
+```
+
+`classify_attempt` matches the variant. `is_access_refusal` is deleted. `detail`
+is carried verbatim into the row, because the reason is for a reader — it is
+just no longer *parsed*.
+
+**2. It collapses to the existing `NO_OA_AVAILABLE`, and the closed set does
+not widen.**
+
+`docs/ERRORS.md` §3 defines a closed `ErrorCode` set, and #538 asked explicitly
+whether a new code was needed. It is not: *"found it, no free copy"* is what
+`NO_OA_AVAILABLE` already means. Adding a code would have split one situation
+across two wire values for an internal refactor, and every consumer switching on
+the code would have needed to learn the new one to keep behaving the same.
+
+`docs/ERRORS.md` §2's description of `NO_OA_AVAILABLE` is widened to match: it
+said *"Tier 1 sources reported no OA URL"*, and it now also covers an optional
+source that holds the record but no retrievable copy. That is the NORMATIVE
+change ADR-0014 requires this ADR for. **The wire value and its recoverability
+guidance are unchanged.**
+
+**3. It is not a `DenialContext`.**
+
+`From<&FetchError> for Option<DenialContext>` returns `None`. ADR-0023's denial
+channel is for policy refusals — a capability to grant, an allowlist to widen.
+An access refusal is a fact about the work: there is no configuration change
+that makes a closed paper open, and offering a `denial_context` would send a
+reader after one that does not exist.
+
+## Consequences
+
+- Rewording a refusal can no longer reclassify a row. The compiler is the guard,
+  which is what #538 asked for.
+- An access refusal that reaches the boundary stops being reported as
+  `INTERNAL_ERROR`. This is a **wire-visible behaviour change for the same
+  input**, and a strictly more accurate one; the code it now returns was already
+  in the closed set and already documented as recoverable-by-enabling-a-source.
+- Adding a source no longer requires knowing a phrasing convention. The variant
+  is the contract.
+- Three tests that asserted `matches!(err, FetchError::SourceSchema { .. })` now
+  assert the category and the collapsed `ErrorCode`, which is a stronger claim.
+  One test asserted the *phrase* `"no retrievable PDF"`; it now asserts the
+  criterion the detail names (`documentStyle = pdf`, `availabilityCode`), since
+  asserting the phrase would have rebuilt the prose-coupling inside the test.
+- `error.disposition` (#506) is left for its own ADR. An access refusal is
+  `needs_config` only when another source could be enabled, and that judgement
+  belongs with the disposition design rather than smuggled in here.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -70,6 +70,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0051 | Contributions carry a relicensable grant, recorded as a commit sign-off | Accepted | `chore/cla-relicensing-grant` | - |
 | 0052 | Crossref `link[]` is programme-scoped, so the fetch path does not carry it | Accepted | `feat/517-publisher-candidate` | #517 |
 | 0053 | A DOI resolver is addressing, not hosting | Accepted | `fix/533-resolver-hop-is-addressing` | #533 |
+| 0054 | An access refusal is a type, and it collapses to `NO_OA_AVAILABLE` | Accepted | `fix/538-typed-access-refusal` | #538 |
 
 ## Conventions
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -36,7 +36,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | Code | Meaning | Recoverable? |
 |---|---|---|
 | `INVALID_REF` | DOI / arXiv id failed validation. | No (user must correct input). |
-| `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
+| `NO_OA_AVAILABLE` | No source could supply a free copy: Tier 1 reported no OA URL, **or** a source holds the record and has no retrievable copy (`FetchError::NotRetrievable`, ADR-0054). | Try later, or enable opt-in source. |
 | `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
 | `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
 | `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | No (the id is wrong or retracted). |

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -42,7 +42,7 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 | Code | Meaning | Recoverable? |
 |---|---|---|
 | `INVALID_REF` | DOI / arXiv id failed validation. | No (user must correct input). |
-| `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
+| `NO_OA_AVAILABLE` | No source could supply a free copy: Tier 1 reported no OA URL, **or** a source holds the record and has no retrievable copy (`FetchError::NotRetrievable`, ADR-0054). | Try later, or enable opt-in source. |
 | `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
 | `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
 | `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | No (the id is wrong or retracted). |


### PR DESCRIPTION
Closes #538.

## The mechanism

A source signalling *"I found it and cannot give it to you"* returned `FetchError::SourceSchema { hint }`, and `classify_attempt` decided what the trace row said by **reading that string back**:

```rust
hint.contains("not open access") || hint.contains("openAccess") || hint.contains("no retrievable PDF")
```

Match → *"consulted: found, not open access"*. Miss → *"consulted: failed"*. Those are different claims to an operator — **the source has it and will not give it to us** versus **the source broke** — and only the second is a bug to chase.

**It had already fired.** #503 reworded Europe PMC's refusal from *"is indexed but not open access"* to *"advertises no retrievable PDF"*, correctly, because the gate moved from OA-subset membership to per-entry retrievability. The hint fell out of the predicate and every Europe PMC refusal silently became `Failed`. Nothing in `europepmc.rs` said the wording was load-bearing. `hal` matched on `openAccess` — a JSON **field name**, not prose anyone chose. And it was latent for any source added later, whose author had no way to learn that the phrasing of an error message decides how the row renders.

## The fix

```rust
FetchError::NotRetrievable { source_key: String, detail: String }
```

`classify_attempt` matches the variant. `is_access_refusal` is deleted. `detail` is still carried verbatim into the row — the reason is for a reader, it is just no longer *parsed*.

**The compiler immediately found a second exhaustive match** over `FetchError` (`From<&FetchError> for Option<DenialContext>`) that the substring approach had no way to flag. That is the argument for the change in one line.

## The wire: no new code

#538 asked whether the closed set in `docs/ERRORS.md` §3 has to widen. **It does not.** `NotRetrievable` collapses to the existing `NO_OA_AVAILABLE` — "found it, no free copy" is what that already means. A new code would have split one situation across two wire values for an internal refactor, and every consumer switching on the code would have had to learn it to keep behaving the same.

What *does* change is §2's **description**: it said "Tier 1 sources reported no OA URL" and now also covers an optional source holding the record with nothing retrievable. That is the NORMATIVE change ADR-0014 requires an ADR for — **ADR-0054**.

### A second defect, underneath

`SourceSchema` collapses to `INTERNAL_ERROR`. So until now, a paper simply not being free at one repository could be reported as **a bug in doiget**. It no longer is. This is a wire-visible behaviour change for the same input, and a strictly more accurate one.

### Not a `DenialContext`

`From<&FetchError> for Option<DenialContext>` returns `None`. ADR-0023's channel is for *policy* refusals — a capability to grant, an allowlist to widen. No configuration makes a closed paper open, and a `denial_context` would send a reader after a fix that does not exist.

## Tests

Three asserted `matches!(err, FetchError::SourceSchema { .. })` and now assert the **category** plus the collapsed `ErrorCode`, which is a stronger claim than "some schema error".

A fourth asserted the *phrase* `"no retrievable PDF"`. It now asserts the criterion the detail names (`documentStyle = pdf`, `availabilityCode`) — because asserting the phrase would have rebuilt inside the test exactly the prose-coupling this removes from the classifier. #503's point survives; it is just carried by the variant now.

Two tests were **not** converted: `no_deposit_surfaces_as_source_schema` and `no_record_surfaces_as_source_schema`. A missing record is not a refusal, and my first pass swept them up with a blind replace — caught before commit.

## Scope

`error.disposition` (#506) is deliberately left for its own ADR. An access refusal is `needs_config` only when *another* source could be enabled, and that judgement belongs with the disposition design rather than smuggled in here.

Local, **both feature sets** (`oa-only` and `oa-only,metadata,tdm-*`): 47 suites each, 0 failures. fmt, clippy `-D warnings` on the full feature set, rustdoc `-D warnings` on both doc surfaces, `version-bump-gate.sh`.
