### PR TITLE
feat(mcp): a failure says what to do about it, not just what happened (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,44 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
+- **[mcp]** Every failure envelope now carries `error.disposition`, so the retry
+  decision stops being a markdown table the agent never reads. `docs/ERRORS.md`
+  §2 has had good per-code guidance since Phase 0; none of it reached the wire
+  (`grep -riE 'retryable|transient|retry' crates/doiget-mcp` returned nothing in
+  the tool descriptions), so an agent's only signal was the **name** of the code
+  - and several names point the wrong way (#506).
+
+  Three states, because two cannot express the one that matters:
+
+  | value | meaning |
+  |---|---|
+  | `terminal` | the answer will not change. Do not retry. |
+  | `retry_after` | it may change on its own. Retry with backoff. |
+  | `needs_config` | it will not change by itself, but a named change makes it. |
+
+  `NO_OA_AVAILABLE` is `needs_config`. It is the most common failure there is,
+  and both its name and its old row ("Try later, or enable opt-in source") read
+  to a machine as *wait* when it is nearly always *configure* - an invitation to
+  loop forever over something that will not change.
+
+  Derived in one place (`ErrorCode::disposition`, an exhaustive match with no
+  wildcard) and built in one place (`error_object`), because a field present on
+  some failures and absent on others teaches the reader to go back to guessing.
+  `docs/ERRORS.md` §2 gains a Disposition column, and a test parses the shipped
+  document and asserts every row against the function - so the doc and the wire
+  cannot drift. The test also asserts it parsed exactly 15 rows, since a parser
+  that silently matches nothing passes every time.
+
+  The contract is stated in the MCP server `instructions`, which every client
+  receives on `initialize`, so an agent that has never opened `ERRORS.md` still
+  meets it. See ADR-0055.
+
+  Three parts of #506 are **not** here and it stays open for them:
+  `error.retry_after_ms` (the `Retry-After` is consumed inside the retry loop
+  and no honest number survives to the boundary - a plausible default would be
+  indistinguishable from a measured one), `remediation` on `ok:false`, and
+  `rate_limit_budget` on live responses.
+
 - **[cli]** The found-nothing fetch now reports what it consulted. Previously
   `fetched ... (metadata-only: no OA PDF available)` was byte-identical whether
   the optional sources were on and had nothing or off and never asked - and it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.8"
+version = "0.8.13-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.8"
+version = "0.8.13-beta.9"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.8"
+version = "0.8.13-beta.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.8"
+version       = "0.8.13-beta.9"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.8" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.8" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.8" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.9" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.9" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.9" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -742,6 +742,98 @@ pub enum ErrorCode {
     TextUnavailable,
 }
 
+/// What a caller should DO about a failure, as opposed to what happened.
+///
+/// `docs/ERRORS.md` §2 has carried per-code retry guidance since Phase 0 and
+/// it is good guidance — but it is a markdown table, and the agent making the
+/// retry decision never reads it. Its only signal was the NAME of the code,
+/// and several names point the wrong way: `NO_OA_AVAILABLE` is the most common
+/// failure there is, and "no OA available" invites an unbounded retry loop for
+/// something that will not change until the configuration does (#506).
+///
+/// Three states, not two. "Retryable / not retryable" cannot express the case
+/// that matters most here — the answer will not change *by itself*, but a
+/// named one-line change makes it change. Facing that, an agent should neither
+/// loop nor give up silently; it should surface the specific change to a human.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Disposition {
+    /// The answer will not change. Do not retry, and do not wait for it.
+    ///
+    /// Includes failures a caller can act on by issuing a DIFFERENT request
+    /// (`INVALID_REF`, `AMBIGUOUS`, `TEXT_UNAVAILABLE`): this call is settled,
+    /// which is what the disposition is about.
+    Terminal,
+    /// The answer may change on its own. Retry, with backoff.
+    RetryAfter,
+    /// The answer will not change by itself, but a named change makes it.
+    /// Surface it; do not loop.
+    NeedsConfig,
+}
+
+impl Disposition {
+    /// The wire token, allocation-free.
+    #[must_use]
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Terminal => "terminal",
+            Self::RetryAfter => "retry_after",
+            Self::NeedsConfig => "needs_config",
+        }
+    }
+}
+
+impl ErrorCode {
+    /// What a caller should do about this code — see [`Disposition`].
+    ///
+    /// This is the single source of truth. `docs/ERRORS.md` §2 carries a
+    /// Disposition column, and `errors_md_disposition_column_matches_the_code`
+    /// parses that table and asserts it against this function for every
+    /// variant, so the document and the wire cannot drift (#506; the drift
+    /// pattern is #493).
+    ///
+    /// An exhaustive `match` with no wildcard: a new code must decide.
+    #[must_use]
+    pub const fn disposition(self) -> Disposition {
+        match self {
+            // Settled. The same call will return the same thing.
+            Self::InvalidRef
+            | Self::NotFound
+            | Self::InternalError
+            // ERRORS.md is explicit: "do not retry".
+            | Self::NotImplemented
+            // A different request may work (narrow the name / fetch the PDF
+            // instead), but THIS one is answered.
+            | Self::Ambiguous
+            | Self::TextUnavailable => Disposition::Terminal,
+
+            // May change on its own.
+            Self::RateLimited
+            | Self::NetworkError
+            | Self::FetchTimeout
+            | Self::LockTimeout => Disposition::RetryAfter,
+
+            // Will not change by itself; a named change makes it.
+            //
+            // `NoOaAvailable` sits here rather than in `RetryAfter` on
+            // purpose: it is the most common failure, and ERRORS.md's "Try
+            // later, or enable opt-in source" reads to a machine as the
+            // former when it is nearly always the latter.
+            //
+            // `StoreError` / `LogError` are disk and permission problems. A
+            // machine cannot name the fix, but it must not loop on it either,
+            // and "surface this to a human" is exactly what this disposition
+            // means.
+            Self::NoOaAvailable
+            | Self::CapabilityDenied
+            | Self::SchemaTooNew
+            | Self::StoreError
+            | Self::LogError => Disposition::NeedsConfig,
+        }
+    }
+}
+
 impl ErrorCode {
     /// The `SCREAMING_SNAKE_CASE` wire token for this code, as a
     /// `&'static str`. Identical to the serde representation but
@@ -2107,6 +2199,74 @@ agreed = true
                 input
             );
         }
