### PR TITLE
chore(deps): the three pending Dependabot bumps, in one pass

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
-      - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
+      - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d  # v2.87.0
         with:
           tool: cargo-llvm-cov
       - name: Generate workspace coverage (lcov)

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -20,4 +20,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
-      - uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f     # v1.49.0
+      - uses: crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3     # v1.50.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,23 @@ flag changes and `doiget-mcp` tool spec changes will be called out explicitly he
   answers `initialize` as `doiget 0.8.12` and lists 22 tools, with pure JSON-RPC on
   stdout and zero bytes on stderr.
 
+- **[deps]** dependency bumps merged from Dependabot: `flate2` 1.1.9 -> 1.1.10,
+  `uuid` 1.25.0 -> 1.26.0 (#578), `quick-xml` 0.41.0 -> 0.42.0 (#579), and the
+  `github/codeql-action`, `taiki-e/install-action` and `crate-ci/typos` CI
+  actions (#581). `cargo-vet` `safe-to-deploy` exemptions updated to match.
+
+  `quick-xml` 0.42 is not a drop-in bump: the reader is UTF-8 throughout, so
+  `QName::as_ref()` and `Attribute::key` yield `&str` rather than `&[u8]` and
+  `BytesText::decode()` is gone. Both XML parsers were migrated -- `local_name`
+  takes and returns `&str`, XML-name comparisons lost their `b` prefixes, and
+  decode-then-unescape collapsed to `quick_xml::escape::unescape`. Behaviour is
+  unchanged; the existing parser tests cover the touched paths.
+
+  `flate2` 1.1.10 changes its own dependency set: with `rust_backend` it now
+  pulls `zlib-rs` 0.6.7, a dependency this tree did not have before. It is
+  exempted at `safe-to-deploy` like every other unaudited crate here, which is a
+  statement about process, not about anyone having read it.
+
 ### Added
 
 - **[mcp]** `error.retry_after_ms` - the server's own `Retry-After`, on the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-cli"
-version = "0.8.13-beta.20"
+version = "0.8.13-beta.21"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-core"
-version = "0.8.13-beta.20"
+version = "0.8.13-beta.21"
 dependencies = [
  "async-trait",
  "biblatex",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "doiget-mcp"
-version = "0.8.13-beta.20"
+version = "0.8.13-beta.21"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -658,12 +658,13 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1298,9 +1299,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1516,9 +1517,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -2624,9 +2625,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3239,6 +3240,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version       = "0.8.13-beta.20"
+version       = "0.8.13-beta.21"
 edition       = "2021"
 rust-version  = "1.86"
 license       = "MIT"
@@ -41,9 +41,9 @@ features-doc-link = "docs/SOURCES.md"
 
 [workspace.dependencies]
 # Core
-doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.20" }
-doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.20" }
-doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.20" }
+doiget-core = { path = "crates/doiget-core", version = "0.8.13-beta.21" }
+doiget-cli  = { path = "crates/doiget-cli", version = "0.8.13-beta.21" }
+doiget-mcp  = { path = "crates/doiget-mcp", version = "0.8.13-beta.21" }
 
 # Async runtime — features are deliberately limited (avoid `full`).
 tokio = { version = "1", default-features = false, features = [
@@ -156,7 +156,7 @@ url = "2"
 # response). Default features (no `serde`, no `encoding`) are sufficient
 # — we hand-roll a small event walker in `sources::arxiv`. Not on
 # `deny.toml`'s banned list.
-quick-xml = { version = "0.41", default-features = false }
+quick-xml = { version = "0.42", default-features = false }
 
 # BibTeX / BibLaTeX bibliography input parser (ADR-0030 D2). Enabled in
 # the default feature set — `.bib` is the dominant export format from

--- a/crates/doiget-core/src/paper_text.rs
+++ b/crates/doiget-core/src/paper_text.rs
@@ -303,19 +303,19 @@ fn apply_max_chars(full: PaperText, max_chars: Option<usize>) -> PaperText {
 /// Local element names whose entire subtree is skipped (text discarded).
 /// `math` is in this set, but its `alttext` is captured before the subtree
 /// is skipped (see [`extract_alttext`]).
-fn is_skip_element(local: &[u8]) -> bool {
-    matches!(local, b"script" | b"style" | b"math")
+fn is_skip_element(local: &str) -> bool {
+    matches!(local, "script" | "style" | "math")
 }
 
 /// Heading level (1..=6) for an `h1`–`h6` local name, else `None`.
-fn heading_level(local: &[u8]) -> Option<u8> {
+fn heading_level(local: &str) -> Option<u8> {
     match local {
-        b"h1" => Some(1),
-        b"h2" => Some(2),
-        b"h3" => Some(3),
-        b"h4" => Some(4),
-        b"h5" => Some(5),
-        b"h6" => Some(6),
+        "h1" => Some(1),
+        "h2" => Some(2),
+        "h3" => Some(3),
+        "h4" => Some(4),
+        "h5" => Some(5),
+        "h6" => Some(6),
         _ => None,
     }
 }
@@ -323,7 +323,7 @@ fn heading_level(local: &[u8]) -> Option<u8> {
 /// Extract a `<math alttext="...">` LaTeX source, if present.
 fn extract_alttext(e: &quick_xml::events::BytesStart<'_>) -> Option<String> {
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"alttext" {
+        if attr.key.as_ref() == "alttext" {
             if let Ok(v) = attr.normalized_value(quick_xml::XmlVersion::Explicit1_0) {
                 let s = v.into_owned();
                 if !s.trim().is_empty() {
@@ -388,7 +388,7 @@ fn parse_ar5iv(html: &[u8]) -> Result<(Option<String>, Vec<TextSection>), FetchE
                 let name = e.name();
                 let local = local_name(name.as_ref());
                 if is_skip_element(local) {
-                    if skip == 0 && local == b"math" {
+                    if skip == 0 && local == "math" {
                         if let Some(alt) = extract_alttext(&e) {
                             let frag = format!("\\({alt}\\) ");
                             push_target(
@@ -407,7 +407,7 @@ fn parse_ar5iv(html: &[u8]) -> Result<(Option<String>, Vec<TextSection>), FetchE
                     flush_section(&mut sections, &mut cur_heading, &mut cur_text);
                     in_heading = level;
                     heading_buf.clear();
-                } else if local == b"title" && title.is_none() {
+                } else if local == "title" && title.is_none() {
                     in_title = true;
                     title_buf.clear();
                 }
@@ -418,7 +418,7 @@ fn parse_ar5iv(html: &[u8]) -> Result<(Option<String>, Vec<TextSection>), FetchE
                 let local = local_name(name.as_ref());
                 // A self-closing `<math .../>` contributes its alttext but
                 // has no subtree to skip.
-                if skip == 0 && local == b"math" {
+                if skip == 0 && local == "math" {
                     if let Some(alt) = extract_alttext(&e) {
                         let frag = format!("\\({alt}\\) ");
                         push_target(
@@ -434,11 +434,7 @@ fn parse_ar5iv(html: &[u8]) -> Result<(Option<String>, Vec<TextSection>), FetchE
                 buf.clear();
             }
             Ok(Event::Text(t)) => {
-                match t.decode().ok().and_then(|raw| {
-                    quick_xml::escape::unescape(&raw)
-                        .ok()
-                        .map(|c| c.into_owned())
-                }) {
+                match quick_xml::escape::unescape(&t).ok().map(|c| c.into_owned()) {
                     Some(s) => {
                         if !s.is_empty() && skip == 0 {
                             let mut frag = s;
@@ -482,7 +478,7 @@ fn parse_ar5iv(html: &[u8]) -> Result<(Option<String>, Vec<TextSection>), FetchE
                     in_heading = 0;
                     // The body of the new section starts fresh.
                     cur_text.clear();
-                } else if local == b"title" && in_title {
+                } else if local == "title" && in_title {
                     in_title = false;
                     let t = normalize(&title_buf);
                     if !t.is_empty() {
@@ -551,10 +547,10 @@ fn flush_section(
     cur_text.clear();
 }
 
-/// Strip an XML namespace prefix, returning the local-part bytes
-/// (`b"xhtml:p"` -> `b"p"`). Mirrors the arXiv Atom parser's helper.
-fn local_name(qname: &[u8]) -> &[u8] {
-    match qname.iter().rposition(|&b| b == b':') {
+/// Strip an XML namespace prefix, returning the local part
+/// (`"xhtml:p"` -> `"p"`). Mirrors the arXiv Atom parser's helper.
+fn local_name(qname: &str) -> &str {
+    match qname.rfind(':') {
         Some(idx) => &qname[idx + 1..],
         None => qname,
     }

--- a/crates/doiget-core/src/sources/arxiv.rs
+++ b/crates/doiget-core/src/sources/arxiv.rs
@@ -417,10 +417,10 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) => {
-                let name_bytes = e.name();
-                let local = local_name(name_bytes.as_ref());
+                let name = e.name();
+                let local = local_name(name.as_ref());
                 if !in_entry {
-                    if local == b"entry" {
+                    if local == "entry" {
                         in_entry = true;
                         saw_entry = true;
                         depth = 0;
@@ -432,33 +432,33 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
                 // Depth==1 means a direct child of `<entry>`.
                 if depth == 1 {
                     match local {
-                        b"title" => target = Some(Target::Title),
-                        b"summary" => target = Some(Target::Summary),
-                        b"published" => target = Some(Target::Published),
-                        b"updated" => target = Some(Target::Updated),
+                        "title" => target = Some(Target::Title),
+                        "summary" => target = Some(Target::Summary),
+                        "published" => target = Some(Target::Published),
+                        "updated" => target = Some(Target::Updated),
                         // arXiv namespace; `local_name` strips the `arxiv:`
                         // prefix, so these match `<arxiv:doi>` /
                         // `<arxiv:journal_ref>`.
-                        b"doi" => target = Some(Target::Doi),
-                        b"journal_ref" => target = Some(Target::JournalRef),
-                        b"author" => {
+                        "doi" => target = Some(Target::Doi),
+                        "journal_ref" => target = Some(Target::JournalRef),
+                        "author" => {
                             in_author = true;
                             authors.push(String::new());
                         }
                         _ => {}
                     }
-                } else if depth == 2 && in_author && local == b"name" {
+                } else if depth == 2 && in_author && local == "name" {
                     target = Some(Target::AuthorName);
                 }
                 buf.clear();
             }
             Ok(Event::Empty(e)) => {
-                let name_bytes = e.name();
-                let local = local_name(name_bytes.as_ref());
-                if in_entry && depth == 0 && local == b"category" {
+                let name = e.name();
+                let local = local_name(name.as_ref());
+                if in_entry && depth == 0 && local == "category" {
                     // <category term="cs.LG" scheme="..."/> — extract `term`.
                     for attr in e.attributes().flatten() {
-                        if attr.key.as_ref() == b"term" {
+                        if attr.key.as_ref() == "term" {
                             // quick-xml 0.40: `unescape_value()` is
                             // deprecated in favour of `normalized_value()`
                             // (attribute-value normalization resolves the
@@ -475,15 +475,12 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
             }
             Ok(Event::Text(t)) => {
                 if let Some(tg) = target {
-                    // quick-xml 0.40 removed `BytesText::unescape`.
-                    // Reproduce the old behaviour: decode the bytes, then
-                    // unescape XML entities via `quick_xml::escape::unescape`.
-                    // Best-effort — skip the text on decode/unescape error.
-                    if let Some(s) = t.decode().ok().and_then(|raw| {
-                        quick_xml::escape::unescape(&raw)
-                            .ok()
-                            .map(|c| c.into_owned())
-                    }) {
+                    // quick-xml 0.40 removed `BytesText::unescape`, and 0.42
+                    // made the reader UTF-8 throughout, so the decode step is
+                    // gone too -- `BytesText` derefs to `str`. Entities still
+                    // need `quick_xml::escape::unescape`, best-effort: skip
+                    // the text if it fails.
+                    if let Some(s) = quick_xml::escape::unescape(&t).ok().map(|c| c.into_owned()) {
                         match tg {
                             Target::Title => title.get_or_insert_with(String::new).push_str(&s),
                             Target::Summary => {
@@ -512,9 +509,9 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
                     buf.clear();
                     continue;
                 }
-                let name_bytes = e.name();
-                let local = local_name(name_bytes.as_ref());
-                if depth == 0 && local == b"entry" {
+                let name = e.name();
+                let local = local_name(name.as_ref());
+                if depth == 0 && local == "entry" {
                     // Done with the first entry — stop. We deliberately
                     // ignore any subsequent entries since the orchestrator
                     // always queries a single id.
@@ -522,7 +519,7 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
                 }
                 depth -= 1;
                 if depth == 0 {
-                    if local == b"author" {
+                    if local == "author" {
                         in_author = false;
                         // Drop empty author names (defensive).
                         if let Some(last) = authors.last() {
@@ -532,7 +529,7 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
                         }
                     }
                     target = None;
-                } else if depth == 1 && in_author && local == b"name" {
+                } else if depth == 1 && in_author && local == "name" {
                     target = None;
                 }
                 buf.clear();
@@ -625,13 +622,13 @@ pub(crate) fn parse_atom_feed(xml: &[u8]) -> Result<Value, FetchError> {
 }
 
 /// Strip an XML namespace prefix from a qualified name, returning the
-/// local-part bytes. `b"atom:entry"` -> `b"entry"`. Atom uses the default
+/// local part. `"atom:entry"` -> `"entry"`. Atom uses the default
 /// namespace so most names arrive unprefixed; this helper makes the
 /// parser robust to either form without depending on quick-xml's
 /// namespace resolver (which would require us to thread a
 /// `NsReader` and explicit prefix bindings through every event).
-fn local_name(qname: &[u8]) -> &[u8] {
-    match qname.iter().rposition(|&b| b == b':') {
+fn local_name(qname: &str) -> &str {
+    match qname.rfind(':') {
         Some(idx) => &qname[idx + 1..],
         None => qname,
     }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -223,7 +223,7 @@ version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.flate2]]
-version = "1.1.9"
+version = "1.1.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.float-cmp]]
@@ -434,6 +434,10 @@ criteria = "safe-to-deploy"
 version = "2.8.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.miniz_oxide]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.mio]]
 version = "1.2.0"
 criteria = "safe-to-deploy"
@@ -495,7 +499,7 @@ version = "0.36.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-xml]]
-version = "0.41.0"
+version = "0.42.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.quinn]]
@@ -875,7 +879,7 @@ version = "2.5.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.25.0"
+version = "1.26.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]
@@ -1096,4 +1100,8 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zmij]]
 version = "1.0.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.zlib-rs]]
+version = "0.6.7"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1098,10 +1098,10 @@ criteria = "safe-to-deploy"
 version = "0.11.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.zmij]]
-version = "1.0.21"
-criteria = "safe-to-deploy"
-
 [[exemptions.zlib-rs]]
 version = "0.6.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.zmij]]
+version = "1.0.21"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Supersedes #578, #579 and #581.

ADR-0033's strict `beta.N+1` means each PR that lands forces a re-bump and a fresh CI cycle on every other open PR. Three separate dependency PRs would have cost three of those rounds for one kind of work.

| PR | bump |
|---|---|
| #578 | `flate2` 1.1.9 → 1.1.10, `uuid` 1.25.0 → 1.26.0 |
| #579 | `quick-xml` 0.41.0 → 0.42.0 |
| #581 | `github/codeql-action`, `taiki-e/install-action`, `crate-ci/typos` |

## quick-xml 0.42 is not a drop-in bump

The reader is UTF-8 throughout now: `QName::as_ref()` and `Attribute::key` yield `&str` instead of `&[u8]`, and `BytesText::decode()` is gone because `BytesText` derefs to `str`. On `next` as-is that is 13 compile errors across `paper_text.rs` and `sources/arxiv.rs` — which is why #579 was red on every clippy, test, rustdoc and coverage job, not just one.

Both parsers are migrated: `local_name` takes and returns `&str` (`rfind(':')` for `rposition`), XML-name comparisons drop their `b` prefixes, and decode-then-unescape collapses to `quick_xml::escape::unescape(&t)`. The PDF magic-byte literals in the tests stay bytes — they are not XML names. `name_bytes` became `name`, because it has not been bytes since `e.name()` changed type.

The existing tests cover the changed paths rather than just the compile:

- `parse_atom_feed_captures_published_doi_and_journal_ref` feeds an `<arxiv:doi>` element, so prefix stripping is exercised
- `parse_extracts_title_sections_and_inline_math` goes through the `alttext` attribute lookup

## supply-chain

`flate2` and `uuid` roll forward; `quick-xml` 0.42.0 replaces 0.41.0, which nothing in the lock uses any more. `miniz_oxide` 0.9.1 and `zlib-rs` 0.6.7 are new entries.

`zlib-rs` is worth naming rather than waving through: it is a dependency this tree did not have, arriving because `flate2` 1.1.10's `rust_backend` feature now routes to it. It is exempted at `safe-to-deploy` like every other unaudited crate here — which says something about our process and nothing about the crate.

The long-stale `quick-xml` 0.36.2 exemption is left alone; it predates this PR and removing it is its own cleanup.

## Verified locally

| | `oa-only` | `oa-only,citation` |
|---|---|---|
| `clippy -D warnings` | 0 errors | 0 errors |
| `doiget-core` suite | green | — |

Closes #578
Closes #579
Closes #581