### PR TITLE
feat(mcp): a citation candidate says whether it is an identity or a coincidence (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,40 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
+- **[mcp]** Citation candidates now carry `confidence` and `matched`, so an
+  agent can tell an identity from a coincidence. A 0.5 near-miss and a 1.0 exact
+  match arrived in the same shape, and nothing in the envelope said which was
+  which (#536).
+
+  The reported case: a citation for a paper in *Psychiatria Danubina* came back
+  as a different 2010 paper, in a different journal, by a different author, at
+  `score: 0.5` - `quality`, `life`, `bipolar`, `2010` were enough to clear the
+  bar. Same structure as the `score: 1.0` identity returned minutes earlier.
+
+  A bare float is not judgement material. To use it as a gate the consumer has
+  to already know that the scorer is token overlap rather than semantic
+  similarity, and that **0.5 is the floor** - so the worst candidate the tool
+  can ever emit still looks like a positive number.
+
+  | `confidence` | meaning |
+  |---|---|
+  | `exact` | every query token was found |
+  | `probable` | at least four query tokens in five |
+  | `weak` | cleared the floor and no more - a near-miss, not a match |
+
+  `matched` lists which of the query's tokens were found. In the reported case
+  that is the whole story: not the author, not the journal.
+
+  This is the half of #372 that was never specified. #372's remedy - return the
+  top candidate with its score rather than an empty list, so the calling agent
+  can judge - is in place and correct; what the agent judges *with* was missing.
+  Both citation tool descriptions now say to branch on `confidence`, not
+  `score`.
+
+  **`doiget-core` API:** `ResolvedCandidate` gains two fields and becomes
+  `#[non_exhaustive]`, matching `MetadataOnlyOutcome` and `AttemptOutcome`, so
+  the next field is not another break.
+
 - **[cli]** The found-nothing fetch now reports what it consulted. Previously
   `fetched ... (metadata-only: no OA PDF available)` was byte-identical whether
   the optional sources were on and had nothing or off and never asked - and it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.9"
+version = "0.8.13-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.9"
+version = "0.8.13-beta.10"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.9"
+version = "0.8.13-beta.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.9"
+version       = "0.8.13-beta.10"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.9" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.9" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.9" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.10" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.10" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.10" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/lib.rs
+++ b/crates/doiget-core/src/lib.rs
@@ -906,8 +906,76 @@ pub struct DenialContext {
 // ResolvedCandidate / ResolveResult (Issue #242)
 // ---------------------------------------------------------------------------
 
+/// How much of the query a candidate actually matched, as something an
+/// agent can branch on (#536).
+///
+/// `score` alone is not judgement material. For it to work as a gate, the
+/// consumer has to already know that the scorer is token overlap rather than
+/// semantic similarity, that 0.5 is the FLOOR so the worst candidate the tool
+/// will ever emit still looks like a positive number, and that for a citation
+/// string carrying author + title + journal + volume + year, 0.5 means most of
+/// it did not match. None of that is in the envelope, and an agent consuming a
+/// ranked list takes the head of it.
+///
+/// The reported case: a citation for a paper in *Psychiatria Danubina* came
+/// back as a different 2010 paper in a different journal by a different author
+/// at `score: 0.5` — `quality`, `life`, `bipolar` and `2010` were enough to
+/// clear the floor — in the same shape as a `score: 1.0` identity.
+///
+/// # These are bands over token overlap, not a semantic verdict
+///
+/// [`Self::Exact`] means every token in the query was found somewhere in the
+/// candidate record. That is a strong signal and it is still not proof: a
+/// short query can match the wrong paper completely. The bands make the
+/// difference between "identity" and "coincidence" legible; they do not
+/// remove the need to verify before citing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Confidence {
+    /// Every query token matched. Verify before citing, but this is an
+    /// identity rather than an overlap.
+    Exact,
+    /// At least four query tokens in five matched.
+    Probable,
+    /// Cleared the 0.5 floor and no more. For a known-item lookup this is a
+    /// NEGATIVE result wearing a positive number.
+    Weak,
+}
+
+impl Confidence {
+    /// Band a token-overlap score.
+    ///
+    /// The floor is 0.5 (`MIN_CITATION_SCORE`), so the range actually in play
+    /// is 0.5..=1.0 and the split at 0.8 asks for four tokens in five. `Exact`
+    /// compares against 0.999 rather than 1.0 because the score is a division:
+    /// asking for bit-exact equality would band an all-tokens match as
+    /// `Probable` on a rounding accident.
+    #[must_use]
+    pub fn from_score(score: f64) -> Self {
+        if score >= 0.999 {
+            Self::Exact
+        } else if score >= 0.8 {
+            Self::Probable
+        } else {
+            Self::Weak
+        }
+    }
+
+    /// The wire token, allocation-free.
+    #[must_use]
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Probable => "probable",
+            Self::Weak => "weak",
+        }
+    }
+}
+
 /// A candidate paper resolved from a bibliographic citation string.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ResolvedCandidate {
     /// Resolved DOI.
     pub doi: String,