+    }
+
+    /// #506: `docs/ERRORS.md` §2 and [`ErrorCode::disposition`] are the same
+    /// claim written twice, so this asserts they say the same thing.
+    ///
+    /// The issue asked for exactly this ("the ERRORS.md §2 table either
+    /// generated from it or asserted against it in a test — otherwise the doc
+    /// and the wire drift, which is the #493 pattern"). Generating the table
+    /// would have cost the per-code prose, which is the useful part; asserting
+    /// it keeps both.
+    ///
+    /// Reads the shipped document rather than a fixture copy, so a doc edit
+    /// that contradicts the code fails here and not in someone's agent.
+    #[test]
+    fn errors_md_disposition_column_matches_the_code() {
+        // Resolves relative to this file; three levels up is the workspace
+        // root (same reasoning as `safekey_matches_reference_vectors`).
+        let doc = include_str!("../../../docs/ERRORS.md");
+
+        let mut checked = 0usize;
+        for line in doc.lines() {
+            // `| \`CODE\` | meaning | \`disposition\` | recoverable |`
+            let Some(rest) = line.strip_prefix("| `") else {
+                continue;
+            };
+            let Some((code_str, tail)) = rest.split_once("` | ") else {
+                continue;
+            };
+            let cols: Vec<&str> = tail.split(" | ").collect();
+            if cols.len() < 3 {
+                continue;
+            }
+            let documented = cols[1].trim().trim_matches('`');
+
+            let code = match code_str {
+                "INVALID_REF" => ErrorCode::InvalidRef,
+                "NO_OA_AVAILABLE" => ErrorCode::NoOaAvailable,
+                "RATE_LIMITED" => ErrorCode::RateLimited,
+                "NETWORK_ERROR" => ErrorCode::NetworkError,
+                "NOT_FOUND" => ErrorCode::NotFound,
+                "AMBIGUOUS" => ErrorCode::Ambiguous,
+                "STORE_ERROR" => ErrorCode::StoreError,
+                "LOG_ERROR" => ErrorCode::LogError,
+                "CAPABILITY_DENIED" => ErrorCode::CapabilityDenied,
+                "FETCH_TIMEOUT" => ErrorCode::FetchTimeout,
+                "SCHEMA_TOO_NEW" => ErrorCode::SchemaTooNew,
+                "LOCK_TIMEOUT" => ErrorCode::LockTimeout,
+                "INTERNAL_ERROR" => ErrorCode::InternalError,
+                "NOT_IMPLEMENTED" => ErrorCode::NotImplemented,
+                "TEXT_UNAVAILABLE" => ErrorCode::TextUnavailable,
+                // Not a §2 row (e.g. the §6 mapping tables).
+                _ => continue,
+            };
+            assert_eq!(
+                documented,
+                code.disposition().as_wire(),
+                "docs/ERRORS.md §2 says {code_str} is `{documented}`, the code says                  `{}` — one of the two is wrong and an agent reads the second",
+                code.disposition().as_wire()
+            );
+            checked += 1;
+        }
+
+        // The guard the assertion above cannot be: a parser that silently
+        // matches nothing would pass every time. §2 has one row per code.
+        assert_eq!(
+            checked, 15,
+            "expected every ErrorCode to have a §2 row with a Disposition              column; parsed {checked}. Either a code was added without              documenting it, or the table's shape changed and this parser              stopped seeing it."
+        );
     }
 
     #[test]

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -962,10 +962,7 @@ impl Server {
                         "entry_key": entry_key,
                         "ref": raw,
                         "ok": false,
-                        "error": {
-                            "code":    ErrorCode::InvalidRef,
-                            "message": source.to_string(),
-                        },
+                        "error": error_object(ErrorCode::InvalidRef, source.to_string()),
                     }));
                 }
                 Err(doiget_core::refs::ParseError::NoIdentifier { entry_key }) => {
@@ -982,10 +979,7 @@ impl Server {
                         "entry_key": entry_key,
                         "ref":       Value::Null,
                         "ok":        false,
-                        "error": {
-                            "code":    ErrorCode::InvalidRef,
-                            "message": "entry has no DOI / arXiv id",
-                        },
+                        "error": error_object(ErrorCode::InvalidRef, "entry has no DOI / arXiv id"),
                     }));
                 }
                 Err(_) => {
@@ -996,10 +990,7 @@ impl Server {
                         "entry_key": Value::Null,
                         "ref":       Value::Null,
                         "ok":        false,
-                        "error": {
-                            "code":    ErrorCode::InvalidRef,
-                            "message": "unhandled bibliography parse error",
-                        },
+                        "error": error_object(ErrorCode::InvalidRef, "unhandled bibliography parse error"),
                     }));
                 }
             }
