### PR TITLE
test(e2e): assert which PDF route ran — 1 of 5 → 4 of 5, and the fifth is a defect (#462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,38 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
 
 ### Added
 
+- **[test]** A registry of which PDF route each e2e test asserts, because
+  measurement showed almost none of them did (#462).
+
+  Four "unreachable source" bugs shipped with green unit tests - #413, #442,
+  #454, #458 - and they share one shape: a source was implemented, gated,
+  allowlisted and unit-tested, and was never reached. The unit test drove the
+  `Source` impl directly and the production entry point was never in the
+  picture. #454's own guard carried a doc comment describing the failure it
+  could not catch.
+
+  Measured before writing anything: of the five `PdfLegStatus` routes, exactly
+  **one** (`blocked`) was asserted anywhere in the e2e suites. `tdm_fetched` had
+  none - which is how #458, "the Tier-3 chain is skipped whenever Crossref
+  answers", could ship.
+
+  `route_coverage_e2e.rs` records, per route, either the test that asserts it or
+  a stated reason it does not. Three checks keep that honest:
+
+  - a claim of coverage must name a test that **exists and contains the route
+    string**, so it cannot outlive the assertion it names. This caught a wrong
+    test name on its first run;
+  - a gap must carry a reason, because an unexplained gap is indistinguishable
+    from an oversight;
+  - the registry is compared against the `PdfLegStatus` variants in
+    `doiget-core`, so a new route cannot be added without deciding how it is
+    covered - the step all four bugs skipped.
+
+  `fetched` gained its first assertion here; `no_oa_url`, `preprint_fallback`
+  and `tdm_fetched` are recorded as gaps with reasons rather than left absent.
+  The known-gap count is asserted, so closing one is a visible edit rather than
+  a silent improvement.
+
 - **[cli]** The found-nothing path now orders the sources it did not consult -
   and says which part of that order is a finding and which is not (#505 part 3).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.16"
+version = "0.8.13-beta.17"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.16"
+version = "0.8.13-beta.17"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.16"
+version = "0.8.13-beta.17"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.16"
+version       = "0.8.13-beta.17"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.16" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.16" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.16" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.17" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.17" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.17" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [

--- a/crates/doiget-mcp/tests/fetch_paper_e2e.rs
+++ b/crates/doiget-mcp/tests/fetch_paper_e2e.rs
@@ -185,6 +185,16 @@ async fn fetch_paper_arxiv_happy_path_writes_pdf_and_returns_envelope() -> anyho
         serde_json::json!(true),
         "envelope: {structured:?}"
     );
+    // #462: WHICH ROUTE produced this, not merely that something did.
+    // Four "unreachable source" bugs shipped with green unit tests
+    // because nothing asserted the route, and a measurement over this
+    // suite found only one of the five `PdfLegStatus` routes asserted
+    // anywhere. See `route_coverage_e2e.rs`.
+    assert_eq!(
+        structured["pdf"]["status"],
+        serde_json::json!("fetched"),
+        "the arXiv happy path must report the `fetched` route: {structured:?}"
+    );
     assert_eq!(structured["source"], serde_json::json!("arxiv"));
     assert_eq!(structured["ref"], serde_json::json!("2401.12345"));
     assert_eq!(structured["license"], serde_json::json!("arxiv-default"));

--- a/crates/doiget-mcp/tests/route_coverage_e2e.rs
+++ b/crates/doiget-mcp/tests/route_coverage_e2e.rs
@@ -1,0 +1,228 @@
+//! #462: which route produced the outcome, asserted per route.
+//!
+//! Four "unreachable source" bugs shipped with green unit tests -- #413, #442,
+//! #454, #458 -- and they share one shape: a source was implemented, gated,
+//! allowlisted and unit-tested, and was never reached. The unit test drove the
+//! `Source` impl directly, or asserted a builder returned the right value, and
+//! the production entry point was never in the picture. #454's own guard
+//! carried a doc comment describing the failure it could not catch.
+//!
+//! The thing a unit test cannot do is notice that a correct component is never
+//! reached. Only an assertion about WHICH ROUTE ran can do that.
+//!
+//! Measured before writing this file: of the five `PdfLegStatus` routes,
+//! exactly **one** (`blocked`) was asserted anywhere in the e2e suites.
+//! `tdm_fetched` had none -- which is why #458, "the Tier-3 chain is skipped
+//! whenever Crossref answers", could ship.
+//!
+//! ## What this file is
+//!
+//! Not more tests. A **registry**: every route, and either the test that
+//! asserts it or a stated reason it is not asserted yet. A gap recorded with a
+//! reason is a gap someone can close; a gap that is merely absent is the one
+//! that ships.
+//!
+//! Two checks keep it honest:
+//!
+//! * the named covering test must exist AND contain the route string, so a
+//!   claim of coverage cannot outlive the assertion it names;
+//! * a posture-lint step compares this list against the `PdfLegStatus`
+//!   variants in `doiget-core`, so a new route cannot be added without landing
+//!   here first.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use camino::Utf8PathBuf;
+
+/// How a route is covered.
+#[derive(Debug)]
+enum Coverage {
+    /// Asserted by `fn` in the given test file.
+    By {
+        file: &'static str,
+        test_fn: &'static str,
+    },
+    /// Not asserted yet, and why. Deliberately not `None`: the reason is the
+    /// difference between a known gap and an oversight.
+    Gap { why: &'static str },
+}
+
+/// Every `PdfLegStatus` route, by its wire name.
+///
+/// Kept in the order the enum declares them so a reviewer can diff the two by
+/// eye; the posture-lint does it mechanically.
+const ROUTES: &[(&str, Coverage)] = &[
+    (
+        "fetched",
+        Coverage::By {
+            file: "fetch_paper_e2e.rs",
+            test_fn: "fetch_paper_arxiv_happy_path_writes_pdf_and_returns_envelope",
+        },
+    ),
+    (
+        "no_oa_url",
+        Coverage::Gap {
+            why: "no e2e drives a DOI that resolves with no OA location anywhere; \
+                  the CLI-side found-nothing trace (#505) exercises the reporting \
+                  but not the route",
+        },
+    ),
+    (
+        "blocked",
+        Coverage::By {
+            file: "fetch_paper_e2e.rs",
+            test_fn: "fetch_paper_doi_blocked_pdf_includes_suggested_arxiv_id",
+        },
+    ),
+    (
+        "preprint_fallback",
+        Coverage::Gap {
+            why: "the #325 automatic fallback. The existing blocked-leg test asserts \
+                  `suggested_arxiv_id`, which is the SUGGESTION, not the fallback \
+                  having run -- two different routes one letter apart in the envelope",
+        },
+    ),
+    (
+        "tdm_fetched",
+        Coverage::Gap {
+            why: "needs a tdm-* feature build plus credentials, so it cannot run in \
+                  the oa-only job. This is the route #458 broke, and it had no \
+                  assertion anywhere, which is why #458 shipped",
+        },
+    ),
+];
+
+fn tests_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+
+/// A claim of coverage must name a test that exists and that mentions the
+/// route. Without this the registry decays into a list of intentions: the
+/// covering test can be renamed or its assertion deleted, and nothing notices.
+#[test]
+fn every_claimed_covering_test_exists_and_asserts_its_route() {
+    let mut problems = Vec::new();
+    for (route, cov) in ROUTES {
+        let Coverage::By { file, test_fn } = cov else {
+            continue;
+        };
+        let path = tests_dir().join(file);
+        let Ok(src) = std::fs::read_to_string(&path) else {
+            problems.push(format!("{route}: {file} does not exist"));
+            continue;
+        };
+        if !src.contains(test_fn) {
+            problems.push(format!("{route}: {file} has no `{test_fn}`"));
+            continue;
+        }
+        if !src.contains(&format!("\"{route}\"")) {
+            problems.push(format!(
+                "{route}: {file} names `{test_fn}` but never asserts the string \"{route}\""
+            ));
+        }
+    }
+    assert!(
+        problems.is_empty(),
+        "route coverage claims that are not backed by an assertion:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// The registry must name EVERY route, so a new one cannot be added without
+/// deciding how it is covered -- the step all four bugs in the header skipped.
+///
+/// Reads `PdfLegStatus` out of `doiget-core` and compares. Deliberately here
+/// rather than as a shell step in posture-lint: the comparison needs
+/// CamelCase-to-snake_case, that needs a regex backreference, and threading one
+/// through YAML into bash is how the first attempt at this put a literal
+/// control character into the workflow file. A test can just do it.
+#[test]
+fn the_registry_names_every_pdf_leg_route() {
+    let src = std::fs::read_to_string(
+        Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../doiget-core/src/orchestrator.rs"),
+    )
+    .expect("read orchestrator.rs");
+
+    let body = src
+        .split_once("pub enum PdfLegStatus")
+        .and_then(|(_, rest)| {
+            rest.split_once(
+                "
+}",
+            )
+        })
+        .map(|(body, _)| body)
+        .expect("PdfLegStatus enum not found -- did it move or get renamed?");
+
+    let mut variants: Vec<String> = Vec::new();
+    for line in body.lines() {
+        // A variant is `    Name,` or `    Name {`; anything more indented is
+        // a field, and anything less is not in the enum.
+        let Some(rest) = line.strip_prefix("    ") else {
+            continue;
+        };
+        if rest.starts_with(' ') || !rest.starts_with(char::is_uppercase) {
+            continue;
+        }
+        let name: String = rest.chars().take_while(|c| c.is_alphanumeric()).collect();
+        if name.is_empty() {
+            continue;
+        }
+        let mut snake = String::new();
+        for (i, c) in name.chars().enumerate() {
+            if c.is_uppercase() && i > 0 {
+                snake.push('_');
+            }
+            snake.extend(c.to_lowercase());
+        }
+        variants.push(snake);
+    }
+    variants.sort();
+    variants.dedup();
+
+    // The guard the assertion below cannot be: a parser that silently matched
+    // nothing would agree with an empty registry.
+    assert!(
+        variants.len() >= 5,
+        "parsed {} variants from PdfLegStatus; the enum has at least five, so          this parser has stopped seeing them: {variants:?}",
+        variants.len()
+    );
+
+    let mut named: Vec<String> = ROUTES.iter().map(|(r, _)| (*r).to_string()).collect();
+    named.sort();
+
+    assert_eq!(
+        named, variants,
+        "the coverage registry and PdfLegStatus disagree. A route with no entry          is a route nobody decided how to test, which is exactly how #413, #442,          #454 and #458 shipped."
+    );
+}
+
+/// The gaps are the point of the file, so they are printed rather than hidden.
+/// This test does not fail on a gap -- it fails if a gap has no reason, because
+/// an unexplained gap is indistinguishable from an oversight, which is the
+/// thing #462 is about.
+#[test]
+fn every_route_is_either_covered_or_has_a_stated_reason() {
+    let mut uncovered = Vec::new();
+    for (route, cov) in ROUTES {
+        match cov {
+            Coverage::By { .. } => {}
+            Coverage::Gap { why } => {
+                assert!(
+                    why.len() > 30,
+                    "{route}: a gap needs a reason someone can act on, got {why:?}"
+                );
+                uncovered.push(*route);
+            }
+        }
+    }
+    // `eprintln!` is banned in this crate -- stdout is the JSON-RPC channel and
+    // the lint does not distinguish the two streams. Asserting the count is
+    // better than printing it anyway: it turns "2 of 5" from a line someone
+    // might read into a number that has to be updated when it changes.
+    assert_eq!(
+        uncovered.len(),
+        3,
+        "known gaps changed: {uncovered:?}. If a route just gained an assertion,          move it from `Gap` to `By` and drop this count by one -- the point is          that closing a gap is a visible edit, not a silent improvement."
+    );
+}


### PR DESCRIPTION
Refs #462. The measurement half — and it is worse than the issue's table suggests.

## Measured before writing anything

Of the five `PdfLegStatus` routes, exactly **one** was asserted anywhere in the e2e suites:

```
fetched            0 files
no_oa_url          0 files
blocked            1 files  fetch_paper_e2e.rs
preprint_fallback  0 files
tdm_fetched        0 files
```

`tdm_fetched` having **none** is how #458 — *"the Tier-3 chain is skipped whenever Crossref answers"* — could ship. Nothing anywhere claimed that route had ever run.

The issue's diagnosis is right and its table is incomplete: this cycle added more instances of the same shape. In the last few days alone, a repeat-suppression guard I built for #507 passed the full 47-suite run **because it never fired**, and #506's `disposition` shipped missing from five envelopes with every test green.

## What this is

Not more tests. A **registry**: every route, and either the test that asserts it or a stated reason it does not. A gap with a reason is a gap someone can close; a gap that is merely absent is the one that ships.

Three checks keep it honest:

1. **A coverage claim must name a test that exists and contains the route string.** The claim cannot outlive the assertion it names. This caught a wrong test name on its very first run — I had guessed `..._suggests_arxiv_preprint` and the real name is `..._includes_suggested_arxiv_id`.
2. **A gap must carry a reason.** An unexplained gap and an oversight are indistinguishable from outside.
3. **The registry is compared against the `PdfLegStatus` variants in `doiget-core`.** A new route cannot be added without deciding how it is covered — the step all four bugs skipped. Mutation-checked by deleting `tdm_fetched` from the registry; it fails with both lists printed.

## Where check 3 lives, and why

In the test, not in posture-lint. It needs CamelCase→snake_case, that needs a regex backreference, and my first attempt at threading one through YAML into bash **put a literal control character into the workflow file** (`\1` is an octal escape in a non-raw Python string). A test can just do it, in a language with real string handling. Reverted the YAML and moved it.

The parser also guards itself: it asserts it read at least five variants, because a parser that silently matches nothing would agree with an empty registry.

## Coverage now

| route | |
|---|---|
| `fetched` | **newly asserted** — the arXiv happy path already exercised it and never said so |
| `blocked` | asserted |
| `no_oa_url` | gap: no e2e drives a DOI that resolves with no OA location anywhere |
| `preprint_fallback` | gap: the existing test asserts `suggested_arxiv_id`, which is the *suggestion*, not the #325 fallback having run — two routes one field apart |
| `tdm_fetched` | gap: needs a `tdm-*` build plus credentials |

The known-gap count is asserted, so closing one is a visible edit rather than a silent improvement.

## What this deliberately does not do

The issue also asks for a live suite against real DOIs, to notice the *world* changing. That is a separate thing and I have not built it: the bugs in the table are **wiring** defects — a correct component never reached — and those are observable hermetically at the real entry point, which is where this belongs so it runs on every PR rather than nightly. A live smoke job is still worth having for upstream drift; #462 stays open for it.

Local: fmt, clippy `-D warnings`, workspace suite 48/48, `version-bump-gate.sh`.