@@ -918,7 +986,20 @@ pub struct ResolvedCandidate {
     /// Publication year, if resolved.
     pub year: Option<i32>,
     /// Token similarity overlap score in `0.0..=1.0`.
+    ///
+    /// Thresholded at `0.5`, so this is never below the floor — which is
+    /// exactly why it reads as a positive number even at its worst. Branch on
+    /// [`Self::confidence`] instead (#536).
     pub score: f64,
+    /// [`Self::score`] banded into something an agent can branch on without
+    /// knowing anything about the scorer (#536).
+    pub confidence: Confidence,
+    /// The query tokens that were found in this candidate's record.
+    ///
+    /// The evidence behind the score, so a reader can see *what* matched: in
+    /// the #536 case it was `quality`, `life`, `bipolar`, `2010` — none of
+    /// them the author or the journal, which is the whole story.
+    pub matched: Vec<String>,
     /// Resolving metadata source (e.g. `"crossref"`).
     pub source: String,
 }

--- a/crates/doiget-core/src/sources/crossref.rs
+++ b/crates/doiget-core/src/sources/crossref.rs
@@ -179,12 +179,19 @@ impl CrossrefSource {
                 .filter(|s| !s.is_empty())
                 .collect();
 
-            let matched = query_tokens
+            // Collected, not counted: the tokens ARE the evidence, and #536
+            // is a report about a caller being handed a number with no way to
+            // tell an identity from a coincidence. In that case the matches
+            // were `quality`, `life`, `bipolar`, `2010` -- not the author, not
+            // the journal, which is the whole story and was not in the
+            // envelope.
+            let matched: Vec<String> = query_tokens
                 .iter()
                 .filter(|q| candidate_tokens.contains(*q))
-                .count();
+                .cloned()
+                .collect();
 
-            let score = matched as f64 / query_tokens.len() as f64;
+            let score = matched.len() as f64 / query_tokens.len() as f64;
 
             if score >= MIN_CITATION_SCORE {
                 let first_author = fields.authors.first().cloned().unwrap_or_default();
@@ -194,6 +201,8 @@ impl CrossrefSource {
                     author: first_author,
                     year: fields.year,
                     score,
+                    confidence: crate::Confidence::from_score(score),
+                    matched,
                     source: "crossref".to_string(),
                 });
             }
@@ -581,6 +590,66 @@ mod tests {
         assert_eq!(cand.author, "Onsager, Lars");
         assert_eq!(cand.year, Some(1944));
         assert_eq!(cand.score, 1.0);
+        // #536: an identity and a coincidence used to arrive in the same
+        // shape. Every query token was found, so this is the top band.
+        assert_eq!(cand.confidence, crate::Confidence::Exact);
+        let mut got = cand.matched.clone();
+        got.sort();
+        assert_eq!(
+            got,
+            vec!["1944".to_string(), "onsager".to_string()],
+            "the evidence behind the score, not just the score"
+        );
+    }
+
+    /// #536: the reported near-miss and the reported identity, banded.
+    ///
+    /// A citation for a paper in *Psychiatria Danubina* came back as a
+    /// different 2010 paper, in a different journal, by a different author, at
+    /// `score: 0.5` -- `quality`, `life`, `bipolar` and `2010` cleared the
+    /// floor -- in the SAME SHAPE as a `score: 1.0` identity. 0.5 is the floor
+    /// (`MIN_CITATION_SCORE`), so the worst candidate the tool can emit still
+    /// looks like a positive number.
+    #[test]
+    fn the_floor_bands_as_weak_and_a_full_match_bands_as_exact() {
+        use crate::Confidence;
+        assert_eq!(
+            Confidence::from_score(MIN_CITATION_SCORE),
+            Confidence::Weak,
+            "the worst candidate the tool can emit must not read as a match"
+        );
+        assert_eq!(Confidence::from_score(1.0), Confidence::Exact);
+
+        // Four tokens in five is the `probable` boundary; below it, `weak`.
+        assert_eq!(Confidence::from_score(0.8), Confidence::Probable);
+        assert_eq!(Confidence::from_score(0.79), Confidence::Weak);
+
+        // `Exact` compares against 0.999, not 1.0: the score is a division,
+        // and banding an all-tokens match as `Probable` on a rounding
+        // accident would be the same defect in miniature.
+        assert_eq!(Confidence::from_score(7.0 / 7.0), Confidence::Exact);
+        assert_eq!(Confidence::from_score(0.9999), Confidence::Exact);
+    }
+
+    /// The bands must stay ordered with the score they band, or the enum says
+    /// something the number contradicts.
+    #[test]
+    fn confidence_is_monotonic_in_the_score() {
+        use crate::Confidence;
+        let rank = |c| match c {
+            Confidence::Weak => 0,
+            Confidence::Probable => 1,
+            // No wildcard: `#[non_exhaustive]` binds DOWNSTREAM crates, not
+            // this one, so a new band has to be ranked here before it compiles.
+            Confidence::Exact => 2,
+        };
+        let mut prev = 0;
+        for i in 50..=100 {
+            let r = rank(Confidence::from_score(f64::from(i) / 100.0));
+            assert!(r >= prev, "score {i}/100 banded below a lower score");
+            prev = r;
+        }
+        assert_eq!(prev, 2, "the top of the range must reach Exact");
     }
 
     #[tokio::test]