@@ -1999,10 +1990,10 @@ impl Server {
             let _ = input;
             return Ok(CallToolResult::structured(json!({
                 "ok": false,
-                "error": {
-                    "code": ErrorCode::NotImplemented,
-                    "message": "doiget_expand_citation_graph requires the `citation` Cargo feature; this binary was built without it",
-                },
+                "error": error_object(
+                    ErrorCode::NotImplemented,
+                    "doiget_expand_citation_graph requires the `citation` Cargo feature; this binary was built without it",
+                ),
             })));
         }
         #[cfg(feature = "citation")]
@@ -3051,7 +3042,7 @@ impl Server {
                 Err(e) => {
                     entries.push(json!({
                         "ref": r,
-                        "error": { "code": ErrorCode::InvalidRef, "message": format!("invalid ref: {e}") },
+                        "error": error_object(ErrorCode::InvalidRef, format!("invalid ref: {e}")),
                     }));
                     continue;
                 }
@@ -3088,7 +3079,7 @@ impl Server {
                 Err(e) => {
                     entries.push(json!({
                         "ref": r,
-                        "error": { "code": ErrorCode::StoreError, "message": format!("store read failed: {e}") },
+                        "error": error_object(ErrorCode::StoreError, format!("store read failed: {e}")),
                     }));
                 }
             }
@@ -3143,14 +3134,30 @@ fn entry_info_to_json(entry: &EntryInfo) -> Value {
 /// per-ref context). This shape-symmetry with the success envelopes
 /// (which always carry `"ref"`) means consumers can pattern-match
 /// uniformly across `ok:true` / `ok:false` envelopes.
+/// The `error` object every failure envelope carries (#506).
+///
+/// One builder rather than ten literals, because the point of `disposition`
+/// is that an agent can rely on it being there. A field present on some
+/// failures and absent on others is worse than no field: it teaches the reader
+/// to fall back to guessing from the code's name, which is the habit this
+/// exists to replace.
+///
+/// `disposition` is derived by [`doiget_core::ErrorCode::disposition`], which
+/// is the same function `docs/ERRORS.md` §2's Disposition column is asserted
+/// against.
+fn error_object(code: ErrorCode, message: impl Into<Value>) -> Value {
+    json!({
+        "code": code,
+        "message": message.into(),
+        "disposition": code.disposition().as_wire(),
+    })
+}
+
 fn read_path_error_envelope(ref_str: Option<&str>, code: ErrorCode, message: &str) -> Value {
     json!({
         "ok": false,
         "ref": ref_str.map(Value::from).unwrap_or(Value::Null),
-        "error": {
-            "code": code,
-            "message": message,
-        },
+        "error": error_object(code, message),
     })
 }
 
@@ -3175,15 +3182,11 @@ fn metadata_only_error_envelope(ref_str: Option<&str>, code: ErrorCode, message:
         // ref to surface) for shape-symmetry with the success
         // envelopes and `read_path_error_envelope`.
         "ref": ref_str.map(Value::from).unwrap_or(Value::Null),
-        "error": {
-            "code": code,
-            "message": message,
-            // denial_context is intentionally absent for these envelope
-            // shapes (parse-error / not-implemented); ADR-0023 §1 says
-            // the field is optional and consumers MUST tolerate it
-            // being absent (§3 covers the per-subfield optionality
-            // rules that apply when denial_context IS present).
-        },
+        // denial_context is intentionally absent for these envelope shapes
+        // (parse-error / not-implemented); ADR-0023 §1 says the field is
+        // optional and consumers MUST tolerate it being absent (§3 covers the
+        // per-subfield optionality rules that apply when it IS present).
+        "error": error_object(code, message),
     })
 }
 
