### PR TITLE
fix(fetch): OpenAlex named the repository; the run said nothing was there (#547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,27 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Fixed
 
+- **[fetch]** When OpenAlex named a repository copy that could not be followed, the
+  run said `no OA PDF available` - a different claim from what OpenAlex actually
+  reported (#547).
+
+  `10.1109/tsp.2023.3269664` has two OpenAlex locations, and the second **is** the
+  Strathprints institutional deposit. It has no `pdf_url`, `is_oa` is `false`, and
+  its `landing_page_url` is an author-listing page (`/view/author/70486.html`)
+  rather than an item, so `open_access_pdf_url` correctly returns nothing. The
+  fact that a repository had been NAMED then reached only a `tracing::debug!`.
+
+  The attempt row now carries what the source said: how many locations, how many
+  flagged OA, how many had a PDF URL, and the repository's name. "openalex named
+  2 location(s) (IEEE Transactions on Signal Processing; Strathprints: The
+  University of Strathclyde): 0 flagged open access, 0 with a PDF URL" points the
+  reader at the repository. "no OA PDF available" points them at giving up.
+
+  Diagnostics only - no new request, no change to what is fetched. The report's
+  second suggestion, following a repository platform's own search when its URL is
+  not an item, is a real capability change and belongs with #474; #547 stays open
+  for it.
+
 - **[core]** An access refusal was classified by reading an error message back.
   A source saying "I found it and cannot give it to you" returned
   `FetchError::SourceSchema` with an explanatory hint, and the orchestrator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.10"
+version = "0.8.13-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.10"
+version = "0.8.13-beta.11"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.10"
+version = "0.8.13-beta.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.11"
+version = "0.8.13-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.11"
+version = "0.8.13-beta.12"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.11"
+version = "0.8.13-beta.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.11"
+version       = "0.8.13-beta.12"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.11" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.11" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.11" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.12" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.12" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.12" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.10"
+version       = "0.8.13-beta.11"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.10" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.10" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.10" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.11" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.11" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.11" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-core/src/orchestrator.rs
+++ b/crates/doiget-core/src/orchestrator.rs
@@ -1882,6 +1882,21 @@ async fn fetch_paper_doi(
 /// request to arrive at a page the chain cannot read, and report a
 /// confusing failure. A source that contributes nothing is not a silent
 /// gap: it still appears in the attempt trace with its own outcome.
+/// What a source said about where the work lives, when it named somewhere
+/// but nothing followable (#547).
+///
+/// Only OpenAlex today: it is the source that reports EVERY location rather
+/// than a best one, so it is the one that can name a repository copy and still
+/// hand back no URL. The others surface a single document URL or nothing, and
+/// "nothing" is already what the trace says.
+#[cfg(feature = "metadata")]
+fn describe_optional_source_locations(source: &str, meta: &Value) -> Option<String> {
+    match source {
+        "openalex" => crate::sources::openalex::describe_locations(meta),
+        _ => None,
+    }
+}
+
 #[cfg(feature = "metadata")]
 fn optional_source_oa_url<'a>(source: &str, meta: &'a Value) -> Option<&'a str> {
     match source {
@@ -1972,6 +1987,17 @@ async fn try_optional_source_oa_fallback(
         }
     };
     let Some(raw) = optional_source_oa_url(name, &meta) else {
+        // #547: the source ANSWERED and named somewhere the work lives; what
+        // it named was just not followable. That is a different fact from
+        // "nobody has a copy", and it used to reach only a `tracing::debug!`
+        // -- so a run whose OpenAlex record pointed straight at an
+        // institutional repository reported `no OA PDF available` and gave the
+        // reader nothing to act on.
+        if let Some(detail) = describe_optional_source_locations(name, &meta) {
+            if let Some(row) = attempts.iter_mut().find(|a| a.source == name) {
+                row.outcome = AttemptOutcome::NotOpenAccess { detail };
+            }
+        }
         tracing::debug!(
             source = name,
             doi = %doi.as_str(),

--- a/crates/doiget-core/src/sources/openalex.rs
+++ b/crates/doiget-core/src/sources/openalex.rs
@@ -255,6 +255,66 @@ pub fn open_access_pdf_url(record: &serde_json::Value) -> Option<&str> {
         })
 }
 
+/// What OpenAlex actually said about where this work lives, for the case
+/// where [`open_access_pdf_url`] found nothing usable (#547).
+///
+/// That function needs `is_oa == true` AND a non-empty `pdf_url`, and a
+/// location can fail both while still being a real repository copy. The
+/// reported DOI has two locations, the second of which IS the institutional
+/// deposit -- but its `landing_page_url` is an author-listing page
+/// (`/view/author/70486.html`), not an item, and `is_oa` is `false`. So the
+/// extractor correctly returns `None`, the run reports "no OA PDF available",
+/// and the fact that a repository was NAMED goes nowhere.
+///
+/// "OpenAlex named 1 repository location; its URL is not an item page" points
+/// the reader at the repository. "no OA PDF available" points them at giving
+/// up. Returns `None` when there is nothing to say.
+#[must_use]
+pub fn describe_locations(record: &serde_json::Value) -> Option<String> {
+    let locations = record
+        .get("locations")
+        .and_then(serde_json::Value::as_array)?;
+    if locations.is_empty() {
+        return None;
+    }
+
+    let mut oa = 0usize;
+    let mut with_pdf = 0usize;
+    let mut named: Vec<&str> = Vec::new();
+    for loc in locations {
+        if loc.get("is_oa").and_then(serde_json::Value::as_bool) == Some(true) {
+            oa += 1;
+        }
+        if loc
+            .get("pdf_url")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|u| !u.is_empty())
+        {
+            with_pdf += 1;
+        }
+        if let Some(host) = loc
+            .get("source")
+            .and_then(|s| s.get("display_name"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+        {
+            if !named.contains(&host) {
+                named.push(host);
+            }
+        }
+    }
+
+    let hosts = if named.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", named.join("; "))
+    };
+    Some(format!(
+        "openalex named {} location(s){hosts}: {oa} flagged open access,          {with_pdf} with a PDF URL. A location without a PDF URL may still be          a real deposit whose landing page is not an item page",
+        locations.len()
+    ))
+}
+
 fn truncate_for_hint(body: &[u8]) -> String {
     const MAX: usize = 200;
     let s = String::from_utf8_lossy(body);
@@ -272,6 +332,74 @@ fn truncate_for_hint(body: &[u8]) -> String {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
+
+    /// #547, with the shape the report measured for `10.1109/tsp.2023.3269664`.
+    ///
+    /// Two locations. The second IS the Strathprints deposit -- and it has no
+    /// `pdf_url`, `is_oa: false`, and a `landing_page_url` pointing at an
+    /// author-listing page rather than an item. `open_access_pdf_url`
+    /// correctly returns `None`; the run then reported `no OA PDF available`,
+    /// which is a different claim from what OpenAlex actually said.
+    #[test]
+    fn a_named_but_unusable_location_is_described_rather_than_dropped() {
+        let record = serde_json::json!({
+            "locations": [
+                {
+                    "is_oa": false,
+                    "pdf_url": serde_json::Value::Null,
+                    "landing_page_url": "https://doi.org/10.1109/tsp.2023.3269664",
+                    "source": { "display_name": "IEEE Transactions on Signal Processing" }
+                },
+                {
+                    "is_oa": false,
+                    "pdf_url": serde_json::Value::Null,
+                    "landing_page_url": "https://strathprints.strath.ac.uk/view/author/70486.html",
+                    "source": { "display_name": "Strathprints: The University of Strathclyde" }
+                }
+            ]
+        });
+
+        assert!(
+            open_access_pdf_url(&record).is_none(),
+            "premise: the extractor still finds nothing followable"
+        );
+
+        let d = describe_locations(&record).expect("locations were named");
+        assert!(d.contains("2 location"), "says how many: {d}");
+        assert!(
+            d.contains("Strathprints"),
+            "NAMES the repository, which is what the reader can act on: {d}"
+        );
+        assert!(
+            d.contains("0 with a PDF URL"),
+            "and why none was followed: {d}"
+        );
+    }
+
+    /// The control from the report: a proper item PDF URL at the same
+    /// repository still resolves, so this describes a gap rather than
+    /// papering over one.
+    #[test]
+    fn a_usable_location_still_resolves_and_needs_no_description() {
+        let record = serde_json::json!({
+            "locations": [{
+                "is_oa": true,
+                "pdf_url": "https://strathprints.strath.ac.uk/91130/7/Khattak-etal.pdf",
+                "source": { "display_name": "Strathprints: The University of Strathclyde" }
+            }]
+        });
+        assert_eq!(
+            open_access_pdf_url(&record),
+            Some("https://strathprints.strath.ac.uk/91130/7/Khattak-etal.pdf")
+        );
+    }
+
+    /// Nothing to say when nothing was named.
+    #[test]
+    fn no_locations_means_no_description() {
+        assert!(describe_locations(&serde_json::json!({})).is_none());
+        assert!(describe_locations(&serde_json::json!({"locations": []})).is_none());
+    }
     use super::*;
 
     use std::sync::Arc;


### PR DESCRIPTION
Refs #547 — the diagnostic half. The capability half is left for #474; the issue stays open.

## What was happening

`doiget fetch 10.1109/tsp.2023.3269664` with all six optional sources on: `no OA PDF available`.

OpenAlex is not silent about that DOI. It returns **two locations**, and the second **is** the Strathprints institutional deposit:

```
locations: 2
  - IEEE Transactions on Signal Processing        | https://doi.org/10.1109/tsp.2023.3269664
  - Strathprints: The University of Strathclyde   | .../view/author/70486.html
```

That location has no `pdf_url`, `is_oa` is `false`, and its `landing_page_url` is an **author-listing page**, not an item. So `open_access_pdf_url` correctly finds nothing followable.

**What was wrong is what happened next.** The fact that a repository had been named reached a `tracing::debug!` and stopped there:

```rust
let Some(raw) = optional_source_oa_url(name, &meta) else {
    tracing::debug!(source = name, "optional source resolved but reported no document URL");
    return (pdf_leg, pdf_bytes);
};
```

## The change

The attempt row now carries what the source actually said:

```
openalex named 2 location(s) (IEEE Transactions on Signal Processing; Strathprints:
The University of Strathclyde): 0 flagged open access, 0 with a PDF URL. A location
without a PDF URL may still be a real deposit whose landing page is not an item page
```

That points the reader at the repository. `no OA PDF available` points them at giving up. This is the same shape as #505, and composes with it — the found-nothing path prints the trace, and the trace now has this in it.

**Diagnostics only.** No new request, no change to what is fetched, and no change to `open_access_pdf_url`'s gate.

## Not papering over it

The report includes a control — `10.1109/access.2024.3495502`, same authors, same repository, a proper item PDF URL — which fetches successfully today. There is a test asserting it **still** resolves by the same route, so this describes a gap rather than hiding one.

Only OpenAlex is described. It is the source that reports *every* location rather than a best one, so it is the only one that can name a copy and still hand back no URL; the others surface a document URL or nothing, and "nothing" is already what the trace says.

## Tests

Built from the shape the report measured, not invented:

- the two-location record with the author-listing URL → described, naming Strathprints and `0 with a PDF URL`, with `open_access_pdf_url` asserted to still return `None` (the premise);
- the control record → still resolves;
- no locations → nothing to say, so the common path gains no noise.

## Left for #474

The report's second suggestion — when a location's host is a known repository platform and its URL is not an item, use the platform's own search (EPrints answers `/cgi/search/advanced?title=…`) — is a real capability change, not a diagnostic one, and the issue itself says it probably belongs with #474's survey. I agree: it adds an outbound interface to a new class of host, which is an access-surface decision rather than a bug fix.

The report also records a methodology trap worth keeping: two search attempts returned zero hits for *method* reasons (the EPrints endpoint 302-redirects and needs `-L`; the DOI field is not `id_number`), and only a positive control on a known-deposited paper separated that from real absence. Whoever picks up #474 should read that paragraph first.

Local: fmt, clippy `-D warnings` (`oa-only,metadata`), rustdoc `-D warnings` on the full feature surface, workspace suite 47/47.