--- a/crates/doiget-mcp/src/lib.rs
+++ b/crates/doiget-mcp/src/lib.rs
@@ -2194,10 +2194,10 @@ impl Server {
     #[tool(
         description = "WHEN TO USE: Resolve a free-form bibliographic citation string (e.g. 'Onsager 1944') to ranked DOI candidates.\n\
                        INPUTS: query (bibliographic citation query string), limit (maximum number of candidates to return, default: 5).\n\
-                       OUTPUTS: { ok: true, query, candidates: [ { doi, title, author, year, score, source } ] } OR { ok: false, error }.\n\
+                       OUTPUTS: { ok: true, query, candidates: [ { doi, title, author, year, score, confidence, matched, source } ] } OR { ok: false, error }.\n\
                        COSTS: 1-2 s round-trip.\n\
                        SIDE EFFECTS: none.\n\
-                       LIMITS: Returns candidates with similarity score >= 0.5.",
+                       LIMITS: Returns candidates with similarity score >= 0.5. BRANCH ON confidence, NOT score: the score is token overlap against your query string and 0.5 is the FLOOR, so the worst candidate this tool can emit still looks like a positive number. confidence is exact (every query token matched), probable (four in five), or weak (cleared the floor and no more) - for a known-item lookup a weak candidate is a near-miss, not a match, so verify it with doiget_resolve_paper before citing. matched lists which of your tokens were found, which is how you see whether the author and the journal were among them.",
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -2249,10 +2249,10 @@ impl Server {
     #[tool(
         description = "WHEN TO USE: Resolve multiple free-form bibliographic citation strings in batch.\n\
                        INPUTS: queries (array of query strings), limit (maximum number of candidates per query, default: 5).\n\
-                       OUTPUTS: { ok: true, results: [ { query, candidates: [ { doi, title, author, year, score, source } ] } ] } OR { ok: false, error }.\n\
+                       OUTPUTS: { ok: true, results: [ { query, candidates: [ { doi, title, author, year, score, confidence, matched, source } ] } ] } OR { ok: false, error }.\n\
                        COSTS: 1-2 s round-trip per query.\n\
                        SIDE EFFECTS: none.\n\
-                       LIMITS: Returns candidates with similarity score >= 0.5. At most 50 queries per call.",
+                       LIMITS: Returns candidates with similarity score >= 0.5. At most 50 queries per call. BRANCH ON confidence, NOT score: the score is token overlap against your query string and 0.5 is the FLOOR, so the worst candidate this tool can emit still looks like a positive number. confidence is exact (every query token matched), probable (four in five), or weak (cleared the floor and no more) - for a known-item lookup a weak candidate is a near-miss, not a match, so verify it with doiget_resolve_paper before citing. matched lists which of your tokens were found, which is how you see whether the author and the journal were among them.",
         annotations(
             read_only_hint = true,
             destructive_hint = false,

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -374,3 +374,28 @@ failure.
 `doiget_batch_resolve_citations` batch-resolves multiple citation strings (up to 50).
 
 Both tools calculate token-based overlap similarity scores, filter out results with a score < 0.5, and sort candidates by score descending. No local store writes or provenance logs are created.
+
+### Branch on `confidence`, not `score` (#536)
+
+Each candidate carries `confidence` and `matched` alongside `score`.
+
+`score` alone is not enough to judge with. It is **token overlap against your
+query string**, not semantic similarity, and 0.5 is the **floor** — so the
+worst candidate these tools can emit still looks like a positive number. A
+citation naming an author, a title, a journal, a volume and a year that comes
+back at 0.5 means most of it did not match, which for a known-item lookup is a
+negative result.
+
+| `confidence` | meaning |
+|---|---|
+| `exact` | every query token was found in the candidate's record |
+| `probable` | at least four query tokens in five |
+| `weak` | cleared the 0.5 floor and no more — a near-miss, not a match |
+
+`matched` lists which of your tokens were found, which is how you see whether
+the author and the journal were among them. In the case that produced #536 they
+were `quality`, `life`, `bipolar`, `2010` — and the returned paper was by a
+different author in a different journal.
+
+These are bands over token overlap, not a semantic verdict: `exact` is a strong
+signal and still not proof, so verify with `doiget_resolve_paper` before citing.

--- a/site/content/developer/mcp-tools.md
+++ b/site/content/developer/mcp-tools.md
@@ -380,3 +380,28 @@ failure.
 `doiget_batch_resolve_citations` batch-resolves multiple citation strings (up to 50).
 
 Both tools calculate token-based overlap similarity scores, filter out results with a score < 0.5, and sort candidates by score descending. No local store writes or provenance logs are created.
+
+### Branch on `confidence`, not `score` (#536)
+
+Each candidate carries `confidence` and `matched` alongside `score`.
+
+`score` alone is not enough to judge with. It is **token overlap against your
+query string**, not semantic similarity, and 0.5 is the **floor** — so the
+worst candidate these tools can emit still looks like a positive number. A
+citation naming an author, a title, a journal, a volume and a year that comes
+back at 0.5 means most of it did not match, which for a known-item lookup is a
+negative result.
+
+| `confidence` | meaning |
+|---|---|
+| `exact` | every query token was found in the candidate's record |
+| `probable` | at least four query tokens in five |
+| `weak` | cleared the 0.5 floor and no more — a near-miss, not a match |
+
+`matched` lists which of your tokens were found, which is how you see whether
+the author and the journal were among them. In the case that produced #536 they
+were `quality`, `life`, `bipolar`, `2010` — and the returned paper was by a
+different author in a different journal.
+
+These are bands over token overlap, not a semantic verdict: `exact` is a strong
+signal and still not proof, so verify with `doiget_resolve_paper` before citing.


### PR DESCRIPTION
Closes #536.

## The report

Two calls from one session, minutes apart, arriving in the **same shape**:

| | | |
|---|---|---|
| `score: 1.0` | Coryell 1998 | the paper asked for |
| `score: 0.5` | Latalova 2010 | a different paper, different journal, different author |

`quality`, `life`, `bipolar`, `2010` were enough to clear the bar. Both came back as a single-element `candidates` array with identical structure, and nothing said which was which.

**A bare float is not judgement material.** For `score` to work as a gate, the consumer must already know that the scorer is token overlap and not semantic similarity; that **0.5 is the floor**, so the worst candidate the tool can ever emit still looks like a positive number; and that for a citation carrying author + title + journal + volume + year, 0.5 means most of it did not match. None of that was on the wire, and an agent consuming a ranked list takes the head of it.

## The fix

| `confidence` | meaning |
|---|---|
| `exact` | every query token was found |
| `probable` | at least four query tokens in five |
| `weak` | cleared the floor and no more — a near-miss, not a match |

Plus `matched`: which of the query's tokens were found. That is the evidence, and in the reported case it is the whole story — **not the author, not the journal**.

Both citation tool descriptions now say to branch on `confidence` rather than `score`, and to verify a `weak` candidate with `doiget_resolve_paper` before citing. The tool description is what an agent reads when it has never opened `MCP_TOOLS.md`.

## What this does not change

- **#242's floor stays exactly where it is.** No change to which candidates are returned.
- **#372's remedy stays.** Returning the top candidate with its score rather than an empty list, *"so the calling agent can judge"*, is in place and correct. This is the half of #372 that was never specified: what the agent judges **with**.
- **The bands are over token overlap, not a semantic verdict.** `exact` means every token matched — a strong signal and still not proof. The docs say so rather than implying the tool has become an oracle.

## Details worth a look

- `Exact` compares against **0.999**, not 1.0. The score is a division; banding an all-tokens match as `probable` on a rounding accident would be this same defect in miniature. Tested with `7.0 / 7.0`.
- `matched` is **collected rather than counted** — the scorer already computed exactly this and threw it away.
- A `confidence_is_monotonic_in_the_score` test walks 0.50→1.00 and asserts the band never goes down as the score goes up, so the enum cannot say something the number contradicts.
- Clippy caught an `_ => unreachable!()` in that test: `#[non_exhaustive]` binds *downstream* crates, not the defining one, so the wildcard was dead and a new band would have silently fallen into it. Removed — a new band now has to be ranked before it compiles.

## API

`ResolvedCandidate` gains two fields and becomes `#[non_exhaustive]`, matching `MetadataOnlyOutcome` / `AttemptOutcome` / `FetchError`, so the next field is not another break. Called out in the CHANGELOG under the `doiget-core` semver note. Only two literal construction sites existed, both in-crate.

Local: fmt, clippy `-D warnings`, rustdoc `-D warnings`, full workspace suite (47 suites, 0 failures), `version-bump-gate.sh`.