@@ -3427,13 +3430,7 @@ fn fetch_paper_error_envelope(ref_str: Option<&str>, code: ErrorCode, message: &
     if let Some(r) = ref_str {
         obj.insert("ref".into(), json!(r));
     }
-    obj.insert(
-        "error".into(),
-        json!({
-            "code": code,
-            "message": message,
-        }),
-    );
+    obj.insert("error".into(), error_object(code, message));
     Value::Object(obj)
 }
 
@@ -3713,10 +3710,7 @@ fn build_batch_dry_run_envelope(plans: &[(Ref, doiget_core::dry_run::FetchPlan)]
 fn batch_fetch_error_envelope(code: ErrorCode, message: &str) -> Value {
     json!({
         "ok": false,
-        "error": {
-            "code": code,
-            "message": message,
-        },
+        "error": error_object(code, message),
     })
 }
 
@@ -4029,7 +4023,14 @@ impl ServerHandler for Server {
                 "doiget v{VERSION} \u{2014} Open Access paper fetcher (stdio MCP). \
                  Tier 1 sources are always-on; Tier 2/3 require build features and \
                  env-var grants. Call `doiget_capability_profile` for the runtime \
-                 view; call `doiget_health` for an operational sanity check."
+                 view; call `doiget_health` for an operational sanity check. \
+                 RETRY CONTRACT: every failure carries `error.disposition`. \
+                 `terminal` = the answer will not change, do not retry. \
+                 `retry_after` = it may change on its own, retry with backoff. \
+                 `needs_config` = it will not change by itself, but a named \
+                 change makes it — surface that to the user instead of \
+                 looping. Read that field, not the error code's name: \
+                 NO_OA_AVAILABLE is `needs_config`, not something to wait out."
             ))
     }
 }

--- a/crates/doiget-mcp/tests/resolve_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/resolve_paper_e2e.rs
@@ -165,6 +165,16 @@ async fn doiget_resolve_paper_invalid_ref_returns_invalid_ref_envelope() -> anyh
             .unwrap_or(false),
         "INVALID_REF message must mention 'invalid ref'; got: {structured:?}"
     );
+    // #506: the retry decision an agent has to make was encoded in a markdown
+    // table it never reads, so its only signal was the code's NAME. Asserted
+    // through the real tool rather than on the helper, because "the envelope
+    // carries it" is the claim -- a helper that is right and unreached would
+    // pass a unit test and change nothing.
+    assert_eq!(
+        structured["error"]["disposition"],
+        serde_json::json!("terminal"),
+        "a malformed ref will not become well-formed by waiting: {structured:?}"
+    );
 
     client.cancel().await?;
     server_handle.await??;

