### PR TITLE
feat(cli): rank the sources not consulted, and say which part is a guess (#505 part 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,36 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
+- **[cli]** The found-nothing path now orders the sources it did not consult -
+  and says which part of that order is a finding and which is not (#505 part 3).
+
+  The issue is emphatic about the risk, and it governs the whole design: *"a
+  ranking that is wrong is worse than no ranking, because it makes people stop
+  early."*
+
+  ```
+    = note: of the sources not consulted:
+        1. openalex     lists every location a work has -- a lookup, not a guess
+        then, in NO particular order: doaj  europe-pmc  hal  openaire
+        last: core      the broadest index outside Unpaywall, so never the first try
+  ```
+
+  Two positions have a real signal. `openalex` is categorically different from
+  everything else in the list: it *lists* a work's locations, so with it enabled
+  the answer is "this repository has it", not "might". `core` is last on its own
+  module's documented grounds - broadest means least discriminating.
+
+  **The middle is returned unordered, deliberately.** The issue proposes ranking
+  it on venue, author affiliation and funder; none of those reach this point -
+  `FetchPaperOutcome` carries title, authors and year, and the DOI-prefix map is
+  Tier-3-only (ADR-0041) and absent from an `oa-only` build entirely. Rendering
+  an invented order would put a guess in the shape of a finding, which is the
+  one thing this must not do, so the output says so instead.
+
+  It is an ordering of the **full** list, never a shortlist: a source dropped
+  from the list is a source the reader will not try, and there is a test that
+  every unconsulted source appears somewhere.
+
 - **[dist]** Homebrew. `#247` promised a tap in 2026-06 and was closed as
   completed; measured against 0.8.12 it was one of the rows that did not exist
   (#501).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.15"
+version = "0.8.13-beta.16"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.15"
+version = "0.8.13-beta.16"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.15"
+version = "0.8.13-beta.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.15"
+version       = "0.8.13-beta.16"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.15" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.15" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.15" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.16" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.16" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.16" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-cli/src/commands/fetch.rs
+++ b/crates/doiget-cli/src/commands/fetch.rs
@@ -1297,6 +1297,55 @@ fn render_blocked_error(
 /// reached.
 ///
 /// Three blocks: what ran, what did not, and the line to paste.
+/// Order the sources that were NOT consulted, for the found-nothing path
+/// (#505 part 3).
+///
+/// The issue is explicit about the risk, and it governs this whole function:
+///
+/// > a ranking that is wrong is worse than no ranking, because it makes people
+/// > stop early. So it must be an *ordering* of the full list, never a
+/// > shortlist, and it must name the signal it ranked on.
+///
+/// Two positions have a real signal and the middle does not, so only two are
+/// ranked:
+///
+/// * **`openalex` first.** It is categorically different from the rest: it
+///   *lists* every location a work has, so with it enabled the answer is "this
+///   repository has it", not "this repository might". Item 1 is a lookup; the
+///   others are guesses, and the issue is emphatic that presenting both in one
+///   list without saying which is which is the failure mode it is about.
+/// * **`core` last.** Not a guess either -- its own module doc calls it "the
+///   broadest single OA index outside Unpaywall and therefore the LAST fallback
+///   in the chain". Broadest means least discriminating, so it is never the
+///   first thing to try and never absent from the list.
+///
+/// **Everything between them is returned unordered, deliberately.** The issue
+/// proposes ranking the middle on venue, author affiliation and funder, and
+/// none of those reach this point: `FetchPaperOutcome` carries `title`,
+/// `authors` and `year`, and the DOI prefix map is Tier-3-only (ADR-0041,
+/// publisher TDM scoping) and absent from an `oa-only` build entirely. Putting
+/// them in an order anyway would render a guess in the shape of a finding,
+/// which is the one thing this must not do.
+fn rank_unconsulted(
+    attempts: &[SourceAttempt],
+) -> (Vec<&'static str>, Vec<&'static str>, Vec<&'static str>) {
+    let mut first = Vec::new();
+    let mut middle = Vec::new();
+    let mut last = Vec::new();
+    for a in attempts {
+        if a.outcome.required_env().is_none() {
+            continue;
+        }
+        match a.source {
+            "openalex" => first.push(a.source),
+            "core" => last.push(a.source),
+            other => middle.push(other),
+        }
+    }
+    middle.sort_unstable();
+    (first, middle, last)
+}
+
 fn not_found_trace_lines(ref_: &Ref, attempts: &[SourceAttempt]) -> Vec<String> {
     let mut out = Vec::new();
     if attempts.is_empty() {
@@ -1341,6 +1390,38 @@ fn not_found_trace_lines(ref_: &Ref, attempts: &[SourceAttempt]) -> Vec<String> 
             "  = note: {} already set, but the source is still off -- this              binary was built without the Cargo feature that provides it.              Widening needs a differently-built binary, not another variable.",
             already_set.join(", ")
         ));
+    }
+
+    // #505 part 3. Ordered only where there is something to order on; see
+    // `rank_unconsulted`.
+    let (first, middle, last) = rank_unconsulted(attempts);
+    if !first.is_empty() || !middle.is_empty() || !last.is_empty() {
+        out.push("  = note: of the sources not consulted:".to_string());
+        for s in &first {
+            out.push(format!(
+                "      1. {s:<12} lists every location a work has -- a lookup, not a guess"
+            ));
+        }
+        if !middle.is_empty() {
+            out.push(format!(
+                "      then, in NO particular order: {}",
+                middle.join("  ")
+            ));
+        }
+        for s in &last {
+            out.push(format!(
+                "      last: {s:<9} the broadest index outside Unpaywall, so never the first try"
+            ));
+        }
+        // Naming the signal is half of what the ranking is for. Saying "the
+        // middle has none" is the honest form of that, and it stops the list
+        // reading as an ordering it is not.
+        if !middle.is_empty() {
+            out.push(
+                "  = note: the middle is unordered because nothing in this run distinguishes                  those sources -- venue, affiliation and funder would, and none of them reach                  here. An invented order would read as information."
+                    .to_string(),
+            );
+        }
     }
 
     out
@@ -2348,6 +2429,124 @@ host = "*.uj.edu.pl"
         assert!(
             joined.contains("DOIGET_ENABLE_HAL=1 doiget fetch 10.1137/0117004"),
             "the widening command must be runnable as printed:
+{joined}"
+        );
+    }
+
+    /// #505 part 3, and the property the issue cares about most: the ranking
+    /// is an ORDERING OF THE FULL LIST, never a shortlist.
+    ///
+    /// > a ranking that is wrong is worse than no ranking, because it makes
+    /// > people stop early.
+    ///
+    /// A source that is dropped from the list is a source the reader will not
+    /// try, so every unconsulted source must appear somewhere.
+    #[test]
+    fn the_ranking_lists_every_unconsulted_source_and_drops_none() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        let disabled = |name: &'static str, env: &'static [&'static str]| {
+            SourceAttempt::new(name, AttemptOutcome::Disabled { env })
+        };
+        let attempts = vec![
+            SourceAttempt::new("crossref", AttemptOutcome::NoRecord),
+            disabled("core", &["DOIGET_ENABLE_CORE"]),
+            disabled("openalex", &["DOIGET_ENABLE_OPENALEX"]),
+            disabled("hal", &["DOIGET_ENABLE_HAL"]),
+            disabled("europe-pmc", &["DOIGET_ENABLE_EUROPE_PMC"]),
+        ];
+
+        let (first, middle, last) = rank_unconsulted(&attempts);
+        let mut all: Vec<&str> = first
+            .iter()
+            .chain(middle.iter())
+            .chain(last.iter())
+            .copied()
+            .collect();
+        all.sort_unstable();
+        assert_eq!(
+            all,
+            vec!["core", "europe-pmc", "hal", "openalex"],
+            "every source that was not consulted must appear, and only those"
+        );
+
+        // A consulted source contributes nothing: it already answered.
+        assert!(!all.contains(&"crossref"));
+
+        // The two positions that HAVE a signal.
+        assert_eq!(first, vec!["openalex"], "the lookup goes first");
+        assert_eq!(last, vec!["core"], "the broadest index goes last");
+        assert_eq!(middle, vec!["europe-pmc", "hal"]);
+    }
+
+    /// The rendered form must mark item 1 as categorically different and must
+    /// say the middle is unordered. Presenting a lookup and a guess in one
+    /// list without saying which is which is the failure mode #505 is about.
+    #[test]
+    fn the_rendered_ranking_says_which_part_is_a_guess() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        let ref_ = Ref::parse("10.1137/0117004").expect("valid doi");
+        let attempts = vec![
+            SourceAttempt::new("crossref", AttemptOutcome::NoRecord),
+            SourceAttempt::new(
+                "openalex",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_OPENALEX"],
+                },
+            ),
+            SourceAttempt::new(
+                "hal",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_HAL"],
+                },
+            ),
+            SourceAttempt::new(
+                "core",
+                AttemptOutcome::Disabled {
+                    env: &["DOIGET_ENABLE_CORE"],
+                },
+            ),
+        ];
+        let joined = not_found_trace_lines(&ref_, &attempts).join(
+            "
+",
+        );
+
+        assert!(
+            joined.contains("a lookup, not a guess"),
+            "item 1 must be marked as categorically different:
+{joined}"
+        );
+        assert!(
+            joined.contains("NO particular order"),
+            "the middle must not read as an ordering:
+{joined}"
+        );
+        assert!(
+            joined.contains("An invented order would read as information"),
+            "and it must say WHY there is no order, which is the named signal:
+{joined}"
+        );
+        assert!(
+            joined.contains("never the first try"),
+            "core's position must carry its own reason:
+{joined}"
+        );
+    }
+
+    /// Nothing to rank when nothing was skipped, and the common path gains no
+    /// noise from a feature about the uncommon one.
+    #[test]
+    fn a_run_that_skipped_nothing_gets_no_ranking() {
+        use doiget_core::orchestrator::{AttemptOutcome, SourceAttempt};
+        let ref_ = Ref::parse("10.1137/0117004").expect("valid doi");
+        let attempts = vec![SourceAttempt::new("crossref", AttemptOutcome::NoRecord)];
+        let joined = not_found_trace_lines(&ref_, &attempts).join(
+            "
+",
+        );
+        assert!(
+            !joined.contains("not consulted:"),
+            "no skipped sources means no ranking block:
 {joined}"
         );
     }


