### PR TITLE
chore(release): tracking files for 0.8.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "doiget",
   "metadata": {
     "description": "The doiget marketplace — one plugin: an OA-first paper fetcher for DOIs and arXiv IDs.",
-    "version": "0.8.12"
+    "version": "0.8.13"
   },
   "owner": {
     "name": "QAtlasHub",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "doiget",
   "description": "Turn DOIs and arXiv IDs into local PDFs and structured metadata via official Open-Access APIs. Never bypasses paywalls.",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "author": {
     "name": "Sota Shimozono",
     "url": "https://github.com/QAtlasHub/doiget"

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "doiget-cli@0.8.12",
+        "doiget-cli@0.8.13",
         "serve"
       ]
     }

--- a/Formula/doiget.rb
+++ b/Formula/doiget.rb
@@ -9,7 +9,7 @@
 class Doiget < Formula
   desc "Open Access paper fetcher with an MCP server"
   homepage "https://github.com/QAtlasHub/doiget"
-  version "0.8.12"
+  version "0.8.13"
   license "MIT"
 
   # The published binaries are the release assets themselves, not archives, so
@@ -17,19 +17,19 @@ class Doiget < Formula
   # which is why there are no dependencies to declare.
   on_macos do
     on_arm do
-      url "https://github.com/QAtlasHub/doiget/releases/download/v0.8.12/doiget-macos-aarch64"
-      sha256 "8aa163dba6c34527ae4ce819835aa138779fdad5041236830ae8833ad18b51cf"
+      url "https://github.com/QAtlasHub/doiget/releases/download/v0.8.13/doiget-macos-aarch64"
+      sha256 "7daa6b22fabd726d6e707887375da1eab750c53ef63554523c7403b5badb34fc"
     end
     on_intel do
-      url "https://github.com/QAtlasHub/doiget/releases/download/v0.8.12/doiget-macos-x86_64"
-      sha256 "caabe258798c9b10f53d3f4238e233e8daa3060596b05bed740e591224f10c5f"
+      url "https://github.com/QAtlasHub/doiget/releases/download/v0.8.13/doiget-macos-x86_64"
+      sha256 "17c7e3d733b446ab7186794020b0692dae0886cc5edaad455565924e602d4c1c"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/QAtlasHub/doiget/releases/download/v0.8.12/doiget-linux-x86_64"
-      sha256 "e22c603447b1a2bc9b7c8cf9616085e789334541c6611e368e69aa2333fa61a5"
+      url "https://github.com/QAtlasHub/doiget/releases/download/v0.8.13/doiget-linux-x86_64"
+      sha256 "4e6a4d09c6bf4056cb02f64bfeb6e2c71340b80646e6f3afeef4b39557806680"
     end
   end
 


### PR DESCRIPTION
The one maintainer step after a stable release, per CONTRIBUTING. Four files record *the last published stable* and none can be written before the release exists — the formula pins the binaries by `sha256`, and `.mcp.json` pins the npm version the plugin runs.

| file | 0.8.12 -> 0.8.13 |
|---|---|
| `Formula/doiget.rb` | regenerated from the release's own `.sha256` assets |
| `.claude-plugin/plugin.json` | `version` |
| `.claude-plugin/marketplace.json` | `version` |
| `.mcp.json` | `doiget-cli@0.8.13` |

## Verified rather than assumed

- `scripts/update-homebrew-formula.test.sh` passes — the committed formula is byte-identical to generator output, so it is not a hand-edit.
- The `release-tracking files name one version` posture check, new this cycle, reports `formula=0.8.13 plugin=0.8.13 marketplace=0.8.13 .mcp.json=0.8.13` **and** that `CHANGELOG.md` has a matching section — the check that exists because `.claude-plugin/*` once sat at 0.8.11 while 0.8.12 was shipping.
- `doiget-cli@0.8.13` is live on npm (`dist-tags.latest = 0.8.13`), so the pin is not a 404 for plugin users.

## Note on `version-bump`

Expected red. `next` carries the clean `0.8.13` after this cycle's cut landed there before the promotion, so every PR to `next` now fails the beta-lane rule. It is not a required check on `next`.