--- a/docs/DECISIONS/0055-error-disposition.md
+++ b/docs/DECISIONS/0055-error-disposition.md
@@ -1,0 +1,93 @@
+# 0055 - A failure says what to do about it, in three states
+
+- **Date:** 2026-08-30
+- **Status:** Accepted
+- **Supersedes:** -
+- **Complements:** [0014](0014-docs-class-system.md) — the ADR `docs/ERRORS.md` §2/§3 changes require; [0023](0023-denial-context-structured.md) and [0043](0043-machine-readable-diagnostics.md), which built the *content* of a fix but only on the success envelope
+- **Source:** #506 (the MCP envelope says what happened but not what to do next)
+
+## Context
+
+`docs/ERRORS.md` §2 has carried per-code retry guidance since Phase 0, and it is
+good guidance: `INVALID_REF` → *"No (user must correct input)"*, `NOT_IMPLEMENTED`
+→ *"do not retry"*. This is not missing thinking. It is missing **plumbing**:
+
+```
+grep -rniE 'retryable|do_not_retry|permanent|transient' crates/doiget-mcp  → 0
+grep -rniE 'retry' crates/doiget-mcp/src/*.rs (tool descriptions)          → 0
+```
+
+The failure envelope was `{ok:false, error:{code, message, denial_context?}}`, so
+an agent's only signal was **the name of the code** — and several names point the
+wrong way. `NO_OA_AVAILABLE` is the most common failure there is, and both its
+name and its ERRORS.md row (*"Try later, or enable opt-in source"*) read to a
+machine as *wait*, when it is nearly always *configure*. That invites an
+unbounded retry loop over something that will not change on its own.
+
+## Decision
+
+**1. `error.disposition`, with three states.**
+
+| value | meaning |
+|---|---|
+| `terminal` | the answer will not change. Do not retry, do not wait. |
+| `retry_after` | it may change on its own. Retry with backoff. |
+| `needs_config` | it will not change by itself, but a named change makes it. Surface it; do not loop. |
+
+Two states cannot express the third, and the third is the one that matters most
+here. Facing it an agent should neither loop nor give up silently.
+
+`terminal` also covers failures a caller can act on by issuing a *different*
+request — `INVALID_REF`, `AMBIGUOUS`, `TEXT_UNAVAILABLE`. **This** call is
+settled, which is what a disposition is about.
+
+`STORE_ERROR` and `LOG_ERROR` are `needs_config`. A machine cannot name the fix
+for a full disk, but it must not loop on one either, and "surface this to a
+human" is exactly what the state means.
+
+**2. One source of truth.** `ErrorCode::disposition()` is an exhaustive `match`
+with no wildcard, so a new code must decide. `docs/ERRORS.md` §2 gains a
+Disposition column, and `errors_md_disposition_column_matches_the_code` parses
+the shipped document and asserts every row against the function. #506 asked for
+the table to be generated from the code or asserted against it, because
+otherwise the doc and the wire drift — the #493 pattern. Generating it would
+have cost the per-code prose, which is the useful part; asserting keeps both.
+
+The test also guards its own parser: it asserts it saw exactly 15 rows, because
+a parser that silently matches nothing passes every time.
+
+**3. One builder.** Every failure envelope goes through `error_object`. A field
+present on some failures and absent on others is worse than no field: it teaches
+the reader to fall back to guessing from the code's name, which is the habit
+this exists to replace.
+
+**4. Stated where an agent that never read ERRORS.md still meets it** — the MCP
+server `instructions`, delivered on `initialize` to every client. One place
+rather than twenty-two tool descriptions, and it names the specific trap:
+`NO_OA_AVAILABLE` is `needs_config`, not something to wait out.
+
+## Consequences
+
+- The wire gains a field. Additive: `{ok:false}` consumers that ignore it are
+  unaffected, and `code` / `message` / `denial_context` are unchanged.
+- `docs/ERRORS.md` §2 gains a column and §3's envelope shape gains the field.
+  That is the NORMATIVE change ADR-0014 requires this ADR for. No code's
+  *meaning* or recoverability guidance changed — only that the guidance is now
+  machine-readable.
+- A new `ErrorCode` will not compile until its disposition is decided, and will
+  not pass tests until `docs/ERRORS.md` records the same answer.
+
+## Not in scope
+
+- **`error.retry_after_ms`.** #506 asks for it and it is not here. `Retry-After`
+  is parsed today (`http::parse_retry_after`) but consumed **inside** the retry
+  loop and discarded; by the time an error surfaces, the retries are exhausted
+  and no honest number remains. Emitting a plausible default would be a number
+  the caller could not distinguish from a measured one. Plumbing the header out
+  of the loop is its own change.
+- **`remediation` on `ok:false`.** ADR-0043's channel keys on `DenialContext`,
+  which is present on only some failures; carrying it for those alone would
+  reproduce the sometimes-present problem this ADR rejects for `disposition`.
+- **`rate_limit_budget` on live responses.** Independent of the retry contract.
+
+#506 stays open for those three.