### PR DESCRIPTION
Refs #505 — **part 3**, the last of the three. Parts 1–2 shipped in #566.

## The constraint that shaped this

> a ranking that is wrong is worse than no ranking, because it makes people stop early. So it must be an *ordering* of the full list, never a shortlist, and it must name the signal it ranked on.

```
  = note: of the sources not consulted:
      1. openalex     lists every location a work has -- a lookup, not a guess
      then, in NO particular order: doaj  europe-pmc  hal  openaire
      last: core      the broadest index outside Unpaywall, so never the first try
  = note: the middle is unordered because nothing in this run distinguishes those
    sources -- venue, affiliation and funder would, and none of them reach here.
    An invented order would read as information.
```

## Two positions have a signal; the middle does not

**`openalex` first.** It is categorically different from everything else in the list — it *lists* a work's locations, so with it enabled the answer is "this repository **has** it", not "might". The issue makes exactly this point, and is emphatic that presenting a lookup and a guess in one list without saying which is which is the failure mode it is about. So item 1 is labelled as a lookup and the rest are not.

**`core` last.** Also not a guess: its own module doc calls it *"the broadest single OA index outside Unpaywall and therefore the LAST fallback in the chain"*. Broadest means least discriminating — never the first try, never absent from the list.

**The middle is returned unordered, on purpose.** I checked what the proposed signals would need *before* writing the ranking, not after:

| proposed signal | available here? |
|---|---|
| venue / subject | **no** — `FetchPaperOutcome` carries `title`, `authors`, `year` |
| author affiliation | **no** |
| funder | **no** |
| DOI prefix → registrant (ADR-0041) | **Tier-3 only**, and a local struct inside one function — absent from an `oa-only` build entirely |

So ordering `europe-pmc` above `hal` above `openaire` would be an ordering with nothing behind it, rendered in the shape of a finding. That is precisely what the issue says not to do, so the output states that the middle has no order and why, which is the honest form of "name the signal you ranked on".

The DOI-prefix map deserves a note: it is real, but it maps to **TDM** sources, and a TDM source is the publisher's own copy under a licensed agreement — not an alternative OA host. Mixing it into an OA ranking would misrepresent both. It is also `#[cfg]`-gated out of the published binary by ADR-0002, so in the build most people run it does not exist.

## Full list, never a shortlist

A source dropped from the list is a source the reader will not try. `the_ranking_lists_every_unconsulted_source_and_drops_none` asserts that every unconsulted source appears in exactly one band, and that a source which *was* consulted contributes nothing — it already answered.

## Tests

- every unconsulted source appears, and only those;
- item 1 is marked "a lookup, not a guess", the middle says "NO particular order", the closing line says why, and `core` carries its own reason — all asserted on the rendered output, since the wording *is* the feature here;
- a run that skipped nothing prints no ranking block, so the common path gains no noise.

Local: fmt, clippy `-D warnings`, workspace suite 47/47, `version-bump-gate.sh`.

## #505 after this

All three parts are in. The issue can close once this lands, unless you want the venue/affiliation signals plumbed onto `FetchPaperOutcome` first — that would make the middle rankable and is a separate change with its own cost.