--- a/docs/DECISIONS/INDEX.md
+++ b/docs/DECISIONS/INDEX.md
@@ -70,6 +70,7 @@ Status column reconciled 2026-05-17 against `CHANGELOG.md` slices (issue #150).
 | 0051 | Contributions carry a relicensable grant, recorded as a commit sign-off | Accepted | `chore/cla-relicensing-grant` | - |
 | 0052 | Crossref `link[]` is programme-scoped, so the fetch path does not carry it | Accepted | `feat/517-publisher-candidate` | #517 |
 | 0053 | A DOI resolver is addressing, not hosting | Accepted | `fix/533-resolver-hop-is-addressing` | #533 |
+| 0055 | A failure says what to do about it, in three states | Accepted | `feat/506-error-disposition` | #506 |
 
 ## Conventions
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -33,29 +33,29 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 
 ## 2. Code semantics
 
-| Code | Meaning | Recoverable? |
-|---|---|---|
-| `INVALID_REF` | DOI / arXiv id failed validation. | No (user must correct input). |
-| `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
-| `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
-| `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
-| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | No (the id is wrong or retracted). |
-| `AMBIGUOUS` | A name filter (`--author` / `--venue` / `--publisher`) matched several entities with no clear winner; the error lists the candidates. Distinct from `NOT_FOUND` ("matched nothing"). CLI exit `2`. | Yes — narrow the name (add a first name / fuller title) or pass an exact id. |
-| `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
-| `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
-| `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |
-| `FETCH_TIMEOUT` | Per-request timeout exceeded. | Retry. |
-| `SCHEMA_TOO_NEW` | Store entry's `schema_version` is ahead. | Upgrade doiget. |
-| `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | Retry; another process holds it. |
-| `INTERNAL_ERROR` | Bug. | Report at <https://github.com/QAtlasHub/doiget/issues>. |
-| `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | Wait for next minor release; do not retry. |
-| `TEXT_UNAVAILABLE` | The id is valid and resolvable, but the **requested representation** is missing: `doiget text` got a 200 from ar5iv with no extractable prose (the paper was never converted to HTML). Distinct from `NOT_FOUND` (the id *does* exist) and `NO_OA_AVAILABLE` (the paper may still be OA — only the HTML render is missing). Issue #302. | Yes — fetch the PDF instead (`doiget fetch <id>`); do not "fix" the identifier. |
+| Code | Meaning | Disposition | Recoverable? |
+|---|---|---|---|
+| `INVALID_REF` | DOI / arXiv id failed validation. | `terminal` | No (user must correct input). |
+| `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | `needs_config` | Try later, or enable opt-in source. |
+| `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | `retry_after` | Retry after `Retry-After` (or 1 s). |
+| `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | `retry_after` | Retry usually fine. |
+| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | `terminal` | No (the id is wrong or retracted). |
+| `AMBIGUOUS` | A name filter (`--author` / `--venue` / `--publisher`) matched several entities with no clear winner; the error lists the candidates. Distinct from `NOT_FOUND` ("matched nothing"). CLI exit `2`. | `terminal` | Yes — narrow the name (add a first name / fuller title) or pass an exact id. |
+| `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | `needs_config` | Depends on cause. |
+| `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | `needs_config` | Free disk / fix perms. |
+| `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | `needs_config` | User opts in, or pick different source. |
+| `FETCH_TIMEOUT` | Per-request timeout exceeded. | `retry_after` | Retry. |
+| `SCHEMA_TOO_NEW` | Store entry's `schema_version` is ahead. | `needs_config` | Upgrade doiget. |
+| `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | `retry_after` | Retry; another process holds it. |
+| `INTERNAL_ERROR` | Bug. | `terminal` | Report at <https://github.com/QAtlasHub/doiget/issues>. |
+| `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | `terminal` | Wait for next minor release; do not retry. |
+| `TEXT_UNAVAILABLE` | The id is valid and resolvable, but the **requested representation** is missing: `doiget text` got a 200 from ar5iv with no extractable prose (the paper was never converted to HTML). Distinct from `NOT_FOUND` (the id *does* exist) and `NO_OA_AVAILABLE` (the paper may still be OA — only the HTML render is missing). Issue #302. | `terminal` | Yes — fetch the PDF instead (`doiget fetch <id>`); do not "fix" the identifier. |
 
 ## 3. Persona × error matrix
 
 | Persona | Surface |
 |---|---|
-| Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
+| Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, disposition, denial_context? } }`. `disposition` is ALWAYS present and is the field to branch a retry on — see §2 and ADR-0055. It is derived from `code` by `ErrorCode::disposition`, never hand-written per call site. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
 | CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). **Records are emitted in completion order, not input order** — see below. |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |

--- a/site/content/developer/errors.md
+++ b/site/content/developer/errors.md
@@ -39,29 +39,29 @@ Wire form (JSON / MCP): `"INVALID_REF"`, `"NO_OA_AVAILABLE"`, etc.
 
 ## 2. Code semantics
 
-| Code | Meaning | Recoverable? |
-|---|---|---|
-| `INVALID_REF` | DOI / arXiv id failed validation. | No (user must correct input). |
-| `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | Try later, or enable opt-in source. |
-| `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | Retry after `Retry-After` (or 1 s). |
-| `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | Retry usually fine. |
-| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | No (the id is wrong or retracted). |
-| `AMBIGUOUS` | A name filter (`--author` / `--venue` / `--publisher`) matched several entities with no clear winner; the error lists the candidates. Distinct from `NOT_FOUND` ("matched nothing"). CLI exit `2`. | Yes — narrow the name (add a first name / fuller title) or pass an exact id. |
-| `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | Depends on cause. |
-| `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | Free disk / fix perms. |
-| `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | User opts in, or pick different source. |
-| `FETCH_TIMEOUT` | Per-request timeout exceeded. | Retry. |
-| `SCHEMA_TOO_NEW` | Store entry's `schema_version` is ahead. | Upgrade doiget. |
-| `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | Retry; another process holds it. |
-| `INTERNAL_ERROR` | Bug. | Report at <https://github.com/QAtlasHub/doiget/issues>. |
-| `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | Wait for next minor release; do not retry. |
-| `TEXT_UNAVAILABLE` | The id is valid and resolvable, but the **requested representation** is missing: `doiget text` got a 200 from ar5iv with no extractable prose (the paper was never converted to HTML). Distinct from `NOT_FOUND` (the id *does* exist) and `NO_OA_AVAILABLE` (the paper may still be OA — only the HTML render is missing). Issue #302. | Yes — fetch the PDF instead (`doiget fetch <id>`); do not "fix" the identifier. |
+| Code | Meaning | Disposition | Recoverable? |
+|---|---|---|---|
+| `INVALID_REF` | DOI / arXiv id failed validation. | `terminal` | No (user must correct input). |
+| `NO_OA_AVAILABLE` | Tier 1 sources reported no OA URL. | `needs_config` | Try later, or enable opt-in source. |
+| `RATE_LIMITED` | Internal rate cap hit, OR 429 from source. | `retry_after` | Retry after `Retry-After` (or 1 s). |
+| `NETWORK_ERROR` | Transport / DNS / TLS failure. **Does NOT cover a deliberate supply-chain policy block** — see §6.1: an off-allowlist / redirect-denied / insecure-scheme OA-PDF leg is `CAPABILITY_DENIED`, not `NETWORK_ERROR`. | `retry_after` | Retry usually fine. |
+| `NOT_FOUND` | Metadata source authoritatively reported the id does not exist: HTTP `404` / `410` / `451`, or a source-specific absence (arXiv returns HTTP 200 with an empty `<feed>` for an unknown id). Network-independent and reproducible — distinct from the transient `NETWORK_ERROR` / `RATE_LIMITED`. `doiget verify` treats it as a definite dead reference (`absent`). For a DOI it is emitted only when all configured sources (Crossref, Unpaywall) fail to resolve it; a DataCite-only DOI may thus be reported `NOT_FOUND`. | `terminal` | No (the id is wrong or retracted). |
+| `AMBIGUOUS` | A name filter (`--author` / `--venue` / `--publisher`) matched several entities with no clear winner; the error lists the candidates. Distinct from `NOT_FOUND` ("matched nothing"). CLI exit `2`. | `terminal` | Yes — narrow the name (add a first name / fuller title) or pass an exact id. |
+| `STORE_ERROR` | Filesystem write failed (disk, permission, etc.). | `needs_config` | Depends on cause. |
+| `LOG_ERROR` | Provenance log write failed. **Fetch is aborted.** | `needs_config` | Free disk / fix perms. |
+| `CAPABILITY_DENIED` | Source not in `CapabilityProfile`. | `needs_config` | User opts in, or pick different source. |
+| `FETCH_TIMEOUT` | Per-request timeout exceeded. | `retry_after` | Retry. |
+| `SCHEMA_TOO_NEW` | Store entry's `schema_version` is ahead. | `needs_config` | Upgrade doiget. |
+| `LOCK_TIMEOUT` | Could not acquire `flock` within 5 s. | `retry_after` | Retry; another process holds it. |
+| `INTERNAL_ERROR` | Bug. | `terminal` | Report at <https://github.com/QAtlasHub/doiget/issues>. |
+| `NOT_IMPLEMENTED` | Feature is spec'd but not yet wired in this Phase. | `terminal` | Wait for next minor release; do not retry. |
+| `TEXT_UNAVAILABLE` | The id is valid and resolvable, but the **requested representation** is missing: `doiget text` got a 200 from ar5iv with no extractable prose (the paper was never converted to HTML). Distinct from `NOT_FOUND` (the id *does* exist) and `NO_OA_AVAILABLE` (the paper may still be OA — only the HTML render is missing). Issue #302. | `terminal` | Yes — fetch the PDF instead (`doiget fetch <id>`); do not "fix" the identifier. |
 
 ## 3. Persona × error matrix
 
 | Persona | Surface |
 |---|---|
-| Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, denial_context? } }`. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
+| Agent (MCP) | Structured, never throws. On failure: `{ ok: false, error: { code, message, disposition, denial_context? } }`. `disposition` is ALWAYS present and is the field to branch a retry on — see §2 and ADR-0055. It is derived from `code` by `ErrorCode::disposition`, never hand-written per call site. `remediation` and `attempts` are **not** carried here — they belong to the `{ ok: true, … }` envelope, as `pdf.remediation` (present when the PDF leg was blocked) and top-level `attempts`. A blocked PDF leg is an `ok: true` result with a failed leg, not an `ok: false` call. |
 | Researcher (CLI human) | `cargo`-style stderr: `error[E0007]: rate limited from unpaywall: retry after 1s`. Exit code 1. |
 | CI / Batch (CLI `--json`) | JSON Lines record per ref with `{"ok":false, "error":{"code":"...","message":"...","denial_context":{...}?,"remediation":[...]?,"attempts":[...]?}}`. Exit code = number of failures (capped at 255). **Records are emitted in completion order, not input order** — see below. |
 | Library (Rust) | `Err(FetchError)` (typed via `thiserror`). |


### PR DESCRIPTION
Refs #506 — the disposition contract. Three sub-asks are deliberately out; see the end. The issue stays open.

## The problem

`docs/ERRORS.md` §2 has carried per-code retry guidance since Phase 0, and it is good. **None of it reached the wire:**

```
grep -riE 'retryable|do_not_retry|permanent|transient' crates/doiget-mcp   → 0
grep -riE 'retry' the tool descriptions                                    → 0
```

The failure envelope was `{ok:false, error:{code, message, denial_context?}}`, so an agent's only signal was **the name of the code** — and several names point the wrong way. `NO_OA_AVAILABLE` is the most common failure there is, and both its name and its ERRORS.md row (*"Try later, or enable opt-in source"*) read to a machine as **wait**, when it is nearly always **configure**. That invites an unbounded retry loop over something that will not change on its own.

## Three states, not two

| value | meaning |
|---|---|
| `terminal` | the answer will not change. Do not retry. |
| `retry_after` | it may change on its own. Retry with backoff. |
| `needs_config` | it will not change by itself, but a named change makes it. Surface it; do not loop. |

Two states cannot express the third, and the third is the one that matters most here.

`terminal` also covers failures a caller can act on with a *different* request (`INVALID_REF`, `AMBIGUOUS`, `TEXT_UNAVAILABLE`) — **this** call is settled, which is what a disposition is about. `STORE_ERROR` / `LOG_ERROR` are `needs_config`: a machine cannot name the fix for a full disk, but it must not loop on one either, and "surface this to a human" is exactly that state.

## One source of truth, enforced

`ErrorCode::disposition()` is an **exhaustive match with no wildcard**, so a new code must decide.

`docs/ERRORS.md` §2 gains a Disposition column, and `errors_md_disposition_column_matches_the_code` **parses the shipped document** and asserts every row against the function. This is what the issue asked for:

> the ERRORS.md §2 table either generated from it or asserted against it in a test — otherwise the doc and the wire drift, which is the #493 pattern

Generating the table would have cost the per-code prose, which is the useful part. Asserting keeps both.

The test guards its own parser: it asserts it saw exactly **15** rows, because a parser that silently stops matching passes every time. **Mutation-checked both ways** — flipping one row's value fails with the code and both values named; deleting a row fails with `parsed 14`.

## One builder

All ten literal error objects route through `error_object`. A field present on some failures and absent on others is worse than no field: it teaches the reader to fall back to guessing from the code's name, which is the habit this replaces. After the change, exactly one raw `"code":` remains in `doiget-mcp` — the builder itself.

## Stated where an agent will actually meet it

The contract is in the MCP server `instructions`, delivered on `initialize` to every client — one place rather than twenty-two tool descriptions — and it names the specific trap rather than the general rule:

> Read that field, not the error code's name: NO_OA_AVAILABLE is `needs_config`, not something to wait out.

## Tests

- The drift test above, mutation-checked in both directions.
- The disposition asserted **through the real tool** over the MCP transport (`doiget_resolve_paper` with a malformed ref → `terminal`), not on the helper. A helper that is right and unreached would pass a unit test and change nothing.

## Deliberately not in this PR

The issue has four asks; this is the first, and the other three each have a reason:

- **`error.retry_after_ms`** — `Retry-After` *is* parsed today (`http::parse_retry_after`), but consumed **inside** the retry loop and discarded. By the time an error surfaces the retries are exhausted and no honest number remains. Emitting a plausible default would give the caller a number indistinguishable from a measured one. Plumbing the header out of the loop is its own change.
- **`remediation` on `ok:false`** — ADR-0043's channel keys on `DenialContext`, which is present on only *some* failures. Carrying it for those alone reproduces the sometimes-present problem this PR rejects for `disposition`.
- **`rate_limit_budget` on live responses** — independent of the retry contract.

ADR-0055 records the decision and these exclusions.

Local: fmt, clippy `-D warnings`, rustdoc `-D warnings`, full workspace suite (47 suites, 0 failures), `version-bump-gate.sh`.
